### PR TITLE
Add zsh support (part 2)

### DIFF
--- a/autoload/neomake/makers/ft/zsh.vim
+++ b/autoload/neomake/makers/ft/zsh.vim
@@ -1,0 +1,18 @@
+" vim: ts=4 sw=4 et
+
+function! neomake#makers#ft#zsh#EnabledMakers() abort
+    return ['zsh']
+endfunction
+
+function! neomake#makers#ft#zsh#shellcheck() abort
+    let maker = neomake#makers#ft#sh#shellcheck()
+    let maker.args += ['--shell', 'zsh']
+    return maker
+endfunction
+
+function! neomake#makers#ft#zsh#zsh() abort
+    return {
+        \ 'args': ['-n'],
+        \ 'errorformat': '%E%f:%l: %m'
+        \}
+endfunction


### PR DESCRIPTION
Followup to https://github.com/neomake/neomake/pull/423.

TODO:
 - [ ] do not enable shellcheck by default (zsh is not supported for current version of shellcheck anymore)