### PR TITLE
Implement support for on-the-fly linting

### DIFF
--- a/autoload/neomake/makers/ft/javascript.vim
+++ b/autoload/neomake/makers/ft/javascript.vim
@@ -20,7 +20,8 @@ endfunction
 
 function! neomake#makers#ft#javascript#eslint()
     return {
-        \ 'args': ['-f', 'compact'],
+        \ 'pipe': 1,
+        \ 'args': ['-f', 'compact', '--stdin', '--stdin-filename'],
         \ 'errorformat': '%E%f: line %l\, col %c\, Error - %m,' .
         \ '%W%f: line %l\, col %c\, Warning - %m'
         \ }

--- a/autoload/neomake/makers/ft/ruby.vim
+++ b/autoload/neomake/makers/ft/ruby.vim
@@ -6,7 +6,8 @@ endfunction
 
 function! neomake#makers#ft#ruby#rubocop()
     return {
-        \ 'args': ['--format', 'emacs'],
+        \ 'pipe': 1,
+        \ 'args': ['--format', 'emacs', '--stdin'],
         \ 'errorformat': '%f:%l:%c: %t: %m',
         \ 'postprocess': function('neomake#makers#ft#ruby#RubocopEntryProcess')
         \ }


### PR DESCRIPTION
This is my attempt to implement  on-the-fly linting using this proposal: https://github.com/benekastah/neomake/issues/190

To actually run `Neomake` on the fly I've added this to my vimrc:

```
autocmd TextChanged,TextChangedI * Neomake
```

Using `CursorHold` is another option.

Rubocop and Eslint makers were changed in order to use this feature.
To use it with different linters, `pipe` option needs to be set to 1
and maker arguments need to be adjusted to handle stdin as source.

Here is an example of how it is configured for rubocop:

```
function! neomake#makers#ft#ruby#rubocop()
    return {
        \ 'pipe': 1,
        \ 'args': ['--format', 'emacs', '--stdin'],
        \ 'errorformat': '%f:%l:%c: %t: %m',
        \ 'postprocess': function('neomake#makers#ft#ruby#RubocopEntryProcess')
        \ }
endfunction
```

Tested on both Neovim (0.1.4) and Vim (7.4.1795)
