### PR TITLE
Fix neomake#CancelJob: pass correct arg to jobstop()

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -33,8 +33,10 @@ endfunction
 
 function! neomake#CancelJob(job_id) abort
     if has_key(s:jobs, a:job_id)
-        call jobstop(s:jobs[a:job_id])
+        call jobstop(a:job_id)
+        return 1
     endif
+    return 0
 endfunction
 
 function! s:GetMakerKey(maker) abort

--- a/tests/neomake.vader
+++ b/tests/neomake.vader
@@ -44,3 +44,15 @@ Execute (neomake#GetMaker from g:neomake_foo_maker):
     \ }
   let maker = neomake#GetMaker('foo')
   AssertEqual maker.exe, 'my-foo'
+
+Execute (neomake#CancelJob):
+  if neomake#has_async_support()
+    let job_id = neomake#Sh("sh -c 'while true; do sleep 0.1; done'")
+    AssertEqual neomake#CancelJob(job_id), 1
+
+    " The job is still in the table, therefore 'E900: Invalid job id'.
+    AssertThrows neomake#CancelJob(job_id)
+
+    NeomakeTestsWaitForFinishedJobs
+    AssertEqual neomake#CancelJob(job_id), 0
+  endif


### PR DESCRIPTION
This was broken in https://github.com/neomake/neomake/pull/352.
Fixes https://github.com/neomake/neomake/pull/352#issuecomment-238693727.