### PR TITLE
Only handle CursorMoved when cursor was moved between lines

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -577,6 +577,7 @@ function! neomake#MakeHandler(job_id, data, event_type) abort
 
         " Show the current line's error
         call neomake#CursorMoved()
+        call neomake#EchoCurrentError()
 
         if has_key(maker, 'next')
             let next_makers = '['.join(maker.next.enabled_makers, ', ').']'
@@ -647,8 +648,12 @@ function! neomake#EchoCurrentError() abort
 endfunction
 
 function! neomake#CursorMoved() abort
-    call neomake#signs#PlaceVisibleSigns()
-    call neomake#EchoCurrentError()
+    let l:line = line('.')
+    if get(s:, 'last_cursormoved_line', 0) != l:line
+        let s:last_cursormoved_line = l:line
+        call neomake#signs#PlaceVisibleSigns()
+        call neomake#EchoCurrentError()
+    endif
 endfunction
 
 function! neomake#CompleteMakers(ArgLead, ...)

--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -576,7 +576,6 @@ function! neomake#MakeHandler(job_id, data, event_type) abort
         endif
 
         " Show the current line's error
-        call neomake#CursorMoved()
         call neomake#EchoCurrentError()
 
         if has_key(maker, 'next')


### PR DESCRIPTION
Moving cursor left and right staying on the same line causes lags,
because visible signs and error messages are redrawn on every move.

Looks like there is no need to do it, because the first error message
for the line is shown anyway, and visible area is not changed.

This PR is my naive attempt to avoid this lag by handling `CursorMoved`
only when line under cursor was changed.