### PR TITLE
Add python checker 'python'

### DIFF
--- a/autoload/neomake/makers/python.vim
+++ b/autoload/neomake/makers/python.vim
@@ -1,7 +1,7 @@
 " vim: ts=4 sw=4 et
 
 function! neomake#makers#python#EnabledMakers()
-    return ['pylint', 'pyflakes', 'pep8', 'python']
+    return ['python', 'pep8', 'pyflakes', 'pylint']
 endfunction
 
 function! neomake#makers#python#pylint()


### PR DESCRIPTION
The interpreter itself is able to detect big problems, e.g. SyntaxError
or problems in top-level code. Therefore it makes a good first-pass
checker.

The python command-line must be passed some code (~10 statements) in
argument, which is done a bit inelegantly here, but doc on multi-line
strings in vim script is quite rare...
