### PR TITLE
Improve shell makers

### DIFF
--- a/autoload/neomake/makers/ft/sh.vim
+++ b/autoload/neomake/makers/ft/sh.vim
@@ -22,3 +22,17 @@ function! neomake#makers#ft#sh#ShellcheckEntryProcess(entry)
     endif
     return a:entry
 endfunction
+
+function! neomake#makers#ft#sh#checkbashisms()
+    return {
+        \ 'args': ['-fx'],
+        \ 'errorformat':
+            \ '%-Gscript %f is already a bash script; skipping,' .
+            \ '%Eerror: %f: %m\, opened in line %l,' .
+            \ '%Eerror: %f: %m,' .
+            \ '%Ecannot open script %f for reading: %m,' .
+            \ '%Wscript %f %m,%C%.# lines,' .
+            \ '%Wpossible bashism in %f line %l (%m):,%C%.%#,%Z.%#,' .
+            \ '%-G%.%#'
+        \ }
+endfunction

--- a/autoload/neomake/makers/ft/sh.vim
+++ b/autoload/neomake/makers/ft/sh.vim
@@ -10,6 +10,15 @@ function! neomake#makers#ft#sh#shellcheck()
         \ 'errorformat':
             \ '%f:%l:%c: %trror: %m,' .
             \ '%f:%l:%c: %tarning: %m,' .
-            \ '%f:%l:%c: %tote: %m'
+            \ '%f:%l:%c: %tote: %m',
+        \ 'postprocess':
+            \ function('neomake#makers#ft#sh#ShellcheckEntryProcess')
         \ }
+endfunction
+
+function! neomake#makers#ft#sh#ShellcheckEntryProcess(entry)
+    if a:entry.type ==? 'N'
+        let a:entry.type = 'W'
+    endif
+    return a:entry
 endfunction

--- a/autoload/neomake/makers/ft/sh.vim
+++ b/autoload/neomake/makers/ft/sh.vim
@@ -1,7 +1,7 @@
 " vim: ts=4 sw=4 et
 
 function! neomake#makers#ft#sh#EnabledMakers()
-    return ['shellcheck']
+    return ['sh', 'shellcheck']
 endfunction
 
 function! neomake#makers#ft#sh#shellcheck()
@@ -35,4 +35,18 @@ function! neomake#makers#ft#sh#checkbashisms()
             \ '%Wpossible bashism in %f line %l (%m):,%C%.%#,%Z.%#,' .
             \ '%-G%.%#'
         \ }
+endfunction
+
+function! neomake#makers#ft#sh#sh()
+    let l:sh = '/bin/sh'
+    let l:line = getline(1)
+    if l:line =~# '^#!'
+        let l:sh = matchstr(l:line, '^#!\zs\S*\ze')
+    endif
+
+    return {
+        \ 'exe': l:sh,
+        \ 'args': ['-n'],
+        \ 'errorformat': '%f: line %l: %m'
+        \}
 endfunction


### PR DESCRIPTION
I did the following improvements to the shell makers:
 - fix error type returned by shellcheck
 - add optional `checkbashism` maker
 - add maker using shell

For the last one, I try to detect the correct shell from the first line of the script, otherwise use `/usr/bin/sh`.