### PR TITLE
tests: add NeomakeTestsEnsureExe to add names to $PATH

### DIFF
--- a/tests/_setup.vader
+++ b/tests/_setup.vader
@@ -38,3 +38,34 @@ Execute:
     redir END
     return split(m, '\n')
   endfunction
+
+  let s:tempname = tempname()
+
+  function! g:NeomakeTestsEnsureExe(name)
+    if executable(a:name)
+      return
+    endif
+    let path_separator = exists('+shellslash') ? ';' : ':'
+    let dir_separator = exists('+shellslash') ? '\' : '/'
+    let tmpbindir = s:tempname . dir_separator . 'neomake-vader-tests'
+    if $PATH !~# tmpbindir . path_separator
+      call mkdir(tmpbindir, 'p', 0770)
+      let $PATH = tmpbindir . ':' . $PATH
+    endif
+    let exe = tmpbindir.dir_separator.a:name
+    if !filereadable(exe)
+      " XXX: this is dirty (for 'Test Neomake on errors.sh with two makers').
+      if a:name == 'shellcheck'
+        call writefile(['#!/bin/sh', 'echo $1:1:1: warning: this is just a stub'], exe)
+      else
+        call writefile([], exe)
+      endif
+      if exists('*setfperm')
+        call setfperm(exe, "rwxrwx---")
+      else
+        " XXX: Windows support
+        call system('chmod 770 '.shellescape(exe))
+      endif
+    endif
+    Log exe
+  endfunction

--- a/tests/integration.vader
+++ b/tests/integration.vader
@@ -24,11 +24,8 @@ Execute (Test Neomake on errors.sh with one maker):
   e! fixtures/errors.sh
   AssertEqual getline(1), '#! /bin/sh'
 
-  if executable('shellcheck')
-    AssertEqual neomake#GetEnabledMakers('sh'), ['sh', 'shellcheck']
-  else
-    AssertEqual neomake#GetEnabledMakers('sh'), ['sh']
-  endif
+  call g:NeomakeTestsEnsureExe('shellcheck')
+  AssertEqual neomake#GetEnabledMakers('sh'), ['sh', 'shellcheck']
 
   AssertEqual len(g:neomake_test_finished), 0
   AssertEqual len(g:neomake_test_countschanged), 0

--- a/tests/utils.vader
+++ b/tests/utils.vader
@@ -7,3 +7,8 @@ Execute (neomake#utils#LogMessage writes to logfile always):
   call neomake#utils#LogMessage(1, 'msg1')
   Assert readfile(g:neomake_logfile)[0] =~# 'Log level 1: Neomake: msg1$'
   Restore
+
+Execute (NeomakeTestsEnsureExe creates exe):
+  Assert !executable('boobar')
+  call g:NeomakeTestsEnsureExe('boobar')
+  Assert executable('boobar')


### PR DESCRIPTION
This is meant for `executable` to pick them up.