### PR TITLE
add mypy to python makers

### DIFF
--- a/autoload/neomake/makers/ft/python.vim
+++ b/autoload/neomake/makers/ft/python.vim
@@ -168,8 +168,11 @@ function! neomake#makers#ft#python#vulture()
         \ }
 endfunction
 
+" Because this uses --silent-imports it requires mypy >= 0.4
+" It is annoying for new users to use MyPy without --silent-imports
 function! neomake#makers#ft#python#mypy()
     return {
+        \ 'args': ['--silent-imports'],
         \ 'errorformat': '%f:%l: error: %m',
         \ }
 endfunction

--- a/autoload/neomake/makers/ft/python.vim
+++ b/autoload/neomake/makers/ft/python.vim
@@ -5,7 +5,14 @@ function! neomake#makers#ft#python#EnabledMakers()
         return s:python_makers
     endif
 
-    let makers = ['python', 'frosted']
+    if executable('mypy')
+        let makers = ['mypy']
+    else
+        let makers = ['python']
+    endif
+    if executable('frosted')
+        call add(makers, 'frosted')
+    endif
 
     if executable('pylama')
         call add(makers, 'pylama')
@@ -158,5 +165,11 @@ endfunction
 function! neomake#makers#ft#python#vulture()
     return {
         \ 'errorformat': '%f:%l: %m',
+        \ }
+endfunction
+
+function! neomake#makers#ft#python#mypy()
+    return {
+        \ 'errorformat': '%f:%l: error: %m',
         \ }
 endfunction


### PR DESCRIPTION
* If you use `mypy` I don't think you have a need to run the `python` checker.
* don't know what is up with `frosted` being treated special: I treated it like all the others instead.

I tested this locally, it works for me (mypy-lang==0.4.0)