### PR TITLE
Specify format for flake8 that errorformat actually parses.

### DIFF
--- a/autoload/neomake/makers/ft/python.vim
+++ b/autoload/neomake/makers/ft/python.vim
@@ -59,6 +59,7 @@ endfunction
 
 function! neomake#makers#ft#python#flake8()
     return {
+        \ 'args': ['--format=default'],
         \ 'errorformat':
             \ '%E%f:%l: could not compile,%-Z%p^,' .
             \ '%A%f:%l:%c: %t%n %m,' .


### PR DESCRIPTION
Without this, flake8 may read local configuration and pickup an output format which is incompatible with the errorformat defined in neomake.