### PR TITLE
Specify --color=false in puppet parser validate output

### DIFF
--- a/autoload/neomake/makers/ft/puppet.vim
+++ b/autoload/neomake/makers/ft/puppet.vim
@@ -12,7 +12,7 @@ endfunction
 
 function! neomake#makers#ft#puppet#puppet()
     return {
-        \ 'args': ['parser', 'validate'],
+        \ 'args': ['parser', 'validate', '--color=false'],
         \ 'errorformat': '%t%*[a-zA-Z]: %m at %f:%l',
         \ }
 endfunction


### PR DESCRIPTION
As you can see in [the syntastic implementation for `puppet parser validate`](https://github.com/scrooloose/syntastic/blob/59cc80a8f7f7544a364814622dc62efd00d17ca4/syntax_checkers/puppet/puppet.vim#L27), later versions of puppet need to be told to avoid colorized output to parse correctly.

I looked through the existing makers to find if there was prior work regarding logic to set checker flags based on executable version but couldn't find anything; but based upon syntastic's logic it looks like only _pretty_ old versions of puppet won't recognize the flag (< 2.7.0, released in 2011) so this feels relatively safe to me.