### PR TITLE
Added preprocess maker option + purescript syntax checker

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -399,7 +399,14 @@ endfunction
 function! s:ProcessJobOutput(maker, lines) abort
     call neomake#utils#DebugMessage(get(a:maker, 'name', 'makeprg').' processing '.
                                     \ len(a:lines).' lines of output')
-    if len(a:lines) > 0
+
+    let lines = a:lines
+    if has_key(a:maker, 'preprocess')
+        let Func = a:maker.preprocess
+        let lines = Func(copy(a:lines))
+    endif
+
+    if len(lines) > 0
         let olderrformat = &errorformat
         let &errorformat = a:maker.errorformat
 
@@ -411,7 +418,7 @@ function! s:ProcessJobOutput(maker, lines) abort
                 exec a:maker.winnr.'wincmd w'
             endif
 
-            laddexpr a:lines
+            laddexpr lines
 
             " Restore window.
             if exists('l:prev_window')
@@ -419,7 +426,7 @@ function! s:ProcessJobOutput(maker, lines) abort
                 exec cur_window.'wincmd w'
             endif
         else
-            caddexpr a:lines
+            caddexpr lines
         endif
         call s:AddExprCallback(a:maker)
 

--- a/autoload/neomake/makers/ft/purescript.vim
+++ b/autoload/neomake/makers/ft/purescript.vim
@@ -1,0 +1,161 @@
+" vim: ts=4 sw=4 et
+
+function! neomake#makers#ft#purescript#EnabledMakers()
+  return ['pulp']
+endfunction
+
+function! neomake#makers#ft#purescript#pulp()
+    return {
+        \ 'exe': 'pulp',
+        \ 'args': ['build', '--no-psa', '--json-errors'],
+        \ 'errorformat': '%t:%f:%l:%c:%n:%m',
+        \ 'buffer_output': 1,
+        \ 'append_file': 0,
+        \ 'preprocess': function("ParsePulp"),
+        \ 'postprocess': function("MarkStyleWarnings")
+        \ }
+endfunction
+
+function! MarkStyleWarnings(entry)
+        if a:entry.type == 'F'
+            let a:entry.type = 'E'
+            let a:entry.subtype = 'Style'
+        endif
+        if a:entry.type == 'V'
+            let a:entry.type = 'W'
+            let a:entry.subtype = 'Style'
+        endif
+endfunction
+
+function! s:error(str)
+  if exists('syntastic#log#error')
+    let logger = function('syntastic#log#error')
+  elseif exists('neomake#utils#ErrorMessage')
+    let logger = function('neomake#utils#ErrorMessage')
+  endif
+  echom a:str
+  if exists("logger")
+    call logger(a:str)
+  endif
+endfunction
+
+function! ParsePulp(lines)
+  let out = []
+  let str = join(a:lines, "")
+  " echom a:line
+  " let str = a:line
+
+  if !exists('g:psc_ide_suggestions')
+    let g:psc_ide_suggestions = {}
+  endif
+
+  "We need at least {"warnings":[],"errors":[]}
+   if len(str) < 20 || str !~# '{' || str !~# '}'
+     return out
+   endif
+
+  let matched = matchlist(str, '{.*}')
+
+  if len(matched) > 0
+    let decoded = s:_decode_JSON(matched[0])
+  else
+    call s:error('checker purescript/pulp: unrecognized error format 1: ' . str)
+    return out
+  endif
+  
+  let i = 0
+
+  if type(decoded) == type({}) && type(decoded["warnings"]) == type([]) && type(decoded["errors"])
+    for e in decoded['warnings']
+      try
+        call s:addEntry(out, 0, i, e)
+        let i = i + 1
+      catch /\m^Vim\%((\a\+)\)\=:E716/
+        call s:error('checker purescript/pulp: unrecognized error format 2: ' . str)
+        let out = []
+        break
+      endtry
+    endfor
+    for e in decoded['errors']
+      try
+        call s:addEntry(out, 1, i, e)
+        let i = i + 1
+      catch /\m^Vim\%((\a\+)\)\=:E716/
+        call s:error('checker purescript/pulp: unrecognized error format 3: ' . str)
+        let out = []
+        break
+      endtry
+    endfor
+  else
+    call s:error('checker purescript/pulp: unrecognized error format 4: ' . str)
+  endif
+  return out
+endfunction
+
+function! s:addEntry(out, err, index, e)
+  let hasSuggestion = exists("a:e.suggestion") && type(a:e.suggestion) == type({}) &&
+                    \ exists("a:e.position") && type(a:e.position) == type({})
+  let isError = a:err == 1
+  let letter = isError ? (hasSuggestion ? 'F' : 'E') : (hasSuggestion ? 'V' : 'W')
+  let startL = (exists("a:e.position") && type(a:e.position) == type({})) ? a:e.position.startLine : 1
+  let startC = (exists("a:e.position") && type(a:e.position) == type({})) ? a:e.position.startColumn : 1
+  let msg = join([letter, 
+                \ a:e.filename, 
+                \ startL,
+                \ startC,
+                \ string(a:index), 
+                \ s:cleanupMessage(a:e.message)], ":")
+
+  call add(a:out, msg)
+
+  if hasSuggestion
+    call s:addSuggestion(a:index, a:e)
+  endif
+endfunction
+
+function! s:addSuggestion(i, e)
+  if !exists('g:psc_ide_suggestions')
+    return
+  endif
+
+  let sugg = {'startLine':   a:e['position']['startLine'], 
+             \'startColumn': a:e['position']['startColumn'], 
+             \'endLine':     a:e['position']['endLine'], 
+             \'endColumn':   a:e['position']['endColumn'], 
+             \'replacement': a:e['suggestion']['replacement']}
+
+   let g:psc_ide_suggestions[string(a:i)] = sugg
+endfunction
+
+function! s:cleanupMessage(str)
+    let transformations = [ ['\s*\n\+\s*', ' '], ['(\s', '('], ['\s)', ')'], ['\s\,', ','] ]
+    let out = a:str
+    for t in transformations
+        let out = substitute(out, t[0], t[1], 'g')
+    endfor
+    return out
+endfunction
+
+function! s:_decode_JSON(json) abort
+    if a:json ==# ''
+        return []
+    endif
+
+    if substitute(a:json, '\v\"%(\\.|[^"\\])*\"|true|false|null|[+-]?\d+%(\.\d+%([Ee][+-]?\d+)?)?', '', 'g') !~# "[^,:{}[\\] \t]"
+        " JSON artifacts
+        let true = 1
+        let false = 0
+        let null = ''
+
+        try
+            let object = eval(a:json)
+        catch
+            " malformed JSON
+            let object = ''
+        endtry
+    else
+        let object = ''
+    endif
+
+    return object
+endfunction 


### PR DESCRIPTION
Hey,

I'm maintaining a PureScript syntax checker for Syntastic for some time now, and am very interested to have a maker for Neomake as well. I ran into a few issues along the way though, and did some controversial stuff so I wouldn't be surprised if you don't just merge this PR off the bat. I'll try to explain my decisions + reasons why:
1. The PureScript compiler (called through the standard build tool, "pulp") has two output modes: One text mode for human users, one JSON mode for editors. In Syntastic you have a maker option called "preprocess", in which I do the JSON parsing. I tried to do this with mapexpr but this is just impossible. The JSON came through in small parts, impossible to parse. I even implemented my own buffering system as an experiment but came to the conclusion that returning multiple errors from mapexpr is impossible.
2. I read in issue #138 that you don't want to add this kind of preprocessing function because you don't want to support the code being written in this function. I totally understand! But to be honest, I would never expect you to support my purescript maker. Secondly, Syntastic has this concept of external plugins (which I use for the Purescript Syntastic checker) and that would completely take away the responsability from you, so maybe that's an idea? Thirdly, writing this kind of wrapper around the PureScript compiler/Pulp is really just redundant, since Pulp is already a wrapper around the compiler. 
3. Something different now: The PureScript compiler also emits suggestions for certain warnings/errors. I use these suggestions in my psc-ide-vim plugin. This is optional of course, but there is some integration code for that in this maker. I hope that's not a problem? Again, I'd feel much more comfortable if I could maintain this maker in my own repo so you'd be shielded from whatever crazy stuff I'd like to do with the compiler output...

Simon
