### PR TITLE
Fix checking if checkstyle xml has already been set

### DIFF
--- a/autoload/neomake/makers/ft/java.vim
+++ b/autoload/neomake/makers/ft/java.vim
@@ -56,7 +56,7 @@ let g:neomake_java_javac_outputdir =
             \ get(g:, 'neomake_java_javac_outputdir', '')
 
 let g:neomake_java_checkstyle_xml =
-            \ get(g:, 'g:neomake_java_checkstyle_xml', '/usr/share/checkstyle/google_checks.xml')
+            \ get(g:, 'neomake_java_checkstyle_xml', '/usr/share/checkstyle/google_checks.xml')
 
 let g:neomake_java_javac_delete_output =
             \ get(g:, 'neomake_java_javac_delete_output', 1)


### PR DESCRIPTION
Right now setting `g:neomake_java_checkstyle_xml` to use a custom checkstyle configuration xml does not work. It is because someone added _g:_ also to the string that is searched for in the defined global variables by mistake.

I noticed that when I was trying to use neomake with checkstyle so I propose this simple fix.