### PR TITLE
Enable eslint_d maker for javascript supersets

### DIFF
--- a/autoload/neomake/makers/ft/angular.vim
+++ b/autoload/neomake/makers/ft/angular.vim
@@ -16,6 +16,10 @@ function! neomake#makers#ft#angular#eslint()
     return neomake#makers#ft#javascript#eslint()
 endfunction
 
+function! neomake#makers#ft#angular#eslint_d()
+    return neomake#makers#ft#javascript#eslint_d()
+endfunction
+
 function! neomake#makers#ft#angular#jscs()
     return neomake#makers#ft#javascript#jscs()
 endfunction

--- a/autoload/neomake/makers/ft/jasmine.vim
+++ b/autoload/neomake/makers/ft/jasmine.vim
@@ -16,6 +16,10 @@ function! neomake#makers#ft#jasmine#eslint()
     return neomake#makers#ft#javascript#eslint()
 endfunction
 
+function! neomake#makers#ft#jasmine#eslint_d()
+    return neomake#makers#ft#javascript#eslint_d()
+endfunction
+
 function! neomake#makers#ft#jasmine#jscs()
     return neomake#makers#ft#javascript#jscs()
 endfunction

--- a/autoload/neomake/makers/ft/jsx.vim
+++ b/autoload/neomake/makers/ft/jsx.vim
@@ -21,3 +21,7 @@ endfunction
 function! neomake#makers#ft#jsx#eslint()
     return neomake#makers#ft#javascript#eslint()
 endfunction
+
+function! neomake#makers#ft#jsx#eslint_d()
+    return neomake#makers#ft#javascript#eslint_d()
+endfunction

--- a/autoload/neomake/makers/ft/node.vim
+++ b/autoload/neomake/makers/ft/node.vim
@@ -16,6 +16,10 @@ function! neomake#makers#ft#node#eslint()
     return neomake#makers#ft#javascript#eslint()
 endfunction
 
+function! neomake#makers#ft#node#eslint_d()
+    return neomake#makers#ft#javascript#eslint_d()
+endfunction
+
 function! neomake#makers#ft#node#jscs()
     return neomake#makers#ft#javascript#jscs()
 endfunction


### PR DESCRIPTION
Given that `eslint_d` is essentially a drop in replacement for `eslint`, I thought it would be a reasonable addition to add `eslint_d` maker support wherever `eslint` is supported in javascript's supersets.