### PR TITLE
Add chef maker to run foodcritic

### DIFF
--- a/autoload/neomake/makers/ft/chef.vim
+++ b/autoload/neomake/makers/ft/chef.vim
@@ -1,35 +1,35 @@
-function! neomake#makers#ft#chef#SupersetOf()
+function! neomake#makers#ft#chef#SupersetOf() abort
     return 'ruby'
 endfunction
 
-function! neomake#makers#ft#chef#foodcritic()
+function! neomake#makers#ft#chef#foodcritic() abort
     return {
       \ 'errorformat': 'FC%n: %m: %f:%l',
       \ 'postprocess': function('neomake#makers#ft#chef#FoodcriticProcess'),
       \ }
 endfunction
 
-function! neomake#makers#ft#chef#FoodcriticProcess(entry)
+function! neomake#makers#ft#chef#FoodcriticProcess(entry) abort
   let a:entry.type='W'
 endfunction
 
-function! neomake#makers#ft#chef#EnabledMakers()
+function! neomake#makers#ft#chef#EnabledMakers() abort
     let ruby_makers = neomake#makers#ft#ruby#EnabledMakers()
     return ruby_makers + ['foodcritic']
 endfunction
 
-function! neomake#makers#ft#chef#mri()
+function! neomake#makers#ft#chef#mri() abort
     return neomake#makers#ft#ruby#mri()
 endfunction
 
-function! neomake#makers#ft#chef#rubocop()
+function! neomake#makers#ft#chef#rubocop() abort
     return neomake#makers#ft#ruby#rubocop()
 endfunction
 
-function! neomake#makers#ft#chef#reek()
+function! neomake#makers#ft#chef#reek() abort
     return neomake#makers#ft#ruby#reek()
 endfunction
 
-function! neomake#makers#ft#chef#rubylint()
+function! neomake#makers#ft#chef#rubylint() abort
     return neomake#makers#ft#ruby#rubylint()
 endfunction

--- a/autoload/neomake/makers/ft/chef.vim
+++ b/autoload/neomake/makers/ft/chef.vim
@@ -4,13 +4,8 @@ endfunction
 
 function! neomake#makers#ft#chef#foodcritic() abort
     return {
-      \ 'errorformat': 'FC%n: %m: %f:%l',
-      \ 'postprocess': function('neomake#makers#ft#chef#FoodcriticProcess'),
+      \ 'errorformat': '%WFC%n: %m: %f:%l',
       \ }
-endfunction
-
-function! neomake#makers#ft#chef#FoodcriticProcess(entry) abort
-  let a:entry.type='W'
 endfunction
 
 function! neomake#makers#ft#chef#EnabledMakers() abort

--- a/autoload/neomake/makers/ft/chef.vim
+++ b/autoload/neomake/makers/ft/chef.vim
@@ -1,0 +1,35 @@
+function! neomake#makers#ft#chef#SupersetOf()
+    return 'ruby'
+endfunction
+
+function! neomake#makers#ft#chef#foodcritic()
+    return {
+      \ 'errorformat': 'FC%n: %m: %f:%l',
+      \ 'postprocess': function('neomake#makers#ft#chef#FoodcriticProcess'),
+      \ }
+endfunction
+
+function! neomake#makers#ft#chef#FoodcriticProcess(entry)
+  let a:entry.type='W'
+endfunction
+
+function! neomake#makers#ft#chef#EnabledMakers()
+    let ruby_makers = neomake#makers#ft#ruby#EnabledMakers()
+    return ruby_makers + ['foodcritic']
+endfunction
+
+function! neomake#makers#ft#chef#mri()
+    return neomake#makers#ft#ruby#mri()
+endfunction
+
+function! neomake#makers#ft#chef#rubocop()
+    return neomake#makers#ft#ruby#rubocop()
+endfunction
+
+function! neomake#makers#ft#chef#reek()
+    return neomake#makers#ft#ruby#reek()
+endfunction
+
+function! neomake#makers#ft#chef#rubylint()
+    return neomake#makers#ft#ruby#rubylint()
+endfunction


### PR DESCRIPTION
Borrowed @rubbsdecvik's work in #444 and implemented it to match the way the javascript superset makers seem to work.

This works for me with a file with an `ft` of `chef.ruby`.

(As an aside, it seems wrong to have to re-express all the subset's makers in the superset; it would be nice to just have them inherited so chef.vim would stop at line 11. Am I missing something?)
