### PR TITLE
Don't do full flowtype check

### DIFF
--- a/autoload/neomake/makers/ft/javascript.vim
+++ b/autoload/neomake/makers/ft/javascript.vim
@@ -44,7 +44,7 @@ function! neomake#makers#ft#javascript#flow()
     " Replace "\n" by space.
     let mapexpr = 'substitute(v:val, "\\\\n", " ", "g")'
     return {
-        \ 'args': ['check', '--old-output-format'],
+        \ 'args': ['--old-output-format'],
         \ 'errorformat': '%f:%l:%c\,%n: %m',
         \ 'mapexpr': mapexpr,
         \ }


### PR DESCRIPTION
Removing the (full) check argument for flowtype. It makes the maker very slow and works fine without. I think full checks on project code should be part of build/deploy scripts.