### PR TITLE
Added a graphviz maker

### DIFF
--- a/autoload/neomake/makers/ft/dot.vim
+++ b/autoload/neomake/makers/ft/dot.vim
@@ -1,0 +1,16 @@
+" vim: ts=4 sw=4 et
+" inspired by wmgraphviz.vim
+function! neomake#makers#ft#dot#EnabledMakers()
+    if neomake#utils#Exists('dot')
+        return ['dot']
+    end
+endfunction
+
+function! neomake#makers#ft#dot#dot()
+    return {
+        \ 'args': ['-Tpng', '%:p', '> %:p.png'],
+        \ 'errorformat':
+            \ '%EError:\ %f:%l:%m,%+Ccontext:\ %.%#,%WWarning:\ %m'
+        \ }
+endfunction
+


### PR DESCRIPTION
It's not ready yet but I had some questions: how to redirect the output of the maker ? for instance here, the 'dot' binary generates a png and it appears in neomake log. I would like to redirect the output, hence the '> %:p.png' but that does not seem to work.
Also I wonder if errorformats should not be splitted as it seems to be in other makers ?
