### PR TITLE
Fix sh maker: recognize output format without 'line' from dash

### DIFF
--- a/autoload/neomake/makers/ft/sh.vim
+++ b/autoload/neomake/makers/ft/sh.vim
@@ -39,9 +39,12 @@ function! neomake#makers#ft#sh#sh()
         let args = ['-n']
     endif
 
+    " NOTE: the format without "line" is used by dash.
     return {
         \ 'exe': exe,
         \ 'args': args,
-        \ 'errorformat': '%f: line %l: %m'
+        \ 'errorformat':
+            \ '%f: line %l: %m,' .
+            \ '%f: %l: %m'
         \}
 endfunction


### PR DESCRIPTION
This is apparently used on Travis, but makes sense in general - e.g.
probably still for Ubuntu systems?!