### PR TITLE
Execute mapexpr in ProcessJobOutput for the buffer context

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -589,6 +589,15 @@ function! s:ProcessJobOutput(jobinfo, lines) abort
     call neomake#utils#DebugMessage(printf(
                 \ '[#%d] %s: processing %d lines of output.',
                 \ a:jobinfo.id, maker.name, len(a:lines)))
+
+    if has_key(maker, 'mapexpr')
+        if file_mode && get(maker, 'mapexpr_setup_bufvars', 0)
+            let neomake_bufname = bufname(maker.bufnr)
+            let neomake_bufdir = fnamemodify(neomake_bufname, ':h')
+        endif
+        let lines = map(a:lines, maker.mapexpr)
+    endif
+
     let olderrformat = &errorformat
     let &errorformat = maker.errorformat
     try
@@ -641,9 +650,6 @@ endfunction
 function! s:RegisterJobOutput(jobinfo, lines) abort
     let lines = copy(a:lines)
     let maker = a:jobinfo.maker
-    if has_key(maker, 'mapexpr')
-        let lines = map(lines, maker.mapexpr)
-    endif
 
     if !get(maker, 'file_mode')
         return s:ProcessJobOutput(a:jobinfo, lines)

--- a/autoload/neomake/makers/ft/go.vim
+++ b/autoload/neomake/makers/ft/go.vim
@@ -16,7 +16,8 @@ function! neomake#makers#ft#go#go()
         \ ],
         \ 'append_file': 0,
         \ 'cwd': '%:h',
-        \ 'mapexpr': 'expand("%:h") . "/" . v:val',
+        \ 'mapexpr_setup_bufvars': 1,
+        \ 'mapexpr': 'neomake_bufdir . "/" . v:val',
         \ 'errorformat':
             \ '%W%f:%l: warning: %m,' .
             \ '%E%f:%l:%c:%m,' .
@@ -40,7 +41,8 @@ function! neomake#makers#ft#go#govet()
         \ 'args': ['vet'],
         \ 'append_file': 0,
         \ 'cwd': '%:h',
-        \ 'mapexpr': 'expand("%:h") . "/" . v:val',
+        \ 'mapexpr_setup_bufvars': 1,
+        \ 'mapexpr': 'neomake_bufdir . "/" . v:val',
         \ 'errorformat':
             \ '%Evet: %.%\+: %f:%l:%c: %m,' .
             \ '%W%f:%l: %m,' .

--- a/doc/neomake.txt
+++ b/doc/neomake.txt
@@ -146,6 +146,14 @@ like so: >
 This allows you to manipulate the lines as needed. Currently this is called
 on stdout and stderr lines alike.
 
+You can set `mapexpr_setup_bufvars` to 1 in the maker's config to setup the
+variables `neomake_bufname` and `neomake_bufdir`, in case you use the
+buffer's name or its directory in your expression.  This is recommended for
+performance reasons, but only applies to file mode.
+The 'mapexpr' itself is being evaluated in the context of the affected buffer
+in file mode, for non-file mode it is evaluated in the context of the buffer
+that is current when the maker finished.
+
 The 'postprocess' property is a function reference that will be applied to the
 entry in the location or quickfix list.
 Example: change the entry type to a warning. >


### PR DESCRIPTION
This also adds mapexpr_setup_bufvars to setup local vars for better
performance and uses it for the go makers.