### PR TITLE
Match warnings in 'rst-lint'.

### DIFF
--- a/autoload/neomake/makers/ft/rst.vim
+++ b/autoload/neomake/makers/ft/rst.vim
@@ -9,6 +9,7 @@ function! neomake#makers#ft#rst#rstlint()
         \ 'exe': 'rst-lint',
         \ 'errorformat':
             \ '%EERROR %f:%l %m,'.
+            \ '%WWARNING %f:%l %m,'.
             \ '%IINFO %f:%l %m',
         \ }
 endfunction


### PR DESCRIPTION
The maker for reStructuredText does not match warnings, only errors and infos. Fixed it. You can test it with this snippet of reStructuredText:
```
Some content.

Hello World
=======
Some more content!
```
The underline is too short, so a warning will be emitted.