### PR TITLE
clean up readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,16 @@
 
 # Neomake
 
-A plugin for asynchronous `:make` using [Neovim's](http://neovim.org/)
-job-control functionality. It is inspired by the excellent vim plugins
-[Syntastic](https://github.com/scrooloose/syntastic) and
-[Dispatch](https://github.com/tpope/vim-dispatch).
+Neomake is a plugin for asynchronous `:make` using
+[Neovim's](http://neovim.org/) job-control functionality. It is inspired by
+the excellent Vim plugins [Syntastic](https://github.com/scrooloose/syntastic)
+and [dispatch.vim](https://github.com/tpope/vim-dispatch).
 
-**This plugin also works in ordinary Vim, but without the asynchronous benefits.**
+**This plugin also works in ordinary Vim, but without the asynchronous
+benefits.**
 
-The minimum Neovim version supported by Neomake is `NVIM 0.0.0-alpha+201503292107` (commit `960b9108c`).
+The minimum Neovim version supported by Neomake is `NVIM
+0.0.0-alpha+201503292107` (commit `960b9108c`).
 The minimum Vim version supported by Neomake is 7.4.503 (although if you don't
 use `g:neomake_logfile` older versions will probably work fine as well).
 
@@ -21,9 +23,9 @@ Just set your `makeprg` and `errorformat` as normal, and run:
 
 If your makeprg can take a filename as an input, then you can run `:Neomake`
 (no exclamation point) to pass the current file as the first argument.
-Otherwise, it is simply invoked in vim's current directory with no arguments.
+Otherwise, it is simply invoked in Vim's current directory with no arguments.
 
-Here's an example of how to run neomake on the current file on every write:
+Here's an example of how to run Neomake on the current file on every write:
 
 ```viml
 autocmd! BufWritePost * Neomake
@@ -53,13 +55,13 @@ is critical that makers follow this naming convention:
 
     g:neomake_{ language }_{ makername }_maker
 
-Where `{ language }` is replaced with the name of the language, and 
+Where `{ language }` is replaced with the name of the language, and
 `{ makername }` is replaced with the name that you want your maker to have. If
-your maker does not follow this convention, neomake will not be able to see
+your maker does not follow this convention, Neomake will not be able to see
 it, and you will get an error message like `{ makername } not found`.
 
 Explanation for the strings making up the errorformat can be found by typing
-`:h errorformat` in Neovim/Vim.
+`:h errorformat` in Neovim (or Vim).
 
 If the string `'%:p'` shows up anywhere in the `'args'` list, it will be
 `expand()`ed to the full path of the current file in place. Otherwise, the full
@@ -279,12 +281,19 @@ Vimscript:
   It can be installed using npm:
   [node-vimlint](https://www.npmjs.com/package/vimlint).
 
-  Or you could create a wrapper script ``vimlint`` and add it to your PATH:
+  Or you could create a wrapper script `vimlint` and add it to your PATH:
 
     ```sh
     #!/bin/sh
-    ~/Vcs/vim-vimlint/bin/vimlint.sh -l ~/Vcs/vim-vimlint -p ~/Vcs/vim-vimlparser "$@"
+    ~/Vcs/vim-vimlint/bin/vimlint.sh  \
+      -l ~/Vcs/vim-vimlint            \
+      -p ~/Vcs/vim-vimlparser         \
+      "$@"
     ```
+
+  Where `~/Vcs/vim-vimlint/bin` is where you have
+  [vimlint.sh](https://github.com/syngan/vim-vimlint/blob/master/bin/vimlint.sh)
+  installed.
 
 YAML:
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ Otherwise, it is simply invoked in vim's current directory with no arguments.
 
 Here's an example of how to run neomake on the current file on every write:
 
-    autocmd! BufWritePost * Neomake
+```viml
+autocmd! BufWritePost * Neomake
+```
 
 The make command will be run in an asynchronous job. The results will be
 populated in the window's quickfix list for `:Neomake!` and the location
@@ -51,10 +53,10 @@ is critical that makers follow this naming convention:
 
     g:neomake_{ language }_{ makername }_maker
 
-Where `{ language }` is replaced with the name of the language, and `{ makername
-}` is replaced with the name that you want your maker to have. If your maker
-does not follow this convention, neomake will not be able to see it, and you
-will get an error message like `{ makername } not found`.
+Where `{ language }` is replaced with the name of the language, and 
+`{ makername }` is replaced with the name that you want your maker to have. If
+your maker does not follow this convention, neomake will not be able to see
+it, and you will get an error message like `{ makername } not found`.
 
 Explanation for the strings making up the errorformat can be found by typing
 `:h errorformat` in Neovim/Vim.
@@ -77,102 +79,129 @@ For more detailed documentation please refer to the
 [plugin's help](https://github.com/neomake/neomake/tree/master/doc/neomake.txt)
 (`:h neomake`).
 
+## Included makers
 
-## Makers provided by Neomake as of this writing are:
+This list may be out of date, look at
+[autoload/neomake/makers](https://github.com/neomake/neomake/tree/master/autoload/neomake/makers)
+for all supported makers.
 
 Applescript:
+
 - osacompile
 
 C:
+
 - clang
 - gcc
 - clang-tidy
 - checkpatch
 
 C++:
+
 - clang++
 - g++
 - clang-tidy
 
 CFEngine 3:
+
 - cf-promises
 
 CUDA:
+
 - nvcc
 
 Coffeescript:
-- coffeelint
+
+- [coffeelint](http://www.coffeelint.org/)
 
 CSS:
+
 - csslint
-- stylelint
+- [stylelint](http://stylelint.io/)
 
 D:
+
 - dmd
 
 Elixir:
-- credo [not enabled by default]
-- dogma [not enabled by default]
+
+- credo (not enabled by default)
+- dogma (not enabled by default)
 - elixirc
 
 Erlang:
+
 - erlc
 
 fish:
+
 - fish
 
 Go:
+
 - go
 - golint
 - go vet
 
 Haskell:
+
 - hlint
 - ghc-mod
 - hdevtools
 - cabal
 
 Java:
+
 - javac
 
-Javascript:
-- eslint
-- standard
-- jscs
+JavaScript / ECMAScript:
+
+- [eslint](http://eslint.org/)
+- flow
+- [jscs](http://jscs.info/)
 - jshint
 - jsxhint
-- flow
+- standard
 - xo
 
 JSON:
-- jsonlint
 
-Jsx:
-- jsxhint
+- [jsonlint](https://github.com/zaach/jsonlint)
+
+JSX:
+
+- [jsxhint](https://github.com/STRML/JSXHint)
 
 Lua:
+
 - luac
 - luacheck
 
 Markdown:
+
 - [markdownlint](https://github.com/igorshubovych/markdownlint-cli)
 - [mdl](https://github.com/mivok/markdownlint)
 - [proselint](http://proselint.com)
 
 nix:
+
 - nix-instantiate
 
 Perl:
+
 - perlcritic
 
 Pug:
+
 - [pug-lint](https://github.com/pugjs/pug-lint)
 
 Puppet:
+
 - puppet
 - puppet-lint
 
 Python:
+
 - pep8
 - flake8
 - pyflakes
@@ -183,6 +212,7 @@ Python:
 - [mypy](http://mypy-lang.org/) [not enabled by default]
 
 Ruby:
+
 - mri
 - jruby
 - rubocop
@@ -190,49 +220,60 @@ Ruby:
 - rubylint
 
 Rust:
+
 - rustc
 
 Scala:
+
 - scalac
 - scalastyle
 
 scss:
+
 - [sass-lint](https://github.com/sasstools/sass-lint) node.js-based linter
 - [scss-lint](https://github.com/brigade/scss-lint) ruby gem-based linter
 
-sh:
+sh / Bash:
 
 - sh
-- shellcheck
+- [shellcheck](https://www.shellcheck.net/)
 
 Slim:
+
 - [slim-lint](https://github.com/sds/slim-lint)
 
 Standard ML:
+
 - smlnj
 
 Stylus:
+
 - [stylint](https://rosspatton.github.io/stylint/)
 
 SQL:
+
 - [sqlint](https://github.com/purcell/sqlint)
 
 TCL:
+
 - Nagelfar
 
 Tex/Latex:
+
 - chktex
 - lacheck
 
 TypeScript:
+
 - tsc
 
 VHDL:
+
 - [GHDL](https://github.com/tgingold/ghdl)
 
 Vimscript:
 
-- vint
+- [vint](https://github.com/Kuniwak/vint)
 - [vimlint](https://github.com/syngan/vim-vimlint)
 
   It can be installed using npm:
@@ -240,30 +281,28 @@ Vimscript:
 
   Or you could create a wrapper script ``vimlint`` and add it to your PATH:
 
-  ```sh
-  #!/bin/sh
-  ~/Vcs/vim-vimlint/bin/vimlint.sh -l ~/Vcs/vim-vimlint -p ~/Vcs/vim-vimlparser "$@"
-  ```
+    ```sh
+    #!/bin/sh
+    ~/Vcs/vim-vimlint/bin/vimlint.sh -l ~/Vcs/vim-vimlint -p ~/Vcs/vim-vimlparser "$@"
+    ```
 
 YAML:
+
 - [yamllint](http://yamllint.readthedocs.org/)
 
 Zsh:
 
-- shellcheck (not enabled by default, current versions do not support Zsh)
+- [shellcheck](https://www.shellcheck.net/) (not enabled by default, current
+  versions do not support Zsh)
 - zsh
-
-Since this list may be out of date, look at
-[autoload/neomake/makers](https://github.com/benekastah/neomake/tree/master/autoload/neomake/makers)
-for all supported makers.
 
 If you find this plugin useful, please contribute your maker recipes to the
 repository! Check out `autoload/neomake/makers/**/*.vim` to see how that is
 currently done.
 
-
 # Contributing
 
 This is a community driven project, and maintainers are wanted.
-Please contact [@bl;eyed](https://github.com/blueyed) if you are interested.
+Please contact [@blueyed](https://github.com/blueyed) if you are interested.
 You should have a good profile of issue triaging and PRs on this repo already.
+


### PR DESCRIPTION
#### Changelog ####

- CHANGED: mark viml language for stuff that goes in your vimrc
- CHANGED: don't break up fenced code (markdownlint)
- CHANGED: move maker notice to top of maker section for better visibility
- CHANGED: spaces around lists (markdownlint)
- CHANGED: Provide links to more makers so people know where to find
installation instructions
- CHANGED: Don't use square brackets for text asides (that's what parentheses
are for)
- CHANGED: Sort JavaScript makers alphabetically and fix casing on maker names
- CHANGED: fenced code blocks in lists need 4space indent for universal markdown
parsing (compatible outside of GFM in case someone opens README.md using pandoc
or something)
- CHANGED: fix @blueyed's username in Contributing section