### PR TITLE
Update the SCSS linter errorformat

### DIFF
--- a/autoload/neomake/makers/ft/scss.vim
+++ b/autoload/neomake/makers/ft/scss.vim
@@ -7,6 +7,6 @@ endfunction
 function! neomake#makers#ft#scss#scsslint()
     return {
         \ 'exe': 'scss-lint',
-        \ 'errorformat': '%f:%l [%t] %m'
+        \ 'errorformat': '%A%f:%l:%v [%t] %m'
     \ }
 endfunction


### PR DESCRIPTION
Seems like the scss-lint format has changed, this updated rule should
cope with the new schema.