### PR TITLE
Fix shebang parsing in neomake#makers#ft#sh#sh

### DIFF
--- a/autoload/neomake/makers/ft/sh.vim
+++ b/autoload/neomake/makers/ft/sh.vim
@@ -29,11 +29,8 @@ function! neomake#makers#ft#sh#checkbashisms()
 endfunction
 
 function! neomake#makers#ft#sh#sh()
-    let l:sh = '/bin/sh'
-    let l:line = getline(1)
-    if l:line =~# '^#!'
-        let l:sh = matchstr(l:line, '^#!\zs\S*\ze')
-    endif
+    let l:shebang = matchstr(getline(1), '^#!\s*\zs.*$')
+    let l:sh = l:shebang == '' ? '/bin/sh' : l:shebang
 
     return {
         \ 'exe': l:sh,


### PR DESCRIPTION
`#! /usr/bin/env bash` is apparently a valid/used shebang (yes, with a
space even).

Followup to #362.