### PR TITLE
python: Add py3kwarn maker

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Python:
 - python
 - [vulture](https://bitbucket.org/jendrikseipp/vulture) [not enabled by default]
 - [mypy](http://mypy-lang.org/) [not enabled by default]
+- [py3kwarn](https://github.com/liamcurry/py3kwarn) [not enabled by default]
 
 Ruby:
 - mri

--- a/autoload/neomake/makers/ft/python.vim
+++ b/autoload/neomake/makers/ft/python.vim
@@ -173,3 +173,9 @@ function! neomake#makers#ft#python#mypy()
             \ '%I%f:%l: note: %m',
         \ }
 endfunction
+
+function! neomake#makers#ft#python#py3kwarn()
+    return {
+        \ 'errorformat': '%W%f:%l:%c: %m',
+        \ }
+endfunction


### PR DESCRIPTION
[py3kwarn](https://github.com/liamcurry/py3kwarn) detects code that is not Python 3 compatible.