### PR TITLE
Add `neomake_place_signs_at_once` option to show all signs at once

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -840,7 +840,9 @@ function! neomake#CursorMoved() abort
     let l:line = line('.')
     if s:last_cursormoved[0] != l:line || s:last_cursormoved[1] != bufnr('%')
         let s:last_cursormoved = [l:line, bufnr('%')]
-        call neomake#signs#PlaceVisibleSigns()
+        if !get(g:, 'neomake_place_signs_at_once', 0)
+            call neomake#signs#PlaceVisibleSigns()
+        endif
         call neomake#EchoCurrentError()
     endif
 endfunction

--- a/autoload/neomake/signs.vim
+++ b/autoload/neomake/signs.vim
@@ -133,8 +133,15 @@ function! neomake#signs#PlaceVisibleSigns() abort
         if !has_key(s:sign_queue[type], buf)
             continue
         endif
-        let topline = line('w0')
-        let botline = line('w$')
+
+        if !get(g:, 'neomake_place_signs_at_once', 0)
+            let topline = line('w0')
+            let botline = line('w$')
+        else
+            let topline = line('0')
+            let botline = line('$')
+        endif
+
         for ln in range(topline, botline)
             if has_key(s:sign_queue[type][buf], ln)
                 call neomake#signs#PlaceSign(s:sign_queue[type][buf][ln], type)

--- a/doc/neomake.txt
+++ b/doc/neomake.txt
@@ -299,6 +299,11 @@ You can use `neomake#signs#DefineHighlights` to get e.g. the "bg" from
 Shows the output returned by |neomake#statusline#LoclistStatus| in the warning
 section of the vim-airline |statusline|. Defaults to 1.
 
+*g:neomake_place_signs_at_once*
+This setting will tell neomake to place all of the signs in the buffer at
+once, instead of only placing visible signs and lazily placing more signs
+when the cursor is moved. Defaults to 0.
+
 ==============================================================================
 4. Functions                                                 *neomake-functions*
 


### PR DESCRIPTION
This new option allows to render all of the signs at once, which eliminates scrolling lag described here: https://github.com/neomake/neomake/issues/240
