### PR TITLE
Use the airline naming format for enable check

### DIFF
--- a/autoload/airline/extensions/neomake.vim
+++ b/autoload/airline/extensions/neomake.vim
@@ -1,6 +1,6 @@
 " vim: ts=4 sw=4 et
 
-if exists('g:neomake_airline') && g:neomake_airline == 0
+if get(g:, 'airline#extensions#neomake#enabled', 1) == 0
     finish
 endif
 


### PR DESCRIPTION
Use the naming format that airline uses for consistency.

PR to have airline initialize neomake
https://github.com/vim-airline/vim-airline/pull/1179