### PR TITLE
Update elixir maker: --one-line is deprecated in favor of --format=on…

### DIFF
--- a/autoload/neomake/makers/ft/elixir.vim
+++ b/autoload/neomake/makers/ft/elixir.vim
@@ -15,7 +15,7 @@ endfunction
 function! neomake#makers#ft#elixir#credo()
     return {
       \ 'exe': 'mix',
-      \ 'args': ['credo', 'list', '%:p', '--one-line', '-i', 'readability'],
+      \ 'args': ['credo', 'list', '%:p', '--format=oneline', '-i', 'readability'],
       \ 'errorformat': '[%t] %. %f:%l:%c %m'
       \ }
 endfunction


### PR DESCRIPTION
Update elixir maker: --one-line is deprecated in favor of --format=oneline.