### PR TITLE
Process job output by window instead of buffer

### DIFF
--- a/doc/neomake.txt
+++ b/doc/neomake.txt
@@ -330,12 +330,12 @@ and the |quickfix| respectively. The return value is something like this: >
 <Where 'E', 'W' and 'x' are error types. Empty error types are ignored for
 now.
 
-*neomake#ProcessCurrentBuffer*
+*neomake#ProcessCurrentWindow*
 This is the function that takes the job output and puts it into the loclist or
-qflist, adds signs, etc. Currently, if you stay in the buffer you called
+qflist, adds signs, etc. Currently, if you stay in the window you called
 |:Neomake| from, this will happen as the job output comes in. However, if you go
-to a different buffer, neomake will wait until you return to that buffer for
-the job output to be processed. Currently, that will happen on |BufEnter| and
+to a different window, neomake will wait until you return to that window for
+the job output to be processed. Currently, that will happen on |WinEnter| and
 |CursorHold|. You can also call this function directly if you need to force
 it. This function is not currently used for |:Neomake!|, which always
 processes its output as it arrives.

--- a/plugin/neomake.vim
+++ b/plugin/neomake.vim
@@ -13,6 +13,6 @@ command! -nargs=1 NeomakeCancelJob call neomake#CancelJob(<args>)
 
 augroup neomake
     autocmd!
-    autocmd BufWinEnter,CursorHold * call neomake#ProcessCurrentBuffer()
+    autocmd WinEnter,CursorHold * call neomake#ProcessCurrentWindow()
     autocmd CursorMoved * call neomake#CursorMoved()
 augroup END


### PR DESCRIPTION
This is a rather huge refactor.

Fixes https://github.com/benekastah/neomake/issues/350 and
https://github.com/benekastah/neomake/issues/348.

It removes 'winnr' from 'maker'.

The behaviour changes so that the output is only processed by windows,
but not buffers.  This means that `Neomake | sp` will not open the
location list, until you go to the previous window.