### PR TITLE
python mypy maker: add type to errorformat

### DIFF
--- a/autoload/neomake/makers/ft/python.vim
+++ b/autoload/neomake/makers/ft/python.vim
@@ -167,6 +167,9 @@ endfunction
 function! neomake#makers#ft#python#mypy()
     return {
         \ 'args': ['--silent-imports'],
-        \ 'errorformat': '%f:%l: error: %m',
+        \ 'errorformat':
+            \ '%E%f:%l: error: %m,' .
+            \ '%W%f:%l: warning: %m,' .
+            \ '%I%f:%l: note: %m',
         \ }
 endfunction


### PR DESCRIPTION
Fixes #336 for the mypy maker for python.