### PR TITLE
Working Perl maker with perl & perlcritic

### DIFF
--- a/autoload/neomake/makers/ft/perl.vim
+++ b/autoload/neomake/makers/ft/perl.vim
@@ -14,7 +14,14 @@ endfunction
 function! neomake#makers#ft#perl#perl() abort
     return { 
          \ 'args' : ['-c', "-X", "-Mwarnings"],
-         \ 'errorformat': '%m at %f line %l%s',
+         \ 'errorformat': '%E%m at %f line %l%s',
+         \ 'postprocess': function('neomake#makers#ft#perl#PerlEntryProcess'),
          \ 'buffer_output': 1
      \}
+endfunction
+
+function! neomake#makers#ft#perl#PerlEntryProcess(entry)
+    let extramsg = substitute(a:entry.pattern, '\^\\V', "", "")
+    let extramsg = substitute(extramsg, '\\\$', "", "")
+    let a:entry.text = a:entry.text . ' ' . extramsg
 endfunction

--- a/autoload/neomake/makers/ft/perl.vim
+++ b/autoload/neomake/makers/ft/perl.vim
@@ -1,6 +1,6 @@
 " vim: ts=4 sw=4 et
-function! neomake#makers#ft#vim#EnabledMakers()
-    return ['perlcritic' ]
+function! neomake#makers#ft#perl#EnabledMakers()
+    return ['perl', 'perlcritic']
 endfunction
 
 function! neomake#makers#ft#perl#perlcritic() abort
@@ -8,5 +8,13 @@ function! neomake#makers#ft#perl#perlcritic() abort
          \ 'args' : ['--quiet', '--nocolor', '--verbose', '\\%f:\\%l:\\%c:(\\%s) \\%m (\\%e)\\n'],
          \ 'errorformat': 
          \ '%f:%l:%c:%m,'
+     \}
+endfunction
+
+function! neomake#makers#ft#perl#perl() abort
+    return { 
+         \ 'args' : ['-c', "-X", "-Mwarnings"],
+         \ 'errorformat': '%m at %f line %l%s',
+         \ 'buffer_output': 1
      \}
 endfunction


### PR DESCRIPTION
The original perlcritic was not working because it had neomake#makers#ft#**vim**#EnabledMakers instead of neomake#makers#ft#**perl**#EnabledMakers.

Added **perl** maker for syntax checking.