### PR TITLE
[RFC] Write first version of the Racket maker.

### DIFF
--- a/autoload/neomake/makers/ft/racket.vim
+++ b/autoload/neomake/makers/ft/racket.vim
@@ -1,0 +1,32 @@
+" vim: ts=4 sw=4 et
+
+function! neomake#makers#ft#racket#EnabledMakers()
+    return ['raco']
+endfunction
+
+" This is the same form of syntax-checking used by DrRacket as well. The
+" downside is that it will only catch the first error, but none of the
+" subsequent ones. This is due to how evaluation in Racket works.
+"
+" About the error format: raco will print the first line as
+"     <file>:<line>:<column> <message>
+" Every successive line will be indented by two spaces:
+"       in: <keyword>
+"       context...:
+"       <file>:<line>:<column>: <keyword>
+" The last pattern will be repeated as often as necessary. Example:
+"     foo.rkt:4:1: dfine: unbound identifier in modulemessage
+"       in: dfine
+"       context...:
+"        /usr/local/Cellar/racket/6.5/share/racket/pkgs/compiler-lib/compiler/commands/expand.rkt:34:15: loop
+"        /usr/local/Cellar/racket/6.5/share/racket/pkgs/compiler-lib/compiler/commands/expand.rkt:10:2: show-program
+"        /usr/local/Cellar/racket/6.5/share/racket/pkgs/compiler-lib/compiler/commands/expand.rkt: [running body]
+"        /usr/local/Cellar/minimal-racket/6.6/share/racket/collects/raco/raco.rkt: [running body]
+"        /usr/local/Cellar/minimal-racket/6.6/share/racket/collects/raco/main.rkt: [running body]
+function! neomake#makers#ft#racket#raco()
+    return {
+        \ 'exe': 'raco',
+        \ 'args': ['expand'],
+        \ 'errorformat': '%-G %.%#,%E%f:%l:%c: %m'
+    \ }
+endfunction


### PR DESCRIPTION
The maker in its current form has a number of issues:
- ~The error message is prefixed with the name of the maker (`raco: bar: unbound idetifier ...`)~
- The location list seems to do some sort of pattern matching as well
- ~Pressing <CR> in the location list on the error message does not open the error, instead an error is thrown: `E924: Current window was closed`~
- If there are no errors the location list will be populated with the output of the expanded file. What I want is for the location list to either contain nothing if there is no error or contain everything if there is an error.
- ~The location list does not open automatically on error like it does for example for Python (I don't have any special settings for Python files).~

I would appreciate help in getting the details right before merging. For comparison, here is what `raco expand` prints on the terminal:

```
test.rkt:3:1: bar: unbound identifier in module
  in: bar
  context...:
   /usr/local/Cellar/racket/6.5/share/racket/pkgs/compiler-lib/compiler/commands/expand.rkt:34:15: loop
   /usr/local/Cellar/racket/6.5/share/racket/pkgs/compiler-lib/compiler/commands/expand.rkt:10:2: show-program
   /usr/local/Cellar/racket/6.5/share/racket/pkgs/compiler-lib/compiler/commands/expand.rkt: [running body]
   /usr/local/Cellar/racket/6.6/share/racket/collects/raco/raco.rkt: [running body]
   /usr/local/Cellar/racket/6.6/share/racket/collects/raco/main.rkt: [running body]
```

And the defective file:

```
#lang racket
(bar "asdf")
```

Nothing special, just using `bar` instead of `car`, and the identifier `bar` is never defined anywhere.
