### PR TITLE
vim: fix vint maker: "-f" specifies the format

### DIFF
--- a/autoload/neomake/makers/ft/vim.vim
+++ b/autoload/neomake/makers/ft/vim.vim
@@ -5,8 +5,8 @@ function! neomake#makers#ft#vim#EnabledMakers() abort
 endfunction
 
 function! neomake#makers#ft#vim#vint() abort
-    let l:args = ['--style-problem', '-f', '--no-color',
-        \ '{file_path}:{line_number}:{column_number}:{severity}:{description} ({policy_name})']
+    let l:args = ['--style-problem', '--no-color',
+        \ '-f', '{file_path}:{line_number}:{column_number}:{severity}:{description} ({policy_name})']
 
     if has('nvim')
         call add(l:args, '--enable-neovim')


### PR DESCRIPTION
Broken in https://github.com/neomake/neomake/pull/491.
/cc @wsdjeg 