### PR TITLE
Vim asynchronous support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,18 +2,17 @@
 
 # Neomake
 
-Neomake is a plugin for asynchronous `:make` using
-[Neovim's](http://neovim.org/) job-control functionality. It is inspired by
-the excellent Vim plugins [Syntastic](https://github.com/scrooloose/syntastic)
-and [dispatch.vim](https://github.com/tpope/vim-dispatch).
+A plugin for asynchronous `:make` using [Neovim's](http://neovim.org/) or [Vim's](http://vim.org/)
+job-control functionality. It is inspired by the excellent vim plugins
+[Syntastic](https://github.com/scrooloose/syntastic) and
+[Dispatch](https://github.com/tpope/vim-dispatch).
 
-**This plugin also works in ordinary Vim, but without the asynchronous
-benefits.**
-
-The minimum Neovim version supported by Neomake is `NVIM
-0.0.0-alpha+201503292107` (commit `960b9108c`).
+The minimum Neovim version supported by Neomake is `NVIM 0.0.0-alpha+201503292107` (commit `960b9108c`).
 The minimum Vim version supported by Neomake is 7.4.503 (although if you don't
 use `g:neomake_logfile` older versions will probably work fine as well).
+
+Starting from Vim version 7.4.2260 Neomake takes advantage of Vim's async support.
+
 
 ## How to use (basic)
 

--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -16,8 +16,8 @@ let s:need_errors_cleaning = {
     \ }
 
 function! neomake#has_async_support() abort
-    " TODO: add support for Vim's async support (job_start).
-    return has('nvim')
+    return has('nvim') ||
+                \ has('channel') && has('job') && has('patch-7-4-2260')
 endfunction
 
 function! neomake#GetJobs() abort
@@ -33,7 +33,12 @@ endfunction
 
 function! neomake#CancelJob(job_id) abort
     if has_key(s:jobs, a:job_id)
-        call jobstop(a:job_id)
+        call neomake#utils#DebugMessage('Stopping job: ' . a:job_id)
+        if has('nvim')
+            call jobstop(a:job_id)
+        else
+            call job_stop(s:jobs[a:job_id].job)
+        endif
         return 1
     endif
     return 0
@@ -102,12 +107,9 @@ function! s:MakeJob(make_id, maker) abort
         call add(args, '%:p')
     endif
 
-    if neomake#utils#IsRunningWindows()
-        " Don't expand &shellcmdflag argument of cmd.exe
-        call map(args, 'v:val !=? &shellcmdflag ? expand(v:val) : v:val')
-    else
-        call map(args, 'expand(v:val)')
-    endif
+    call neomake#utils#DebugMessage('Arguments before expansion: '. string(args))
+    call neomake#utils#ExpandArgs(args)
+    call neomake#utils#DebugMessage('Arguments after expansion: '. string(args))
 
     if has_key(a:maker, 'cwd')
         let old_wd = getcwd()
@@ -117,39 +119,71 @@ function! s:MakeJob(make_id, maker) abort
 
     try
         let has_args = type(args) == type([])
-        if has('nvim')
-            let argv = [exe]
-            if has_args
-                let argv = argv + args
-            endif
-            call neomake#utils#LoudMessage('Starting: '.join(argv, ' '))
-            let opts = {
-                \ 'on_stdout': function('neomake#MakeHandler'),
-                \ 'on_stderr': function('neomake#MakeHandler'),
-                \ 'on_exit': function('neomake#MakeHandler')
-                \ }
-            let job = jobstart(argv, opts)
-            let jobinfo.start = localtime()
-            let jobinfo.last_register = 0
+        if neomake#has_async_support()
+            if has('nvim')
+                let argv = [exe]
+                if has_args
+                    let argv = argv + args
+                endif
+                call neomake#utils#LoudMessage('Starting: '.join(argv, ' '))
+                let opts = {
+                            \ 'on_stdout': function('neomake#MakeHandler'),
+                            \ 'on_stderr': function('neomake#MakeHandler'),
+                            \ 'on_exit': function('neomake#MakeHandler')
+                            \ }
+                let job = jobstart(argv, opts)
+                let jobinfo.start = localtime()
+                let jobinfo.last_register = 0
 
-            if job == 0
-                throw 'Job table is full or invalid arguments given'
-            elseif job == -1
-                throw 'Non executable given'
-            endif
+                if job == 0
+                    throw 'Job table is full or invalid arguments given'
+                elseif job == -1
+                    throw 'Non executable given'
+                endif
 
-            let jobinfo.id = job
-            let s:jobs[job] = jobinfo
-            let maker_key = s:GetMakerKey(a:maker)
-            let s:jobs_by_maker[maker_key] = jobinfo
-            call s:AddJobinfoForCurrentWin(jobinfo.id)
-            let r = jobinfo.id
-            if !exists('s:jobids_by_makeid[a:make_id]')
-                let s:jobids_by_makeid[a:make_id] = []
+                let jobinfo.id = job
+                let s:jobs[job] = jobinfo
+                let maker_key = s:GetMakerKey(a:maker)
+                let s:jobs_by_maker[maker_key] = jobinfo
+                call s:AddJobinfoForCurrentWin(jobinfo.id)
+                let r = jobinfo.id
+                if !exists('s:jobids_by_makeid[a:make_id]')
+                    let s:jobids_by_makeid[a:make_id] = []
+                endif
+                call add(s:jobids_by_makeid[a:make_id], jobinfo.id)
+            else
+                if has_args
+                    let program = [exe] + args
+                else
+                    let program = [exe]
+                endif
+
+                call neomake#utils#LoudMessage('Starting: ' . string(program))
+                let job = job_start(program, {
+                            \ 'callback': 'neomake#MakeHandlerVim',
+                            \ 'close_cb': 'neomake#MakeHandlerVimClose'
+                            \ })
+                let jobinfo.job = job
+                let jobinfo.start = localtime()
+                let jobinfo.last_register = 0
+                let jobinfo.data = []
+
+                let job_channel = job_getchannel(job)
+                let jobinfo.id = s:GetChannelId(job_channel)
+
+                let s:jobs[jobinfo.id] = jobinfo
+
+                let maker_key = s:GetMakerKey(a:maker)
+                let s:jobs_by_maker[maker_key] = jobinfo
+                call s:AddJobinfoForCurrentWin(jobinfo.id)
+                let r = jobinfo.id
+                if !exists('s:jobids_by_makeid[a:make_id]')
+                    let s:jobids_by_makeid[a:make_id] = []
+                endif
+                call add(s:jobids_by_makeid[a:make_id], jobinfo.id)
             endif
-            call add(s:jobids_by_makeid[a:make_id], jobinfo.id)
         else
-            " Vim, synchronously.
+            call neomake#utils#DebugMessage('Running synchronously')
             if has_args
                 if neomake#utils#IsRunningWindows()
                     let program = exe.' '.join(map(args, 'v:val'))
@@ -159,6 +193,9 @@ function! s:MakeJob(make_id, maker) abort
             else
                 let program = exe
             endif
+
+            call neomake#utils#LoudMessage('Starting: ' . program)
+
             let jobinfo.id = job_id
             let s:jobs[job_id] = jobinfo
             call s:AddJobinfoForCurrentWin(jobinfo.id)
@@ -426,7 +463,7 @@ function! s:Make(options, ...) abort
             let jobinfo = s:jobs_by_maker[maker_key]
             let jobinfo.maker.next = copy(a:options)
             try
-                call jobstop(jobinfo.id)
+                call neomake#CancelJob(jobinfo.id)
             catch /^Vim\%((\a\+)\)\=:E900/
                 " Ignore invalid job id errors. Happens when the job is done,
                 " but on_exit hasn't been called yet.
@@ -668,6 +705,22 @@ function! s:RegisterJobOutput(jobinfo, lines) abort
     endif
 endfunction
 
+function! s:GetChannelId(channel) abort
+    return ch_info(a:channel)['id']
+endfunction
+
+function! neomake#MakeHandlerVim(channel, line) abort
+    call add(s:jobs[s:GetChannelId(a:channel)].data, a:line)
+endfunction
+
+function! neomake#MakeHandlerVimClose(channel) abort
+    call neomake#utils#DebugMessage('Channel has been closed: ' . a:channel)
+    let channel_id = s:GetChannelId(a:channel)
+    let jobinfo = s:jobs[channel_id]
+    call neomake#MakeHandler(channel_id, jobinfo.data, 'stdout')
+    call neomake#MakeHandler(channel_id, job_info(jobinfo.job)['exitval'], 'exit')
+endfunction
+
 function! neomake#MakeHandler(job_id, data, event_type) abort
     if !has_key(s:jobs, a:job_id)
         return
@@ -708,7 +761,7 @@ function! neomake#MakeHandler(job_id, data, event_type) abort
     elseif a:event_type ==# 'exit'
         " Handle any unfinished lines from stdout/stderr callbacks.
         if has_key(jobinfo, 'lines')
-            if jobinfo.lines[-1] ==# ''
+            if len(jobinfo.lines) && jobinfo.lines[-1] ==# ''
                 call remove(jobinfo.lines, -1)
             endif
             if len(jobinfo.lines)
@@ -732,8 +785,8 @@ function! neomake#MakeHandler(job_id, data, event_type) abort
             endtry
         endif
         call s:CleanJobinfo(jobinfo)
-        if has('nvim')
-            " Only report completion for neovim, since it is asynchronous
+
+        if neomake#has_async_support()
             call neomake#utils#QuietMessage(get(maker, 'name', 'make').
                                           \ ' completed with exit code '.status)
         endif
@@ -760,7 +813,7 @@ function! neomake#MakeHandler(job_id, data, event_type) abort
         endif
 
         " Trigger autocmd if all jobs for a s:Make instance have finished.
-        if has('nvim')
+        if neomake#has_async_support()
             let make_id = -1
             for [k, v] in items(s:jobids_by_makeid)
                 if index(v, a:job_id) != -1

--- a/autoload/neomake/utils.vim
+++ b/autoload/neomake/utils.vim
@@ -202,18 +202,6 @@ function! neomake#utils#GetHighlight(group, what) abort
 endfunction
 
 function! neomake#utils#ExpandArgs(args) abort
-    if neomake#utils#IsRunningWindows()
-        call neomake#utils#ExpandArgsInWindows(a:args)
-    else
-        call neomake#utils#ExpandArgsInLinux(a:args)
-    endif
-endfunction
-
-function! neomake#utils#ExpandArgsInWindows(args) abort
-    " Don't expand &shellcmdflag argument of cmd.exe nor arguments like '"something"'
-    call map(a:args, "(v:val ==? &shellcmdflag || v:val =~? '.*\".*\".*') ? v:val : expand(v:val)")
-endfunction
-
-function! neomake#utils#ExpandArgsInLinux(args) abort
-    call map(a:args, 'expand(v:val)')
+    " Only expand those args that start with \ and a single %
+    call map(a:args, "v:val =~# '\\(^\\\\\\|^%$\\|^%[^%]\\)' ? expand(v:val) : v:val")
 endfunction

--- a/autoload/neomake/utils.vim
+++ b/autoload/neomake/utils.vim
@@ -200,3 +200,20 @@ function! neomake#utils#GetHighlight(group, what) abort
   endif
   return val
 endfunction
+
+function! neomake#utils#ExpandArgs(args) abort
+    if neomake#utils#IsRunningWindows()
+        call neomake#utils#ExpandArgsInWindows(a:args)
+    else
+        call neomake#utils#ExpandArgsInLinux(a:args)
+    endif
+endfunction
+
+function! neomake#utils#ExpandArgsInWindows(args) abort
+    " Don't expand &shellcmdflag argument of cmd.exe nor arguments like '"something"'
+    call map(a:args, "(v:val ==? &shellcmdflag || v:val =~? '.*\".*\".*') ? v:val : expand(v:val)")
+endfunction
+
+function! neomake#utils#ExpandArgsInLinux(args) abort
+    call map(a:args, 'expand(v:val)')
+endfunction

--- a/doc/neomake.txt
+++ b/doc/neomake.txt
@@ -6,8 +6,7 @@
  _/    _/_/  _/        _/    _/  _/    _/    _/  _/    _/  _/  _/    _/        ~
 _/      _/    _/_/_/    _/_/    _/    _/    _/    _/_/_/  _/    _/    _/_/_/   ~
 
-        Runs make tasks and syntax checkers asynchronously (for neovim)
-                         and simply (for all the vims)!
+        Runs make tasks and syntax checkers asynchronously!
 
 ==============================================================================
 CONTENTS                                                      *neomake-contents*
@@ -22,11 +21,11 @@ CONTENTS                                                      *neomake-contents*
 ==============================================================================
 1. Introduction                                           *neomake-introduction*
 
-Neomake leverages neovim's |job-control| feature where available to run
+Neomake leverages Neovim's or Vim's |job-control| feature where available to run
 programs like syntax checkers asynchronously. Where job control is not
 available, it resorts to a synchronous |system()| call, making it possible to
-run this plugin in both vim and neovim. This plugin is heavily inspired by
-fantastic vim plugins such as syntastic and dispatch.
+run this plugin in both Vim and Neovim. This plugin is heavily inspired by
+fantastic Vim plugins such as syntastic and dispatch.
 
 ==============================================================================
 2. Commands                                                   *neomake-commands*
@@ -58,8 +57,8 @@ fantastic vim plugins such as syntastic and dispatch.
                         job_id job_name
 <
                                                              *:NeomakeCancelJob*
-:NeomakeCancelJob *{job_id}*
-                        Sends a 'jobstop' to *job_id* which terminates the job.
+:NeomakeCancelJob {job_id}
+                        Terminate a job identified by its job_id.
 
 ==============================================================================
 3. Configuration                                         *neomake-configuration*
@@ -325,8 +324,8 @@ functions useful.
 *neomake#Make* (filemode, makers[, callback])
 This function is called by |:Neomake(!)| command. It runs all the *makers*
 specified, in order. If *filemode* is 1, then the current file is used as input
-to the makers. |neomake#Make| returns an array of the job ids that it creates
-via 'jobstart'; you can potentially cancel these jobs with |neomake#CancelJob|.
+to the makers. |neomake#Make| returns an array of job ids that were created;
+you can potentially cancel these jobs with |neomake#CancelJob|.
 
 It also accepts a third, optional callback argument that
 is called when the command exits.  The callback is given the following
@@ -338,8 +337,8 @@ dictionary as its sole argument: >
 *neomake#Sh* (command[, callback])
 This function is called by the |:NeomakeSh| command. It runs the specified
 shell *command* according to 'shell'. |neomake#Sh| returns the single job id
-that it created via 'jobstart' (or 0 on Vim); you can potentially cancel
-this job with |neomake#CancelJob|.
+that was created (0 on Vim without asynchronous support);
+you can potentially cancel this job with |neomake#CancelJob|.
 
 It also accepts a second, optional callback argument that is called when
 the command exits. The callback is given the following dictionary as its
@@ -353,7 +352,7 @@ Invoked via |:NeomakeListJobs|. Echoes a list of running jobs in the format
 (job_id, job_name).
 
 *neomake#CancelJob*
-Invoked via |:NeomakeCancelJob|. Sends a 'jobstop' to the job id specified.
+Invoked via |:NeomakeCancelJob|. Terminate a job identified by its job_id
 Will trigger callback if it was specified when the job was started.
 Example: >
     let job_id = neomake#Sh("bash -c 'while true; do sleep 1; done'")
@@ -442,7 +441,7 @@ You can make quickfixsigns respect Neomake's signs using this option: >
 
 6.2 How to configure the makers to be used?~
 
-See |g:neomake_<ft>_enabled_makers| (press `K` on the link to go there).
+See |g:neomake_<ft>_enabled_makers| (press `<C-]>` on the link to go there).
 
 
 vim: ft=help tw=78 isk+=<,>,\:

--- a/tests/utils.vader
+++ b/tests/utils.vader
@@ -12,3 +12,34 @@ Execute (NeomakeTestsEnsureExe creates exe):
   Assert !executable('boobar')
   call g:NeomakeTestsEnsureExe('boobar')
   Assert executable('boobar')
+
+Execute (shellcmdflag should not be expanded in Windows):
+  let old_shellcmdflag = &shellcmdflag
+  let &shellcmdflag = '%:h'
+  let args = [&shellcmdflag]
+  let expected_args = [&shellcmdflag]
+
+  try
+    call neomake#utils#ExpandArgsInWindows(args)
+    AssertEqual expected_args, args
+  finally
+    let &shellcmdflag = old_shellcmdflag
+  endtry
+
+Execute (Arguments in Windows are expanded correctly):
+  let param1 = '--param1="key1:val1 key2:val2"'
+  let param2 = '--param2=true'
+  let args = ['%', param1, param2]
+  let expected_args = [expand('%'), param1, param2]
+
+  call neomake#utils#ExpandArgsInWindows(args)
+  AssertEqual expected_args, args
+
+Execute (Arguments in Linux are expanded correctly):
+  let param1 = '--param1="key1:val1 key2:val2"'
+  let param2 = '--param2=true'
+  let args = ['%', param1 , param2]
+  let expected_args = [expand('%'), param1, param2]
+
+  call neomake#utils#ExpandArgsInLinux(args)
+  AssertEqual expected_args, args

--- a/tests/utils.vader
+++ b/tests/utils.vader
@@ -13,33 +13,25 @@ Execute (NeomakeTestsEnsureExe creates exe):
   call g:NeomakeTestsEnsureExe('boobar')
   Assert executable('boobar')
 
-Execute (shellcmdflag should not be expanded in Windows):
-  let old_shellcmdflag = &shellcmdflag
-  let &shellcmdflag = '%:h'
-  let args = [&shellcmdflag]
-  let expected_args = [&shellcmdflag]
-
-  try
-    call neomake#utils#ExpandArgsInWindows(args)
-    AssertEqual expected_args, args
-  finally
-    let &shellcmdflag = old_shellcmdflag
-  endtry
-
-Execute (Arguments in Windows are expanded correctly):
-  let param1 = '--param1="key1:val1 key2:val2"'
-  let param2 = '--param2=true'
-  let args = ['%', param1, param2]
-  let expected_args = [expand('%'), param1, param2]
-
-  call neomake#utils#ExpandArgsInWindows(args)
+Execute (Should expand arguments that start with %):
+  let param1 = '%'
+  let param2 = '%:h'
+  let param3 = '--param1=%:h'
+  let args = [param1, param2, param3]
+  let expected_args = [expand(param1), expand(param2), param3]
+  call neomake#utils#ExpandArgs(args)
   AssertEqual expected_args, args
 
-Execute (Arguments in Linux are expanded correctly):
-  let param1 = '--param1="key1:val1 key2:val2"'
-  let param2 = '--param2=true'
-  let args = ['%', param1 , param2]
-  let expected_args = [expand('%'), param1, param2]
+Execute (Should expand arguments that start with escape char \):
+  let param1 = '\%'
+  let param2 = '\%:p'
+  let args = [param1, param2]
+  let expected_args = [expand(param1), expand(param2)]
+  call neomake#utils#ExpandArgs(args)
+  AssertEqual expected_args, args
 
-  call neomake#utils#ExpandArgsInLinux(args)
+Execute (Should not expand arguments that start with double %):
+  let args = ['%%:h', '%%']
+  let expected_args = ['%%:h', '%%']
+  call neomake#utils#ExpandArgs(args)
   AssertEqual expected_args, args


### PR DESCRIPTION
This pull request addresses https://github.com/neomake/neomake/issues/319

It was tested successfully in:

- Linux (Fedora 23) with Vim 7.4.2260
- Windows 8 x64 both with gVim as well as plain-old Vim (inside ConEmu) 7.4.2305 (precompiled from https://tuxproject.de/projects/vim/)

With Python & Vim makers.

Can someone test this on Mac OSX?