### PR TITLE
Add coffeelint to check coffeescript

### DIFF
--- a/autoload/neomake/makers/coffee.vim
+++ b/autoload/neomake/makers/coffee.vim
@@ -1,0 +1,15 @@
+" vim: ts=4 sw=4 et
+
+function! neomake#makers#coffee#EnabledMakers()
+    return ['coffeelint']
+endfunction
+
+function! neomake#makers#coffee#coffeelint()
+    return {
+        \ 'args': ['--reporter=csv'],
+        \ 'errorformat': '%f\,%l\,%\d%#\,%trror\,%m,' .
+            \ '%f\,%l\,%trror\,%m,' .
+            \ '%f\,%l\,%\d%#\,%tarn\,%m,' .
+            \ '%f\,%l\,%tarn\,%m'
+            \ }
+endfunction


### PR DESCRIPTION
Currently it displays the header line of the ouput as first item in the loclist(|| path,lineNumber,lineNumberEnd,level,message). Syntastic probably does something clever to get rid of this line? Otherwise it works as expected.
