### PR TITLE
go: Fix golint maker

### DIFF
--- a/autoload/neomake/makers/ft/go.vim
+++ b/autoload/neomake/makers/ft/go.vim
@@ -28,8 +28,6 @@ endfunction
 
 function! neomake#makers#ft#go#golint()
     return {
-        \ 'cwd': '%:h',
-        \ 'mapexpr': 'expand("%:h") . "/" . v:val',
         \ 'errorformat':
             \ '%f:%l:%c: %m,' .
             \ '%-G%.%#'


### PR DESCRIPTION
Wrongfully broken in 5ac6c80, golint behaves differently in contrast to the core go toolchain