### PR TITLE
introduce buffer specific b:neomake_FT_enabled_makers

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -278,7 +278,9 @@ endfunction
 function! neomake#GetEnabledMakers(...) abort
     if !a:0 || type(a:1) !=# type('')
         " If we have no filetype, our job isn't complicated.
-        return get(g:, 'neomake_enabled_makers', [])
+        return get(b:, 'neomake_enabled_makers',
+                    \   get(g:, 'neomake_enabled_makers', [])
+                    \ )
     endif
 
     " If a filetype was passed, get the makers that are enabled for each of
@@ -288,19 +290,30 @@ function! neomake#GetEnabledMakers(...) abort
     let fts = neomake#utils#GetSortedFiletypes(a:1)
     for ft in fts
         let ft = substitute(ft, '\W', '_', 'g')
-        let varname = 'g:neomake_'.ft.'_enabled_makers'
-        let fnname = 'neomake#makers#ft#'.ft.'#EnabledMakers'
-        if exists(varname)
-            let enabled_makers = eval(varname)
-        else
+        unlet l:enabled_makers
+
+        let l:varname = 'b:neomake_'.ft.'_enabled_makers'
+        if exists(l:varname)    " Try buffer's enabled makers for the ft
+            let l:enabled_makers = eval(l:varname)
+        else                    " Try global enabled makers for the ft
+            let l:varname = 'g:neomake_'.ft.'_enabled_makers'
+            if exists(l:varname)
+                let l:enabled_makers = eval(l:varname)
+            endif
+        endif
+
+        " Use plugin's defaults if not user customized
+        if !exists('l:enabled_makers')
             try
+                let fnname = 'neomake#makers#ft#'.ft.'#EnabledMakers'
                 let default_makers = eval(fnname . '()')
             catch /^Vim\%((\a\+)\)\=:E117/
                 let default_makers = []
             endtry
-            let enabled_makers = neomake#utils#AvailableMakers(ft, default_makers)
+            let l:enabled_makers = neomake#utils#AvailableMakers(ft, default_makers)
         endif
-        for maker_name in enabled_makers
+
+        for maker_name in l:enabled_makers
             let c = get(makers_count, maker_name, 0)
             let makers_count[maker_name] = c + 1
             " Add each maker only once, but keep the order.

--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -290,7 +290,7 @@ function! neomake#GetEnabledMakers(...) abort
     let fts = neomake#utils#GetSortedFiletypes(a:1)
     for ft in fts
         let ft = substitute(ft, '\W', '_', 'g')
-        unlet l:enabled_makers
+        unlet! l:enabled_makers
 
         let l:varname = 'b:neomake_'.ft.'_enabled_makers'
         if exists(l:varname)    " Try buffer's enabled makers for the ft

--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -277,10 +277,10 @@ endfunction
 
 function! neomake#GetEnabledMakers(...) abort
     if !a:0 || type(a:1) !=# type('')
-        " If we have no filetype, our job isn't complicated.
-        return get(b:, 'neomake_enabled_makers',
-                    \   get(g:, 'neomake_enabled_makers', [])
-                    \ )
+        " If we have no filetype, use the global default makers
+        " This variable is used for running neomake against multiple files, too
+        " so there is no analogous buffer local ('b:') counterpart
+        return get(g:, 'neomake_enabled_makers', [])
     endif
 
     " If a filetype was passed, get the makers that are enabled for each of

--- a/doc/neomake.txt
+++ b/doc/neomake.txt
@@ -199,12 +199,14 @@ Configure a property for a prexisting maker where property is one of 'exe',
 *g:neomake_<ft>_enabled_makers*
 This setting will tell neomake which makers to use by default for the given
 filetype. Filetypes that already have makers should have a default list
-of makers already. Example: >
+of makers already. Can also be set by buffer. Example: >
     let g:neomake_python_enabled_makers = ['pep8', 'pylint']
+    let b:neomake_python_enabled_makers = ['flake8']
 <
 *g:neomake_enabled_makers*
 This setting will tell neomake which makers to use by default when not
-operating on a single file. This effectively defaults to: >
+operating on a single file, or when no makers are defined for the filetype of
+the current buffer. This effectively defaults to: >
     let g:neomake_enabled_makers = ['makeprg']
 <
 *g:neomake_open_list*


### PR DESCRIPTION
Example use case:

- Project has blog posts in markdown format that need to be linted using `prose` linter
- Project has a `readme.md` that should not be `prose` linted
- Set `b:neomake_markdown_enabled_makers = [ 'prose', 'markdownlint' ]` on the blog post buffer, set `b:neomake_markdwon_enabled_makers = [ 'markdownlint' ]` on the readme.md buffer