### PR TITLE
Vim async, take 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ env:
     - ENV=docker_test MAKE_ARGS=DOCKER_VIM=vim73
     - ENV=docker_test MAKE_ARGS=DOCKER_VIM=vim74-trusty
     - ENV=docker_test MAKE_ARGS=DOCKER_VIM=vim74-xenial
+    - ENV=docker_test MAKE_ARGS=DOCKER_VIM=vim8000
     - ENV=docker_test MAKE_ARGS=DOCKER_VIM=vim-master
     - ENV=vint-diff
     - ENV=vint-errors

--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -5,9 +5,11 @@ FROM neomake/vim-testbed:latest
 #  - v7.3.429 (Ubuntu Precise, 12.04LTS; same as on Travis currently)
 #  - v7.4.052 (Ubuntu Trusty, 14.04LTS)
 #  - v7.4.1689 (Ubuntu Xenial, 16.04LTS)
+#  - v8.0.0000 (Vim 8, for reference)
 #  - Git master
 
 RUN install_vim -tag v7.3.429 -name vim73 -build \
                 -tag v7.4.052 -name vim74-trusty -build \
                 -tag v7.4.1689 -name vim74-xenial -build \
+                -tag v8.0.0000 -name vim8000 -build \
                 -tag master -build

--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ docker_image:
 docker_push:
 	docker push $(DOCKER_IMAGE)
 
-DOCKER_VIMS:=vim73 vim74-trusty vim74-xenial vim-master
+DOCKER_VIMS:=vim73 vim74-trusty vim74-xenial vim8000 vim-master
 _DOCKER_VIM_TARGETS:=$(addprefix docker_test-,$(DOCKER_VIMS))
 
 docker_test_all: $(_DOCKER_VIM_TARGETS)

--- a/README.md
+++ b/README.md
@@ -4,13 +4,10 @@
 # Neomake
 
 Neomake is a plugin that asynchronously runs programs using
-[Neovim]'s job-control functionality. It is intended to
-replace Vim's built-in `:make` command and provides functionality similar to
+[Neovim]'s or [Vim]'s job-control functionality. It is intended to
+replace the built-in `:make` command and provides functionality similar to
 plugins like [syntastic] and [dispatch.vim]. It is primarily used to run code
 linters and compilers from within Vim, but can be used to run any program.
-
-**This plugin also works in ordinary Vim, but without the asynchronous
-benefits.**
 
 ## Requirements
 
@@ -18,6 +15,9 @@ The minimum [Neovim] version supported by Neomake is
 `NVIM 0.0.0-alpha+201503292107` ([commit 960b9108c]). The minimum Vim version
 supported by Neomake is 7.4.503 (although if you don't use `g:neomake_logfile`
 older versions will probably work fine as well).
+
+Vim's async mode is used with Vim 7.4.2260 or later, but is considered to be
+experimental and awaits fixes in Vim.
 
 ## Usage
 
@@ -137,6 +137,7 @@ Please contact [@blueyed](https://github.com/blueyed) if you are interested.
 You should have a good profile of issue triaging and PRs on this repo already.
 
 [Neovim]: http://neovim.org/
+[Vim]: http://vim.org/
 [syntastic]: https://github.com/scrooloose/syntastic
 [dispatch.vim]: https://github.com/tpope/vim-dispatch
 [commit 960b9108c]: https://github.com/neovim/neovim/tree/960b9108c2928b6cf0adcabdb829d06996635211

--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -137,6 +137,15 @@ function! s:MakeJob(make_id, maker) abort
                 endif
                 let jobinfo.id = job
             else
+                " HACK: We need to add some 'sleep' for Vim (8.0.8) to work
+                " around https://groups.google.com/d/msg/vim_dev/us740TrOxNQ/IcBgP7YQBQAJ.
+                " Currently it is only being done in tests, but a) is
+                " hopefully not necessary anymore and b) might be needed in
+                " real usage, too.
+                " Fix: https://groups.google.com/d/msg/vim_dev/LhXQJusQScM/_wV4u5y5AAAJ
+                if !has('nvim')
+                    let argv = ['/bin/sh', '-c', 'sleep .05 & '.join(map(argv, 'shellescape(v:val)'))]
+                endif
                 let job = job_start(argv, {
                             \ 'err_cb': 'neomake#MakeHandlerVimStderr',
                             \ 'out_cb': 'neomake#MakeHandlerVimStdout',

--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -16,8 +16,8 @@ let s:need_errors_cleaning = {
     \ }
 
 function! neomake#has_async_support() abort
-    " TODO: add support for Vim's async support (job_start).
-    return has('nvim')
+    return has('nvim') ||
+                \ has('channel') && has('job') && has('patch-7-4-2260')
 endfunction
 
 function! neomake#GetJobs() abort
@@ -33,7 +33,12 @@ endfunction
 
 function! neomake#CancelJob(job_id) abort
     if has_key(s:jobs, a:job_id)
-        call jobstop(a:job_id)
+        call neomake#utils#DebugMessage('Stopping job: ' . a:job_id)
+        if has('nvim')
+            call jobstop(a:job_id)
+        else
+            call job_stop(s:jobs[a:job_id].vim_job)
+        endif
         return 1
     endif
     return 0
@@ -102,12 +107,7 @@ function! s:MakeJob(make_id, maker) abort
         call add(args, '%:p')
     endif
 
-    if neomake#utils#IsRunningWindows()
-        " Don't expand &shellcmdflag argument of cmd.exe
-        call map(args, 'v:val !=? &shellcmdflag ? expand(v:val) : v:val')
-    else
-        call map(args, 'expand(v:val)')
-    endif
+    call neomake#utils#ExpandArgs(args)
 
     if has_key(a:maker, 'cwd')
         let old_wd = getcwd()
@@ -117,36 +117,47 @@ function! s:MakeJob(make_id, maker) abort
 
     try
         let has_args = type(args) == type([])
-        if has('nvim')
+        if neomake#has_async_support()
             let argv = [exe]
             if has_args
-                let argv = argv + args
+                let argv += args
             endif
             call neomake#utils#LoudMessage('Starting: '.join(argv, ' '))
-            let opts = {
-                \ 'on_stdout': function('neomake#MakeHandler'),
-                \ 'on_stderr': function('neomake#MakeHandler'),
-                \ 'on_exit': function('neomake#MakeHandler')
-                \ }
-            let job = jobstart(argv, opts)
-            if job == 0
-                throw 'Job table is full or invalid arguments given'
-            elseif job == -1
-                throw 'Non executable given'
+            if has('nvim')
+                let opts = {
+                    \ 'on_stdout': function('neomake#MakeHandler'),
+                    \ 'on_stderr': function('neomake#MakeHandler'),
+                    \ 'on_exit': function('neomake#MakeHandler')
+                    \ }
+                let job = jobstart(argv, opts)
+                if job == 0
+                    throw 'Job table is full or invalid arguments given'
+                elseif job == -1
+                    throw 'Non executable given'
+                endif
+                let jobinfo.id = job
+            else
+                let job = job_start(argv, {
+                            \ 'err_cb': 'neomake#MakeHandlerVimStderr',
+                            \ 'out_cb': 'neomake#MakeHandlerVimStdout',
+                            \ 'close_cb': 'neomake#MakeHandlerVimClose',
+                            \ 'mode': 'raw',
+                            \ })
+                let jobinfo.id = ch_info(job)['id']
+                let jobinfo.vim_job = job
             endif
 
-            let jobinfo.id = job
-            let s:jobs[job] = jobinfo
+            let s:jobs[jobinfo.id] = jobinfo
             let maker_key = s:GetMakerKey(a:maker)
             let s:jobs_by_maker[maker_key] = jobinfo
             call s:AddJobinfoForCurrentWin(jobinfo.id)
-            let r = jobinfo.id
             if !exists('s:jobids_by_makeid[a:make_id]')
                 let s:jobids_by_makeid[a:make_id] = []
             endif
             call add(s:jobids_by_makeid[a:make_id], jobinfo.id)
+            let r = jobinfo.id
         else
-            " Vim, synchronously.
+            call neomake#utils#DebugMessage('Running synchronously')
             if has_args
                 if neomake#utils#IsRunningWindows()
                     let program = exe.' '.join(map(args, 'v:val'))
@@ -156,12 +167,15 @@ function! s:MakeJob(make_id, maker) abort
             else
                 let program = exe
             endif
+
+            call neomake#utils#LoudMessage('Starting: ' . program)
+
             let jobinfo.id = job_id
             let s:jobs[job_id] = jobinfo
             call s:AddJobinfoForCurrentWin(jobinfo.id)
             call neomake#MakeHandler(job_id, split(system(program), '\r\?\n', 1), 'stdout')
             call neomake#MakeHandler(job_id, v:shell_error, 'exit')
-            let r = 0
+            let r = -1
         endif
     finally
         if exists('old_wd')
@@ -414,7 +428,7 @@ function! s:Make(options, ...) abort
             let jobinfo = s:jobs_by_maker[maker_key]
             let jobinfo.maker.next = copy(a:options)
             try
-                call jobstop(jobinfo.id)
+                call neomake#CancelJob(jobinfo.id)
             catch /^Vim\%((\a\+)\)\=:E900/
                 " Ignore invalid job id errors. Happens when the job is done,
                 " but on_exit hasn't been called yet.
@@ -431,7 +445,7 @@ function! s:Make(options, ...) abort
             let maker.exit_callback = a:options.exit_callback
         endif
         let job_id = s:MakeJob(make_id, maker)
-        if job_id != 0
+        if job_id != -1
             call add(job_ids, job_id)
         endif
         " If we are serializing makers, stop after the first one. The
@@ -657,6 +671,22 @@ function! s:RegisterJobOutput(jobinfo, lines) abort
     endif
 endfunction
 
+function! neomake#MakeHandlerVimStdout(channel, output) abort
+    call neomake#utils#DebugMessage('MakeHandlerVim: stdout: ' . a:channel)
+    call neomake#MakeHandler(ch_info(a:channel)['id'], split(a:output, "\n", 1), 'stdout')
+endfunction
+
+function! neomake#MakeHandlerVimStderr(channel, output) abort
+    call neomake#utils#DebugMessage('MakeHandlerVim: stderr: ' . a:channel)
+    call neomake#MakeHandler(ch_info(a:channel)['id'], split(a:output, "\n", 1), 'stderr')
+endfunction
+
+function! neomake#MakeHandlerVimClose(channel) abort
+    call neomake#utils#DebugMessage('Channel has been closed: ' . a:channel)
+    let job = ch_getjob(a:channel)
+    call neomake#MakeHandler(ch_info(a:channel)['id'], job_info(job)['exitval'], 'exit')
+endfunction
+
 function! neomake#MakeHandler(job_id, data, event_type) abort
     if !has_key(s:jobs, a:job_id)
         return
@@ -690,7 +720,7 @@ function! neomake#MakeHandler(job_id, data, event_type) abort
     elseif a:event_type ==# 'exit'
         " Handle any unfinished lines from stdout/stderr callbacks.
         if has_key(jobinfo, 'lines')
-            if jobinfo.lines[-1] ==# ''
+            if len(jobinfo.lines) && jobinfo.lines[-1] ==# ''
                 call remove(jobinfo.lines, -1)
             endif
             if len(jobinfo.lines)
@@ -714,8 +744,7 @@ function! neomake#MakeHandler(job_id, data, event_type) abort
             endtry
         endif
         call s:CleanJobinfo(jobinfo)
-        if has('nvim')
-            " Only report completion for neovim, since it is asynchronous
+        if neomake#has_async_support()
             call neomake#utils#QuietMessage(printf(
                         \ '[#%d] %s: completed with exit code %d.',
                         \ jobinfo.id, maker.name, status))
@@ -743,7 +772,7 @@ function! neomake#MakeHandler(job_id, data, event_type) abort
         endif
 
         " Trigger autocmd if all jobs for a s:Make instance have finished.
-        if has('nvim')
+        if neomake#has_async_support()
             let make_id = -1
             for [k, v] in items(s:jobids_by_makeid)
                 if index(v, a:job_id) != -1

--- a/autoload/neomake/utils.vim
+++ b/autoload/neomake/utils.vim
@@ -297,3 +297,8 @@ function! neomake#utils#redir(cmd) abort
     endtry
     return neomake_redir
 endfunction
+
+function! neomake#utils#ExpandArgs(args) abort
+    " Only expand those args that start with \ and a single %
+    call map(a:args, "v:val =~# '\\(^\\\\\\|^%$\\|^%[^%]\\)' ? expand(v:val) : v:val")
+endfunction

--- a/doc/neomake.txt
+++ b/doc/neomake.txt
@@ -6,8 +6,7 @@
  _/    _/_/  _/        _/    _/  _/    _/    _/  _/    _/  _/  _/    _/        ~
 _/      _/    _/_/_/    _/_/    _/    _/    _/    _/_/_/  _/    _/    _/_/_/   ~
 
-        Runs make tasks and syntax checkers asynchronously (for neovim)
-                         and simply (for all the vims)!
+        Runs make tasks and syntax checkers asynchronously!
 
 ==============================================================================
 CONTENTS                                                      *neomake-contents*
@@ -22,11 +21,11 @@ CONTENTS                                                      *neomake-contents*
 ==============================================================================
 1. Introduction                                           *neomake-introduction*
 
-Neomake leverages neovim's |job-control| feature where available to run
+Neomake leverages Neovim's or Vim's |job-control| feature where available to run
 programs like syntax checkers asynchronously. Where job control is not
 available, it resorts to a synchronous |system()| call, making it possible to
-run this plugin in both vim and neovim. This plugin is heavily inspired by
-fantastic vim plugins such as syntastic and dispatch.
+run this plugin in both Vim and Neovim. This plugin is heavily inspired by
+fantastic Vim plugins such as syntastic and dispatch.
 
 ==============================================================================
 2. Commands                                                   *neomake-commands*
@@ -63,8 +62,8 @@ fantastic vim plugins such as syntastic and dispatch.
                         job_id job_name
 <
                                                              *:NeomakeCancelJob*
-:NeomakeCancelJob *{job_id}*
-                        Sends a 'jobstop' to *job_id* which terminates the job.
+:NeomakeCancelJob {job_id}
+                        Terminate a job identified by its job_id.
 
 ==============================================================================
 3. Configuration                                         *neomake-configuration*
@@ -331,8 +330,8 @@ functions useful.
 *neomake#Make* (filemode, makers[, callback])
 This function is called by |:Neomake(!)| command. It runs all the *makers*
 specified, in order. If *filemode* is 1, then the current file is used as input
-to the makers. |neomake#Make| returns an array of the job ids that it creates
-via 'jobstart'; you can potentially cancel these jobs with |neomake#CancelJob|.
+to the makers. |neomake#Make| returns an array of job ids that were created;
+you can potentially cancel these jobs with |neomake#CancelJob|.
 
 It also accepts a third, optional callback argument that
 is called when the command exits.  The callback is given the following
@@ -344,8 +343,8 @@ dictionary as its sole argument: >
 *neomake#Sh* (command[, callback])
 This function is called by the |:NeomakeSh| command. It runs the specified
 shell *command* according to 'shell'. |neomake#Sh| returns the single job id
-that it created via 'jobstart' (or 0 on Vim); you can potentially cancel
-this job with |neomake#CancelJob|.
+that was created (-1 on Vim without asynchronous support);
+you can potentially cancel this job with |neomake#CancelJob|.
 
 It also accepts a second, optional callback argument that is called when
 the command exits. The callback is given the following dictionary as its
@@ -359,7 +358,7 @@ Invoked via |:NeomakeListJobs|. Echoes a list of running jobs in the format
 (job_id, job_name).
 
 *neomake#CancelJob*
-Invoked via |:NeomakeCancelJob|. Sends a 'jobstop' to the job id specified.
+Invoked via |:NeomakeCancelJob|. Terminate a job identified by its job_id
 Will trigger callback if it was specified when the job was started.
 Example: >
     let job_id = neomake#Sh("bash -c 'while true; do sleep 1; done'")
@@ -448,7 +447,7 @@ You can make quickfixsigns respect Neomake's signs using this option: >
 
 6.2 How to configure the makers to be used?~
 
-See |g:neomake_<ft>_enabled_makers| (press `K` on the link to go there).
+See |g:neomake_<ft>_enabled_makers| (press `<C-]>` on the link to go there).
 
 6.3 How to develop/debug the errorformat setting?~
 

--- a/tests/utils.vader
+++ b/tests/utils.vader
@@ -70,3 +70,26 @@ Execute(neomake#utils#redir):
   endif
   AssertEqual neomake#utils#redir(['NeomakeTestCommand', 'echon 3']), "\n1\n23"
   AssertThrows neomake#utils#redir(['NeomakeTestCommand', 'echoerr 3'])
+
+Execute (Should expand arguments that start with %):
+  let param1 = '%'
+  let param2 = '%:h'
+  let param3 = '--param1=%:h'
+  let args = [param1, param2, param3]
+  let expected_args = [expand(param1), expand(param2), param3]
+  call neomake#utils#ExpandArgs(args)
+  AssertEqual expected_args, args
+
+Execute (Should expand arguments that start with escape char \):
+  let param1 = '\%'
+  let param2 = '\%:p'
+  let args = [param1, param2]
+  let expected_args = [expand(param1), expand(param2)]
+  call neomake#utils#ExpandArgs(args)
+  AssertEqual expected_args, args
+
+Execute (Should not expand arguments that start with double %):
+  let args = ['%%:h', '%%']
+  let expected_args = ['%%:h', '%%']
+  call neomake#utils#ExpandArgs(args)
+  AssertEqual expected_args, args


### PR DESCRIPTION
Followup of https://github.com/neomake/neomake/pull/575.

The main hack being https://github.com/neomake/neomake/pull/636/commits/650d4562aac94e4198e3f3b397fa786b582cf7e4 probably, but other crucial things were changed, e.g. using "raw" mode to behave the same as Neovim does - for non-buffered output.

TODO
 - [x] refactor: https://github.com/neomake/neomake/pull/636#discussion_r80370397
 - [x] handle return value with sleep hack.  Add a test.