### PR TITLE
Fix some error type specific code

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -646,7 +646,7 @@ function! neomake#EchoCurrentError() abort
 
     let s:neomake_last_echoed_error = ln_errors[0]
     for error in ln_errors
-        if error.type ==# 'E'
+        if error.type ==? 'E'
             let s:neomake_last_echoed_error = error
             break
         endif

--- a/autoload/neomake/signs.vim
+++ b/autoload/neomake/signs.vim
@@ -56,7 +56,7 @@ endfunction
 function! neomake#signs#RegisterSign(entry, type) abort
     let s:sign_queue[a:type][a:entry.bufnr] = get(s:sign_queue[a:type], a:entry.bufnr, {})
     let existing = get(s:sign_queue[a:type][a:entry.bufnr], a:entry.lnum, {})
-    if empty(existing) || a:entry.type ==# 'E' && existing.type !=# 'E'
+    if empty(existing) || a:entry.type ==? 'E' && existing.type !=? 'E'
         let s:sign_queue[a:type][a:entry.bufnr][a:entry.lnum] = a:entry
     endif
 endfunction


### PR DESCRIPTION
The error type should be checked using case insensitive comparison. At some places, case sensitive comparison is used however.
