### PR TITLE
Support multi-line errorformat for Flow

### DIFF
--- a/autoload/neomake/makers/ft/javascript.vim
+++ b/autoload/neomake/makers/ft/javascript.vim
@@ -41,12 +41,9 @@ function! neomake#makers#ft#javascript#standard()
 endfunction
 
 function! neomake#makers#ft#javascript#flow()
-    " Replace "\n" by space.
-    let mapexpr = 'substitute(v:val, "\\\\n", " ", "g")'
     return {
         \ 'args': ['--old-output-format'],
-        \ 'errorformat': '%E%f:%l:%c\,%n: %m',
-        \ 'mapexpr': mapexpr,
+        \ 'errorformat': '%E%f:%l:%c\,%n: %m,%Z%m',
         \ }
 endfunction
 


### PR DESCRIPTION
Newline stripping didn't seem to work when using Flow for JS. I've updated the `errorformat` to support the multi-line format that flow is outputting.
