### PR TITLE
Handle a message/entry of unknown type as an error (fixes #336).

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -483,6 +483,11 @@ function! s:AddExprCallback(jobinfo) abort
             endif
         endif
 
+        " Assume a message of unknown type is an error.
+        if entry.type == ''
+            let entry.type = 'E'
+        endif
+
         if !entry.valid
             if maker.remove_invalid_entries
                 let index -= 1


### PR DESCRIPTION
Entries of unknown type (where the matched errorformat does not specify `%E`, `%W`, `%I`, etc.) are not being included in the statusline summary returned by `neomake#statusline#LoclistStatus()`. This PR fixes this issue by assigning the error type to such entries. Fixes #336.

Note that such entries were already being marked as errors in the sign column, per `autoload/neomake/signs.vim:78`. This PR does the same with the statusline, resolving the inconsistency.