### PR TITLE
Include hlint suggestions in error format

### DIFF
--- a/autoload/neomake/makers/ft/haskell.vim
+++ b/autoload/neomake/makers/ft/haskell.vim
@@ -44,6 +44,7 @@ function! neomake#makers#ft#haskell#hlint()
         \ 'errorformat':
             \ '%E%f:%l:%v: Error: %m,' .
             \ '%W%f:%l:%v: Warning: %m,' .
+            \ '%I%f:%l:%v: Suggestion: %m,' .
             \ '%C%m'
         \ }
 endfunction


### PR DESCRIPTION
`hlint` has three message types: [Errors, Warnings, and Suggestions](https://github.com/ndmitchell/hlint#what-is-the-difference-between-errorwarningsuggestion). Currently, neomake's default hlint format only parses Errors and Warnings. This PR adds Suggestions to the error format as informational messages.

This should address issues like #339 where users mentioned the quickfix window not showing on all occasions (most likely due to missing Suggestions).