### PR TITLE
New errorfmt for Rust

### DIFF
--- a/autoload/neomake/makers/cargo.vim
+++ b/autoload/neomake/makers/cargo.vim
@@ -1,11 +1,9 @@
 " vim: ts=4 sw=4 et
 
-function! neomake#makers#cargo#cargo()
+function! neomake#makers#cargo#cargo() abort
     return {
         \ 'args': ['build'],
         \ 'errorformat':
-            \   '%-Z%f:%l,' .
-            \   '%+C %s,' .
-            \   '%A%f:%l:%c: %*\d:%*\d\ %t%*[^:]: %m,',
+            \ neomake#makers#ft#rust#rustc()['errorformat'],
         \ }
 endfunction

--- a/autoload/neomake/makers/clippy.vim
+++ b/autoload/neomake/makers/clippy.vim
@@ -4,14 +4,7 @@
 let s:rustup_has_nightly = -1
 
 function! neomake#makers#clippy#clippy() abort
-    let errorfmt = '%Eerror[E%n]: %m,'.
-                 \ '%Eerror: %m,'.
-                 \ '%Wwarning: %m,'.
-                 \ '%Inote: %m,'.
-                 \ '%-Z\ %#-->\ %f:%l:%c,'.
-                 \ '%I\ %#\= %t%*[^:]: %m,'.
-                 \ '%I\ %#|\ %#%\\^%\\+ %m,'.
-                 \ '%-G%s,'
+    let errorfmt = neomake#makers#ft#rust#rustc()['errorformat']
 
     " When rustup and a nightly toolchain is installed, that is used.
     " Otherwise, the default cargo exectuable is used. If this is not part

--- a/autoload/neomake/makers/ft/rust.vim
+++ b/autoload/neomake/makers/ft/rust.vim
@@ -1,19 +1,24 @@
 " vim: ts=4 sw=4 et
 
-function! neomake#makers#ft#rust#EnabledMakers()
+function! neomake#makers#ft#rust#EnabledMakers() abort
     return ['rustc']
 endfunction
 
-function! neomake#makers#ft#rust#rustc()
+function! neomake#makers#ft#rust#rustc() abort
     return {
-        \ 'args': ['-Z', 'parse-only'],
         \ 'errorformat':
-            \ '%-G%f:%s:,' .
-            \ '%f:%l:%c: %trror: %m,' .
-            \ '%f:%l:%c: %tarning: %m,' .
-            \ '%f:%l:%c: %m,'.
-            \ '%f:%l: %trror: %m,'.
-            \ '%f:%l: %tarning: %m,'.
-            \ '%f:%l: %m',
+            \ '%-Gerror: aborting due to previous error,'.
+            \ '%-Gerror: aborting due to %\\d%\\+ previous errors,'.
+            \ '%-Gerror: Could not compile `%s`.,'.
+            \ '%Eerror[E%n]: %m,'.
+            \ '%Eerror: %m,'.
+            \ '%Wwarning: %m,'.
+            \ '%Inote: %m,'.
+            \ '%-Z\ %#-->\ %f:%l:%c,'.
+            \ '%G\ %#\= %*[^:]: %m,'.
+            \ '%G\ %#|\ %#%\\^%\\+ %m,'.
+            \ '%I%>help:\ %#%m,'.
+            \ '%Z\ %#%m,'.
+            \ '%-G%s',
         \ }
 endfunction


### PR DESCRIPTION
This PR closes #592. Stable 1.12 version of Rust, which introduces new errorfmt as default, will land in a few days and i think that it's reasonable to switch to the new errorfmt.

Introduced makers try to remove unnecessary informations, while maintaining error/warning messages, error description taken from the pointer line and note/help lines. The only thing that is missing is proper parsing of error/warning width, as pointer line contains both markers (^^^^) and error description.

More information about new format can be found [here](https://blog.rust-lang.org/2016/08/10/Shape-of-errors-to-come.html). I decided against parsing lifetime messages, because in my opinion they can't be shown in a sane way.
