### PR TITLE
golang: add errcheck maker

### DIFF
--- a/autoload/neomake/makers/ft/go.vim
+++ b/autoload/neomake/makers/ft/go.vim
@@ -47,3 +47,64 @@ function! neomake#makers#ft#go#govet()
             \ '%-G%.%#'
         \ }
 endfunction
+
+" This comes straight out of vim-go.
+" PathListSep returns the appropriate OS specific path list separator.
+function! neomake#makers#ft#go#PathListSep()
+    if neomake#utils#IsRunningWindows()
+        return ";"
+    endif
+    return ":"
+endfunction
+
+" This comes straight out of vim-go.
+function! neomake#makers#ft#go#Paths()
+    let dirs = []
+
+    if !exists("s:goroot")
+        if executable('go')
+            let s:goroot = substitute(system('go env GOROOT'), '\n', '', 'g')
+        else
+            let s:goroot = $GOROOT
+        endif
+    endif
+
+    if len(s:goroot) != 0 && isdirectory(s:goroot)
+        let dirs += [s:goroot]
+    endif
+
+    let workspaces = split($GOPATH, neomake#makers#ft#go#PathListSep())
+    if workspaces != []
+        let dirs += workspaces
+    endif
+
+    return dirs
+endfunction
+
+" This comes straight out of vim-go.
+function! neomake#makers#ft#go#ImportPath(arg)
+    let path = fnamemodify(resolve(a:arg), ':p')
+    let dirs = neomake#makers#ft#go#Paths()
+
+    for dir in dirs
+        if len(dir) && match(path, dir) == 0
+            let workspace = dir
+        endif
+    endfor
+
+    if !exists('workspace')
+        return -1
+    endif
+
+    let srcdir = substitute(workspace . '/src/', '//', '/', '')
+    return substitute(path, srcdir, '', '')
+endfunction
+
+function! neomake#makers#ft#go#errcheck()
+    let path = neomake#makers#ft#go#ImportPath(expand('%:p:h'))
+    return {
+        \ 'args': ['-abspath', path],
+        \ 'append_file': 0,
+        \ 'errorformat': '%E%f:%l:%c:\ %m, %f:%l:%c\ %#%m'
+        \ }
+endfunction


### PR DESCRIPTION
Add errcheck maker with [kisielk/errcheck](https://github.com/kisielk/errcheck).

This feature is depends on [fatih/vim-go](https://github.com/fatih/vim-go) for now. Which is better depending on vim-go or copying vim-go's functions?
