### PR TITLE
Add flake8 error code to displayed error message

### DIFF
--- a/autoload/neomake/makers/ft/python.vim
+++ b/autoload/neomake/makers/ft/python.vim
@@ -83,6 +83,7 @@ function! neomake#makers#ft#python#Flake8EntryProcess(entry)
     else
         let type = ''
     endif
+    let a:entry.text = a:entry.type . a:entry.nr . ' ' . a:entry.text
     let a:entry.type = type
 endfunction
 

--- a/autoload/neomake/makers/ft/python.vim
+++ b/autoload/neomake/makers/ft/python.vim
@@ -85,6 +85,7 @@ function! neomake#makers#ft#python#Flake8EntryProcess(entry)
     endif
     let a:entry.text = a:entry.type . a:entry.nr . ' ' . a:entry.text
     let a:entry.type = type
+    let a:entry.nr = ''  " Avoid redundancy in the displayed error message.
 endfunction
 
 function! neomake#makers#ft#python#pyflakes()


### PR DESCRIPTION
It is useful to know the flake8 error code when you need to: (a) look it up in documentation, or (b) suppress it by updating the flake8 config or directive in the code comments (e.g. `# flake8: disable=F401`).

Currently, the status line message does not show the error code, just the message:
```
flake8: 'foo' imported but unused
```

This PR adds the error code to the message, as follows:
```
flake8: F401 'foo' imported but unused
```