### PR TITLE
neomake#utils#LogMessage: call redraw before echo

### DIFF
--- a/autoload/neomake/utils.vim
+++ b/autoload/neomake/utils.vim
@@ -6,6 +6,7 @@ function! neomake#utils#LogMessage(level, msg) abort
     let logfile = get(g:, 'neomake_logfile')
     let msg ='Neomake: '.a:msg  " .' ('.a:level.')'
     if verbose >= a:level
+        redraw
         if a:level ==# 0
             echohl ErrorMsg
         endif

--- a/autoload/neomake/utils.vim
+++ b/autoload/neomake/utils.vim
@@ -69,7 +69,7 @@ function! neomake#utils#WideMessage(msg) abort " {{{2
     "convert tabs to spaces so that the tabs count towards the window
     "width as the proper amount of characters
     let chunks = split(msg, "\t", 1)
-    let msg = join(map(chunks[:-2], 'v:val . repeat(" ", &tabstop - strwidth(v:val) % &tabstop)'), '') . chunks[-1]
+    let msg = join(map(chunks[:-2], "v:val . repeat(' ', &tabstop - strwidth(v:val) % &tabstop)"), '') . chunks[-1]
     let msg = strpart(msg, 0, &columns - 1)
 
     set noruler noshowcmd


### PR DESCRIPTION
Without this, you would see a hit-ENTER prompt in the default setup,
with `autocmd BufWritePost * Neomake` and `let neomake_verbose = 3`:

  "test.js" 1L, 8C written
  Neomake: Starting: eslint -f compact …
  Press ENTER or type command to continue