### PR TITLE
tests/_setup.vader: restore g:neomake_verbose

### DIFF
--- a/tests/_setup.vader
+++ b/tests/_setup.vader
@@ -1,7 +1,19 @@
 " Setup and helpers for all tests.
 
-Execute:
-  let neomake_verbose = 3
+Before:
+  if exists('g:neomake_verbose')
+    let g:save_neomake_verbose = g:neomake_verbose
+  endif
+  let g:neomake_verbose = 3
 
+After:
+  if exists('g:save_neomake_verbose')
+    let g:neomake_verbose = g:save_neomake_verbose
+    unlet g:save_neomake_verbose
+  else
+    unlet g:neomake_verbose
+  endif
+
+Execute:
   command! -nargs=* RunNeomake Neomake <args>
     \ | while len(neomake#GetJobs()) | sleep 50m | endwhile


### PR DESCRIPTION
This is needed when running Vader from inside of Vim itself, to not mess
with the user's setting.