### PR TITLE
check for +signs

### DIFF
--- a/autoload/neomake/signs.vim
+++ b/autoload/neomake/signs.vim
@@ -65,6 +65,10 @@ endfunction
 
 " type may be either 'file' or 'project'
 function! neomake#signs#PlaceSign(entry, type) abort
+    if !has('signs')
+        return
+    endif
+
     if a:entry.type ==? 'W'
         let sign_type = 'neomake_warn'
     elseif a:entry.type ==? 'I'
@@ -107,6 +111,10 @@ endfunction
 
 " type may be either 'file' or 'project'
 function! neomake#signs#CleanOldSigns(bufnr, type) abort
+    if !has('signs')
+        return
+    endif
+
     if !has_key(s:last_placed_signs[a:type], a:bufnr)
         return
     endif
@@ -139,9 +147,15 @@ function! neomake#signs#PlaceVisibleSigns() abort
     endfor
 endfunction
 
-exe 'sign define neomake_invisible'
+if has('signs')
+    exe 'sign define neomake_invisible'
+endif
 
 function! neomake#signs#RedefineSign(name, opts) abort
+    if !has('signs')
+        return
+    endif
+
     let sign_define = 'sign define '.a:name
     for attr in keys(a:opts)
         let sign_define .= ' '.attr.'='.a:opts[attr]
@@ -216,6 +230,10 @@ endfunction
 
 
 function! neomake#signs#DefineHighlights() abort
+    if !has('signs')
+        return
+    endif
+
     let ctermbg = neomake#utils#GetHighlight('SignColumn', 'bg')
     let guibg = neomake#utils#GetHighlight('SignColumn', 'bg#')
     let bg = 'ctermbg='.ctermbg.' guibg='.guibg
@@ -245,6 +263,10 @@ endfunction
 
 let s:signs_defined = 0
 function! neomake#signs#DefineSigns() abort
+    if !has('signs')
+        return
+    endif
+
     if !s:signs_defined
         let s:signs_defined = 1
         call neomake#signs#RedefineErrorSign()


### PR DESCRIPTION
just added guards wherever `sign ` is called in case someone is running (n)vim without `+signs`
I sometimes use neomake on regular vim (which is supported by this plugin according to its docs) on older systems that are distributed with vim 7.4 compiled `-signs`