### PR TITLE
Fix neomake#statusline#LoclistCounts(0)

### DIFF
--- a/autoload/neomake/statusline.vim
+++ b/autoload/neomake/statusline.vim
@@ -35,7 +35,7 @@ endfunction
 
 function! neomake#statusline#LoclistCounts(...) abort
     let buf = a:0 ? a:1 : bufnr('%')
-    if buf ==# 'all'
+    if buf is# 'all'
         return s:loclist_counts
     endif
     return get(s:loclist_counts, buf, {})

--- a/tests/statusline.vader
+++ b/tests/statusline.vader
@@ -1,0 +1,19 @@
+Include: _setup.vader
+
+Execute (LoclistCounts):
+  call neomake#statusline#ResetCountsForBuf(99)
+  call neomake#statusline#AddLoclistCount(99, {'type': 'E', 'bufnr': 99})
+  call neomake#statusline#AddLoclistCount(99, {'type': 'W', 'bufnr': 99})
+  AssertEqual neomake#statusline#LoclistCounts(), {}
+  " With 'buf ==# "all"' this matched 0.
+  AssertEqual neomake#statusline#LoclistCounts(0), {}
+
+  " 0 could refer to current buffer, but does not currently.
+  let curbufnr = bufnr('%')
+  call neomake#statusline#AddLoclistCount(curbufnr, {'type': 'E', 'bufnr': curbufnr})
+  AssertEqual neomake#statusline#LoclistCounts(0), {}
+
+  AssertEqual neomake#statusline#LoclistCounts(1), {}
+  AssertEqual neomake#statusline#LoclistCounts(99), {'E': 1, 'W': 1}
+  AssertEqual filter(neomake#statusline#LoclistCounts('all'), 'v:key == 99'),
+    \ {'99': {'E': 1, 'W': 1}}


### PR DESCRIPTION
It would return the same as 'all', since `0 ==# 'all'`!