### PR TITLE
Add .vintrc.yaml to disable style warnings about local scope

### DIFF
--- a/.vintrc.yaml
+++ b/.vintrc.yaml
@@ -1,0 +1,3 @@
+policies:
+  ProhibitImplicitScopeVariable:
+    enabled: false


### PR DESCRIPTION
E.g.

> Make the scope explicit like `l:jobinfo`

Ref: https://github.com/neomake/neomake/pull/425#issuecomment-219907955.

/cc @sbdchd