### PR TITLE
sh: pass in filetype to shellcheck

### DIFF
--- a/autoload/neomake/makers/ft/sh.vim
+++ b/autoload/neomake/makers/ft/sh.vim
@@ -4,9 +4,17 @@ function! neomake#makers#ft#sh#EnabledMakers() abort
     return ['sh', 'shellcheck']
 endfunction
 
+" IDEA: could be detected once from "shellcheck --help" (since older versions
+" support zsh, and newer might do so again).
+let s:shellcheck_supported = ['sh', 'bash', 'dash', 'ksh']
+
 function! neomake#makers#ft#sh#shellcheck() abort
+    let args = ['-fgcc']
+    if index(s:shellcheck_supported, &filetype) != -1
+        let args += ['-s', &filetype]
+    endif
     return {
-        \ 'args': ['-fgcc'],
+        \ 'args': args,
         \ 'errorformat':
             \ '%f:%l:%c: %trror: %m,' .
             \ '%f:%l:%c: %tarning: %m,' .

--- a/tests/sh.vader
+++ b/tests/sh.vader
@@ -1,0 +1,10 @@
+Include: _setup.vader
+
+Execute (shellcheck):
+  AssertEqual neomake#makers#ft#sh#shellcheck()['args'], ['-fgcc']
+  set ft=sh
+  AssertEqual neomake#makers#ft#sh#shellcheck()['args'], ['-fgcc', '-s', 'sh']
+  set ft=bash
+  AssertEqual neomake#makers#ft#sh#shellcheck()['args'], ['-fgcc', '-s', 'bash']
+  set ft=nadda
+  AssertEqual neomake#makers#ft#sh#shellcheck()['args'], ['-fgcc']


### PR DESCRIPTION
This avoids the warning from shellcheck in case if there is no shebang.
This does not parse / look closely on any existing shebang line on purpose.
Ref: https://github.com/neomake/neomake/pull/409#issuecomment-219785830

/cc @lverweijen