### PR TITLE
Go cwd

### DIFF
--- a/autoload/neomake/makers/ft/go.vim
+++ b/autoload/neomake/makers/ft/go.vim
@@ -31,6 +31,7 @@ endfunction
 function! neomake#makers#ft#go#govet()
     return {
         \ 'exe': 'go',
+        \ 'cwd': '%:p:h',
         \ 'args': ['vet'],
         \ 'append_file': 0,
         \ 'errorformat':

--- a/autoload/neomake/makers/ft/go.vim
+++ b/autoload/neomake/makers/ft/go.vim
@@ -4,13 +4,19 @@ function! neomake#makers#ft#go#EnabledMakers()
     return ['go', 'golint', 'govet']
 endfunction
 
+" The mapexprs in these are needed because cwd will make the command print out
+" the wrong path (it will just be ./%:h in the output), so the mapexpr turns
+" that back into the relative path
+
 function! neomake#makers#ft#go#go()
     return {
         \ 'args': [
-            \ 'build',
-            \ '-o', neomake#utils#DevNull()
+            \ 'test', '-c',
+            \ '-o', neomake#utils#DevNull(),
         \ ],
         \ 'append_file': 0,
+        \ 'cwd': '%:h',
+        \ 'mapexpr': 'expand("%:h") . "/" . v:val',
         \ 'errorformat':
             \ '%W%f:%l: warning: %m,' .
             \ '%E%f:%l:%c:%m,' .
@@ -22,6 +28,8 @@ endfunction
 
 function! neomake#makers#ft#go#golint()
     return {
+        \ 'cwd': '%:h',
+        \ 'mapexpr': 'expand("%:h") . "/" . v:val',
         \ 'errorformat':
             \ '%f:%l:%c: %m,' .
             \ '%-G%.%#'
@@ -31,9 +39,10 @@ endfunction
 function! neomake#makers#ft#go#govet()
     return {
         \ 'exe': 'go',
-        \ 'cwd': '%:p:h',
         \ 'args': ['vet'],
         \ 'append_file': 0,
+        \ 'cwd': '%:h',
+        \ 'mapexpr': 'expand("%:h") . "/" . v:val',
         \ 'errorformat':
             \ '%Evet: %.%\+: %f:%l:%c: %m,' .
             \ '%W%f:%l: %m,' .


### PR DESCRIPTION
There's two fixes in here:

* use `go test` instead of `go build` for the main syntax check. `go build` only actually works on a `main` package, so if you're working on a library package it's not very useful. `go test` with `-c` will only compile the tests without running them. Even if there's no tests it will still make sure the package compiles. Otherwise it's virtually identical to `go build`.

* use `mapexpr` to fix the output paths from things erroring. Since `cwd` puts the command inside an inner-path, it will break the output paths on its own.