### PR TITLE
[elixir] Fix typo in function namespace

### DIFF
--- a/autoload/neomake/makers/ft/elixir.vim
+++ b/autoload/neomake/makers/ft/elixir.vim
@@ -20,7 +20,7 @@ function! neomake#makers#ft#elixir#credo()
       \ }
 endfunction
 
-function! neomake#markers#ft#elixir#dogma()
+function! neomake#makers#ft#elixir#dogma()
     return {
       \ 'exe': 'mix',
       \ 'args': ['dogma', '%:p', '--format=flycheck'],


### PR DESCRIPTION
This pull request fixes the following error : 

```
Error detected while processing [...]/neomake/autoload/neomake/makers/ft/elixir.vim:
line   29:
E746: Function name does not match script file name: neomake#markers#ft#elixir#dogma
Error detected while processing function neomake#Make:
line    3:
E171: Missing :endif
```
