### PR TITLE
javascript makers: use %E in errorformat

### DIFF
--- a/autoload/neomake/makers/ft/javascript.vim
+++ b/autoload/neomake/makers/ft/javascript.vim
@@ -14,7 +14,7 @@ endfunction
 function! neomake#makers#ft#javascript#jscs()
     return {
         \ 'args': ['--no-colors', '--reporter', 'inline'],
-        \ 'errorformat': '%f: line %l\, col %c\, %m',
+        \ 'errorformat': '%E%f: line %l\, col %c\, %m',
         \ }
 endfunction
 
@@ -36,7 +36,7 @@ endfunction
 
 function! neomake#makers#ft#javascript#standard()
     return {
-        \ 'errorformat': '  %f:%l:%c: %m'
+        \ 'errorformat': '%E%f:%l:%c: %m'
         \ }
 endfunction
 
@@ -45,7 +45,7 @@ function! neomake#makers#ft#javascript#flow()
     let mapexpr = 'substitute(v:val, "\\\\n", " ", "g")'
     return {
         \ 'args': ['--old-output-format'],
-        \ 'errorformat': '%f:%l:%c\,%n: %m',
+        \ 'errorformat': '%E%f:%l:%c\,%n: %m',
         \ 'mapexpr': mapexpr,
         \ }
 endfunction


### PR DESCRIPTION
Fixes https://github.com/neomake/neomake/issues/336#issuecomment-217201458.