### PR TITLE
Don't append_file to makeprg if in args

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -89,7 +89,7 @@ function! neomake#MakeJob(maker) abort
     else
         let args = a:maker.args
     endif
-    let append_file = a:maker.file_mode && index(args, '%:p') <= 0 && get(a:maker, 'append_file', 1)
+    let append_file = a:maker.file_mode && index(args, '%:p') == -1 && get(a:maker, 'append_file', 1)
     if append_file
         call add(args, '%:p')
     endif


### PR DESCRIPTION
Don't append the filename to the makeprg when it exists in the maker's args in ANY position

This is for cases like `phpmd` where the args are specifically `phpmd [filename|directory] [report format] [ruleset file]`

Currently since `%:p` is the first argument in `args`, neomake will append the filename, causing an extra argument, e.g. makeprg will be:

`phpmd ~/mu-plugins/nda-fbia/facebook.php text ruleset.xml ~/mu-plugins/nda-fbia/facebook.php`
(note facebook.php file is added twice)

While phpmd will still run like this, it is better to adhere to the exact syntax a maker expects and there is no other way to specify this (e.g. implementation of a boolean `b:neomake_ft_maker_append_file` would suffice as well)

I don't believe this will break any makers