### PR TITLE
Fix AddExprCallback a:maker.bufnr/buffer_output

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -515,7 +515,7 @@ function! s:AddExprCallback(maker) abort
     if counts_changed
         call s:neomake_hook('NeomakeCountsChanged', {
                     \ 'file_mode': a:maker.file_mode,
-                    \ 'bufnr': a:maker.bufnr})
+                    \ 'bufnr': a:maker.buffer_output})
     endif
 endfunction
 


### PR DESCRIPTION
AddExprCallback a:maker doesn't have bufnr, it has buffer_output. Fixes endless error readouts when errors are returned from the maker. This would print a heap of times:

```
Error detected while processing function neomake#MakeHandler[33]..<SNR>147_RegisterJobOutput[31]..<SNR>147_ProcessJobOutpu
t[13]..<SNR>147_AddExprCallback:
line   82:
E716: Key not present in Dictionary: bufnr})
Press ENTER or type command to continue
Error detected while processing function neomake#MakeHandler[33]..<SNR>147_RegisterJobOutput[31]..<SNR>147_ProcessJobOutpu
t[13]..<SNR>147_AddExprCallback:
line   82:
E116: Invalid arguments for function <SNR>147_neomake_hook
```