### PR TITLE
postprocess: if entry was changed, update the list

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -392,7 +392,13 @@ function! s:AddExprCallback(maker) abort
         let index += 1
 
         if has_key(a:maker, 'postprocess')
+            if !list_modified
+                let before = copy(entry)
+            endif
             call a:maker.postprocess(entry)
+            if !list_modified && entry != before
+                let list_modified = 1
+            endif
         endif
 
         if !entry.valid

--- a/tests/lists.vader
+++ b/tests/lists.vader
@@ -7,11 +7,11 @@ Execute (Postprocessing should update list):
   AssertNotEqual list, []
 
   let s:efm = neomake#makers#ft#sh#sh()
-  function s:postprocess(entry)
+  function g:Postprocess(entry)
     let a:entry.text .= ' SUFFIX'
   endfunction
   function! neomake#makers#ft#sh#sh()
-    return extend(s:efm, {'postprocess': function('s:postprocess')})
+    return extend(s:efm, {'postprocess': function('g:Postprocess')})
   endfunction
   let expected_list = map(list, 'extend(v:val, {"text": v:val.text." SUFFIX"})')
   RunNeomake sh

--- a/tests/lists.vader
+++ b/tests/lists.vader
@@ -1,0 +1,18 @@
+Include: _setup.vader
+
+Execute (Postprocessing should update list):
+  e! fixtures/errors.sh
+  RunNeomake sh
+  let list = getloclist(0)
+  AssertNotEqual list, []
+
+  let s:efm = neomake#makers#ft#sh#sh()
+  function s:postprocess(entry)
+    let a:entry.text .= ' SUFFIX'
+  endfunction
+  function! neomake#makers#ft#sh#sh()
+    return extend(s:efm, {'postprocess': function('s:postprocess')})
+  endfunction
+  let expected_list = map(list, 'extend(v:val, {"text": v:val.text." SUFFIX"})')
+  RunNeomake sh
+  AssertEqual getloclist(0), expected_list


### PR DESCRIPTION
An alternate approach would be to look at the `postprocess` return status, but that is not backward compatible.

TODO:
 - [x] add test