### PR TITLE
Rust clippy maker

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,8 @@ Ruby:
 Rust:
 
 - rustc
+- cargo [Call with `Neomake! cargo`]
+- [clippy](https://github.com/Manishearth/rust-clippy) [Call with `Neomake! clippy`, needs [rustup](https://github.com/rust-lang-nursery/rustup.rs) with a nightly toolchain or a nightly rust installation]
 
 Scala:
 

--- a/README.md
+++ b/README.md
@@ -230,8 +230,8 @@ Ruby:
 Rust:
 
 - rustc
-- cargo [Call with `Neomake! cargo`]
-- [clippy](https://github.com/Manishearth/rust-clippy) [Call with `Neomake! clippy`, needs [rustup](https://github.com/rust-lang-nursery/rustup.rs) with a nightly toolchain or a nightly rust installation]
+- cargo (call with `Neomake! cargo`)
+- [clippy](https://github.com/Manishearth/rust-clippy) (call with `Neomake! clippy`, needs nightly rust, supports [rustup](https://github.com/rust-lang-nursery/rustup.rs))
 
 Scala:
 

--- a/autoload/neomake/makers/clippy.vim
+++ b/autoload/neomake/makers/clippy.vim
@@ -1,5 +1,8 @@
 " vim: ts=4 sw=4 et
 
+" Yet to be determined
+let s:rustup_has_nightly = -1
+
 function! neomake#makers#clippy#clippy() abort
     let errorfmt = '%Eerror[E%n]: %m,'.
                  \ '%Eerror: %m,'.
@@ -13,7 +16,7 @@ function! neomake#makers#clippy#clippy() abort
     " When rustup and a nightly toolchain is installed, that is used.
     " Otherwise, the default cargo exectuable is used. If this is not part
     " of a nightly rust, this will fail.
-    if !exists('s:rustup_has_nightly')
+    if !exists('s:rustup_has_nightly') || s:rustup_has_nightly == -1
         if !executable('rustup')
             let s:rustup_has_nightly = 0
         else

--- a/autoload/neomake/makers/clippy.vim
+++ b/autoload/neomake/makers/clippy.vim
@@ -21,7 +21,7 @@ function! neomake#makers#clippy#clippy() abort
             let s:rustup_has_nightly = 0
             call system('rustc --version | grep -q "\-nightly"')
             if v:shell_error
-                call neomake#utils#LoudMessage('Clippy requires a nightly rust installation.')
+                call neomake#utils#ErrorMessage('Clippy requires a nightly rust installation.')
             endif
         else
             call system('rustup show | grep -q "^nightly-"')

--- a/autoload/neomake/makers/clippy.vim
+++ b/autoload/neomake/makers/clippy.vim
@@ -19,6 +19,10 @@ function! neomake#makers#clippy#clippy() abort
     if !exists('s:rustup_has_nightly') || s:rustup_has_nightly == -1
         if !executable('rustup')
             let s:rustup_has_nightly = 0
+            call system('rustc --version | grep -q "\-nightly"')
+            if v:shell_error
+                call neomake#utils#LoudMessage('Clippy requires a nightly rust installation.')
+            endif
         else
             call system('rustup show | grep -q "^nightly-"')
             let s:rustup_has_nightly = !v:shell_error

--- a/autoload/neomake/makers/clippy.vim
+++ b/autoload/neomake/makers/clippy.vim
@@ -16,7 +16,7 @@ function! neomake#makers#clippy#clippy() abort
     " When rustup and a nightly toolchain is installed, that is used.
     " Otherwise, the default cargo exectuable is used. If this is not part
     " of a nightly rust, this will fail.
-    if !exists('s:rustup_has_nightly') || s:rustup_has_nightly == -1
+    if s:rustup_has_nightly == -1
         if !executable('rustup')
             let s:rustup_has_nightly = 0
             call system('rustc --version | grep -q "\-nightly"')

--- a/autoload/neomake/makers/clippy.vim
+++ b/autoload/neomake/makers/clippy.vim
@@ -15,9 +15,9 @@ function! neomake#makers#clippy#clippy() abort
     " of a nightly rust, this will fail.
     if !exists('s:rustup_has_nightly')
         if !executable('rustup')
-            let s:rustup_has_nightly = false
+            let s:rustup_has_nightly = 0
         else
-            call system('rustup show | grep -q nightly')
+            call system('rustup show | grep -q "^nightly-"')
             let s:rustup_has_nightly = !v:shell_error
         endif
     endif

--- a/autoload/neomake/makers/clippy.vim
+++ b/autoload/neomake/makers/clippy.vim
@@ -25,4 +25,5 @@ function! neomake#makers#clippy#clippy() abort
             \ 'args': ['clippy'],
             \ 'errorformat': errorfmt,
             \ }
+    endif
 endfunction

--- a/autoload/neomake/makers/clippy.vim
+++ b/autoload/neomake/makers/clippy.vim
@@ -1,0 +1,28 @@
+" vim: ts=4 sw=4 et
+
+function! neomake#makers#clippy#clippy()
+    let errorfmt = '%Eerror[E%n]: %m,'.
+                 \ '%Eerror: %m,'.
+                 \ '%Wwarning: %m,'.
+                 \ '%Inote: %m,'.
+                 \ '%-Z\ %#-->\ %f:%l:%c,'.
+                 \ '%I\ %#\= %t%*[^:]: %m,'.
+                 \ '%I\ %#|\ %#%\\^%\\+ %m,'.
+                 \ '%-G%s,'
+
+    " When rustup and a nightly toolchain is installed, that is used
+    " Otherwise, the default cargo exectuable is used. If this is not part
+    " of a nightly rust, this will fail.
+    if executable('rustup') && system('rustup show | grep nightly | wc -l') >= 2
+        return {
+            \ 'exe': 'rustup',
+            \ 'args': ['run', 'nightly', 'cargo', 'clippy'],
+            \ 'errorformat': errorfmt,
+            \ }
+    else
+        return {
+            \ 'exe': 'cargo',
+            \ 'args': ['clippy'],
+            \ 'errorformat': errorfmt,
+            \ }
+endfunction

--- a/autoload/neomake/makers/clippy.vim
+++ b/autoload/neomake/makers/clippy.vim
@@ -10,7 +10,7 @@ function! neomake#makers#clippy#clippy() abort
                  \ '%I\ %#|\ %#%\\^%\\+ %m,'.
                  \ '%-G%s,'
 
-    " When rustup and a nightly toolchain is installed, that is used
+    " When rustup and a nightly toolchain is installed, that is used.
     " Otherwise, the default cargo exectuable is used. If this is not part
     " of a nightly rust, this will fail.
     if executable('rustup') && system('rustup show | grep nightly | wc -l') >= 1

--- a/autoload/neomake/makers/clippy.vim
+++ b/autoload/neomake/makers/clippy.vim
@@ -13,7 +13,16 @@ function! neomake#makers#clippy#clippy() abort
     " When rustup and a nightly toolchain is installed, that is used.
     " Otherwise, the default cargo exectuable is used. If this is not part
     " of a nightly rust, this will fail.
-    if executable('rustup') && system('rustup show | grep nightly | wc -l') >= 1
+    if !exists('s:rustup_has_nightly')
+        if !executable('rustup')
+            let s:rustup_has_nightly = false
+        else
+            call system('rustup show | grep -q nightly')
+            let s:rustup_has_nightly = !v:shell_error
+        endif
+    endif
+
+    if s:rustup_has_nightly
         return {
             \ 'exe': 'rustup',
             \ 'args': ['run', 'nightly', 'cargo', 'clippy'],

--- a/autoload/neomake/makers/clippy.vim
+++ b/autoload/neomake/makers/clippy.vim
@@ -13,7 +13,7 @@ function! neomake#makers#clippy#clippy()
     " When rustup and a nightly toolchain is installed, that is used
     " Otherwise, the default cargo exectuable is used. If this is not part
     " of a nightly rust, this will fail.
-    if executable('rustup') && system('rustup show | grep nightly | wc -l') >= 2
+    if executable('rustup') && system('rustup show | grep nightly | wc -l') >= 1
         return {
             \ 'exe': 'rustup',
             \ 'args': ['run', 'nightly', 'cargo', 'clippy'],

--- a/autoload/neomake/makers/clippy.vim
+++ b/autoload/neomake/makers/clippy.vim
@@ -1,6 +1,6 @@
 " vim: ts=4 sw=4 et
 
-function! neomake#makers#clippy#clippy()
+function! neomake#makers#clippy#clippy() abort
     let errorfmt = '%Eerror[E%n]: %m,'.
                  \ '%Eerror: %m,'.
                  \ '%Wwarning: %m,'.


### PR DESCRIPTION
Clippy is a rust linter that has more lints than standard rustc (`Neomake! clippy` will show the rustc/cargo lints as well as the clippy ones).
Since clippy integrates with the rust compiler, it has the same errorformat (I copied the error format from #613). Clippy needs a nightly compiler to work. Since it is the most convenient way, `rustup` (manages multiple rust installations) is used if available to run clippy with nightly rust, while other compilations can use stable rust.

I also added cargo and clippy to the Readme, with the annotation that `Neomake!` needs to be used (wasn't obvious for me).