### PR TITLE
only reset counts for buf in file_mode

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -281,10 +281,17 @@ endfunction
 
 function! s:Make(options) abort
     call neomake#signs#DefineSigns()
-    call neomake#statusline#ResetCounts()
 
+    let buf = bufnr('%')
+    let win = winnr()
     let ft = get(a:options, 'ft', '')
     let file_mode = get(a:options, 'file_mode')
+
+    if file_mode
+        call neomake#statusline#ResetCountsForBuf(buf)
+    else
+        call neomake#statusline#ResetCounts()
+    endif
 
     let enabled_makers = get(a:options, 'enabled_makers', [])
     if !len(enabled_makers)
@@ -306,8 +313,6 @@ function! s:Make(options) abort
     if !get(a:options, 'continuation')
         " Only do this if we have one or more enabled makers
         if file_mode
-            let buf = bufnr('%')
-            let win = winnr()
             call neomake#signs#ResetFile(buf)
             let s:need_errors_cleaning['file'][buf] = 1
             let s:loclist_nr = get(s:, 'loclist_nr', {})
@@ -391,8 +396,7 @@ function! s:AddExprCallback(maker) abort
         endif
 
         if file_mode
-            call neomake#statusline#AddLoclistCount(
-                \ a:maker.winnr, entry.bufnr, entry)
+            call neomake#statusline#AddLoclistCount(entry.bufnr, entry)
         endif
 
         " On the first valid error identified by a maker,

--- a/autoload/neomake/statusline.vim
+++ b/autoload/neomake/statusline.vim
@@ -1,9 +1,12 @@
-
 function! s:setCount(counts, item, buf) abort
     let type = toupper(a:item.type)
     if len(type) && (!a:buf || a:item.bufnr ==# a:buf)
         let a:counts[type] = get(a:counts, type, 0) + 1
     endif
+endfunction
+
+function! neomake#statusline#ResetCountsForBuf(buf) abort
+    let s:loclist_counts[a:buf] = {}
 endfunction
 
 function! neomake#statusline#ResetCounts() abort
@@ -12,21 +15,21 @@ function! neomake#statusline#ResetCounts() abort
 endfunction
 call neomake#statusline#ResetCounts()
 
-function! neomake#statusline#AddLoclistCount(win, buf, item) abort
-    let s:loclist_counts[a:win] = get(s:loclist_counts, a:win, {})
-    let s:loclist_counts[a:win][a:buf] = get(s:loclist_counts[a:win], a:buf, {})
-    call s:setCount(s:loclist_counts[a:win][a:buf], a:item, a:buf)
+function! neomake#statusline#AddLoclistCount(buf, item) abort
+    let s:loclist_counts[a:buf] = get(s:loclist_counts, a:buf, {})
+    call s:setCount(s:loclist_counts[a:buf], a:item, a:buf)
 endfunction
 
 function! neomake#statusline#AddQflistCount(item) abort
     call s:setCount(s:qflist_counts, a:item, 0)
 endfunction
 
-function! neomake#statusline#LoclistCounts() abort
-    let win = winnr()
-    let buf = bufnr('%')
-    let s:loclist_counts[win] = get(s:loclist_counts, win, {})
-    return get(s:loclist_counts[win], buf, {})
+function! neomake#statusline#LoclistCounts(...) abort
+    let buf = a:0 ? a:1 : bufnr('%')
+    if buf ==# 'all'
+        return s:loclist_counts
+    endif
+    return get(s:loclist_counts, buf, {})
 endfunction
 
 function! neomake#statusline#QflistCounts() abort

--- a/doc/neomake.txt
+++ b/doc/neomake.txt
@@ -332,8 +332,12 @@ or warnings and the empty string otherwise.
 These functions get the counts of errors by error type for the |location-list|
 and the |quickfix| respectively. The return value is something like this: >
     {'E': 2, 'W': 1, 'x': 5}
-<Where 'E', 'W' and 'x' are error types. Empty error types are ignored for
-now.
+<Where 'E', 'W' and 'x' are error types. Empty error types are ignored for now.
+
+By default, *LoclistCounts* returns the counts for the current buffer (i.e.
+|bufnr(%)|). *LoclistCounts* also takes an optional |buf| argument: passing a
+buffer number will retrieve the counts for a particular buffer, while
+passing the string `'all'` will return a Dictionary of counts for all buffers.
 
 *neomake#ProcessCurrentWindow*
 This is the function that takes the job output and puts it into the loclist or


### PR DESCRIPTION
Currently, Neomake _attempts_ to track per-buffer loclist counts but these counts get reset anytime `s:Make` is called, even if the intention is to only process one particular buffer. In other words, if I have N different buffers open but I only want to check the syntax for one particular buffer, Neomake will (mistakenly) clear the loclist counts for all buffers regardless.

This PR fixes the issue by only resetting the counts for a particular buffer if `neomake#Make` is running in `file_mode`.