### PR TITLE
Allow for maker.args to be a callback and use it for shellcheck

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -76,7 +76,21 @@ function! neomake#MakeJob(maker) abort
     endif
     let jobinfo.maker = a:maker
 
-    let args = a:maker.args
+    " Resolve exe/args, which might be a function or dictionary.
+    if type(a:maker.exe) == type(function('tr'))
+        let exe = call(a:maker.exe, [])
+    elseif type(a:maker.exe) == type({})
+        let exe = call(a:maker.exe.fn, [], a:maker.exe)
+    else
+        let exe = a:maker.exe
+    endif
+    if type(a:maker.args) == type(function('tr'))
+        let args = call(a:maker.args, [])
+    elseif type(a:maker.args) == type({})
+        let args = call(a:maker.args.fn, [], a:maker.args)
+    else
+        let args = a:maker.args
+    endif
     let append_file = a:maker.file_mode && index(args, '%:p') <= 0 && get(a:maker, 'append_file', 1)
     if append_file
         call add(args, '%:p')
@@ -95,7 +109,7 @@ function! neomake#MakeJob(maker) abort
         exe 'cd' fnameescape(cwd)
     endif
 
-    let job = s:JobStart(make_id, a:maker.exe, args)
+    let job = s:JobStart(make_id, exe, args)
     let jobinfo.start = localtime()
     let jobinfo.last_register = 0
 

--- a/doc/neomake.txt
+++ b/doc/neomake.txt
@@ -81,6 +81,11 @@ All 'args' will be |expand()|ed: >
         \ 'exe': 'lint',
         \ 'args': ['%:p'],
         \ }
+
+The 'exe' and 'args' entries can be a function (callback) or a dictionary with
+an expected entry 'fn' (which has to be a function).
+The function has to return a string, and receives no arguments.
+
 <
 Running "|:Neomake!| lint" from file.txt would cause "lint /path/to/file.txt" to
 be run.


### PR DESCRIPTION
This makes shellcheck pass &ft in case there is no shebang.

Fixes https://github.com/neomake/neomake/issues/373.