### PR TITLE
fixed multi-line bug on hdevtools

### DIFF
--- a/autoload/neomake/makers/ft/haskell.vim
+++ b/autoload/neomake/makers/ft/haskell.vim
@@ -4,9 +4,11 @@ function! neomake#makers#ft#haskell#EnabledMakers()
 endfunction
 
 function! neomake#makers#ft#haskell#hdevtools()
+    let mapexpr = 'substitute(v:val, "\n", "", "g")'
     return {
         \ 'exe': 'hdevtools',
         \ 'args': ['check', '-g-Wall'],
+        \ 'mapexpr': mapexpr,
         \ 'errorformat':
             \ '%-Z %#,'.
             \ '%W%f:%l:%v: Warning: %m,'.


### PR DESCRIPTION
hdevtools had the same bug that we fixed in ghcmod. Currently, hdevtools can output things that will cause the error prompt to take up multiple lines. This small 2 line change fixes that. 