### PR TITLE
add running status for statusline

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -95,7 +95,7 @@ function! neomake#MakeJob(maker) abort
         let cwd = expand(a:maker.cwd, 1)
         exe 'cd' fnameescape(cwd)
     endif
-
+    call neomake#statusline#SetRunningStatus(winnr(), bufnr('%'), '...')
     let job = s:JobStart(make_id, a:maker.exe, args)
     let jobinfo.start = localtime()
     let jobinfo.last_register = 0
@@ -580,6 +580,7 @@ function! neomake#MakeHandler(job_id, data, event_type) abort
         else
             call neomake#CleanOldProjectSignsAndErrors()
         endif
+        call neomake#statusline#SetRunningStatus(maker.winnr, jobinfo.bufnr, '')
 
         " Show the current line's error
         call neomake#CursorMoved()

--- a/autoload/neomake/statusline.vim
+++ b/autoload/neomake/statusline.vim
@@ -9,6 +9,8 @@ endfunction
 function! neomake#statusline#ResetCounts() abort
     let s:qflist_counts = {}
     let s:loclist_counts = {}
+    let s:running_status = {}
+    let g:status = s:running_status
 endfunction
 call neomake#statusline#ResetCounts()
 
@@ -16,6 +18,17 @@ function! neomake#statusline#AddLoclistCount(win, buf, item) abort
     let s:loclist_counts[a:win] = get(s:loclist_counts, a:win, {})
     let s:loclist_counts[a:win][a:buf] = get(s:loclist_counts[a:win], a:buf, {})
     call s:setCount(s:loclist_counts[a:win][a:buf], a:item, a:buf)
+endfunction
+
+function! neomake#statusline#SetRunningStatus(win, buf, status)
+    let s:running_status[a:win] = get(s:running_status, a:win, {})
+    let s:running_status[a:win][a:buf] = get(a:, 'status', '')
+endfunction
+
+function! neomake#statusline#GetRunningStatus()
+    let win = winnr()
+    let buf = bufnr('%')
+    return get(get(s:running_status, win, {}), buf, '')
 endfunction
 
 function! neomake#statusline#AddQflistCount(item) abort


### PR DESCRIPTION
User could use function `neomake#statusline#GetRunningStatus()` to show neomake running status in their statusline setting.

 `...` is returned when neomake is running for this buffer and window, empty string returned if not. 
