### PR TITLE
Adds support for typescript projects.

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -512,7 +512,7 @@ function! s:AddExprCallback(maker) abort
             call setqflist(list, 'r')
         endif
     endif
-    if counts_changed
+    if counts_changed && has_key(a:maker, 'bufnr')
         call s:neomake_hook('NeomakeCountsChanged', {
                     \ 'file_mode': a:maker.file_mode,
                     \ 'bufnr': a:maker.bufnr})

--- a/autoload/neomake/makers/typescript_project.vim
+++ b/autoload/neomake/makers/typescript_project.vim
@@ -1,0 +1,13 @@
+" vim: ts=4 sw=4 et
+
+function! neomake#makers#typescript_project#typescript_project()
+    return {
+        \ 'exe': 'tsc',
+        \ 'args': ['--noEmit'],
+        \ 'errorformat':
+            \ '%E%f %#(%l\,%c): error %m,' .
+            \ '%E%f %#(%l\,%c): %m,' .
+            \ '%Eerror %m,' .
+            \ '%C%\s%\+%m'
+        \ }
+endfunction


### PR DESCRIPTION
Right now we have a typescript file maker that builds a single file
with tsc.  This commit adds support for "typescript projects" which
run the typescript compiler on every typescript file contained in
a typescript project. (a typescript project is a folder that has
a tsconfig.json file somewhere in the directory hierarchy).

I also made a bugfix in neomake.vim which wasn't handling the
non-existance of bufnumber that could happen when running a maker
without having any files opened in neovim.

How to use: 
`:NeomakeProject typescript_project`
