### PR TITLE
Allow buflocal maker settings

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -192,7 +192,7 @@ function! neomake#GetMaker(name_or_maker, ...) abort
         if len(fts)
             for ft in fts
                 for scope in [b:, g:]
-                    let m = get(g:, 'neomake_'.ft.'_'.a:name_or_maker.'_maker')
+                    let m = get(scope, 'neomake_'.ft.'_'.a:name_or_maker.'_maker')
                     if type(m) == type({})
                         let maker = m
                         break

--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -191,12 +191,14 @@ function! neomake#GetMaker(name_or_maker, ...) abort
     else
         if len(fts)
             for ft in fts
-                let m = get(g:, 'neomake_'.ft.'_'.a:name_or_maker.'_maker')
-                if type(m) == type({})
-                    let maker = m
-                    break
-                endif
-                unlet m
+                for scope in [b:, g:]
+                    let m = get(g:, 'neomake_'.ft.'_'.a:name_or_maker.'_maker')
+                    if type(m) == type({})
+                        let maker = m
+                        break
+                    endif
+                    unlet m
+                endfor
             endfor
         elseif exists('g:neomake_'.a:name_or_maker.'_maker')
             let maker = get(g:, 'neomake_'.a:name_or_maker.'_maker')


### PR DESCRIPTION
The way `neomake` expands the filename doesn't allow me to programmatically create a string that contains some expansion of the buffer name (e.g. `expand('%:t:r') . '_SUITE'`)

By allowing me to set e.g. `b:neomake_erlang_eunit_maker` I can construct this string myself when opening the buffer, and set a maker specific to this buffer.

```
    let b:neomake_erlang_eunit_maker = {
        \ 'exe': 'rebar',
        \ 'args': ['-q', 'eunit', 'skip_deps=true', 'suites=' . expand('%:t:r')],
        \ }
```