### PR TITLE
Add maker file for clippy

### DIFF
--- a/autoload/neomake/makers/clippy.vim
+++ b/autoload/neomake/makers/clippy.vim
@@ -1,0 +1,12 @@
+" vim: ts=4 sw=4 et
+
+function! neomake#makers#clippy#clippy()
+    return {
+        \ 'exe': 'cargo',
+        \ 'args': ['clippy'],
+        \ 'errorformat':
+            \   '%-Z%f:%l,' .
+            \   '%+C %s,' .
+            \   '%A%f:%l:%c: %*\d:%*\d\ %t%*[^:]: %m,',
+        \ }
+endfunction


### PR DESCRIPTION
`clippy` is a tool for Rust which lints for possible style issues in addition to the usual type and syntax errors detected by the rust compiler. This pull request adds support for `cargo clippy`, which has the same output format as `cargo build`. Note: `clippy` has to be installed with `cargo install clippy` for this to work.

Questions:
 - Is it necessary to specify `exe`?
 - Is there a way to give an error message when `clippy` isn't run from the working directory of a project?