### PR TITLE
Add support for fish

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ D:
 Erlang:
 - erlc
 
+fish:
+- fish
+
 Go:
 - go
 - golint

--- a/autoload/neomake/makers/ft/fish.vim
+++ b/autoload/neomake/makers/ft/fish.vim
@@ -1,0 +1,16 @@
+" vim: ts=4 sw=4 et
+
+function! neomake#makers#ft#fish#EnabledMakers()
+    return ['fish']
+endfunction
+
+function! neomake#makers#ft#fish#fish()
+    return {
+        \ 'args': ['-n'],
+        \ 'errorformat':
+            \ '%C%f (line %l): %s,'.
+            \ '%-Gfish: %.%#,'.
+            \ '%Z%p^,'.
+            \ '%E%m'
+        \}
+endfunction


### PR DESCRIPTION
This adds the command fish with error format accordingly.

I find that this is a bit buggy sometimes, e.g. sometimes when I run it, it will only parse part of the error message as the message, but with several consecutive runs it will eventually get the full message. It is kind of like it returns too early.

Is there something weird with my pattern or is this a known issue?