### PR TITLE
tests: allow for tests/vim/plugins/vader.override

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,21 +6,21 @@ test: testnvim testvim
 VADER?=Vader!
 VIM_ARGS='+$(VADER) tests/*.vader'
 
-VADER_DIR:=tests/vim/plugins/vader
-$(VADER_DIR):
+export TESTS_VADER_DIR:=$(firstword $(wildcard tests/vim/plugins/vader.override) tests/vim/plugins/vader)
+$(TESTS_VADER_DIR):
 	mkdir -p $(dir $@)
 	git clone --depth=1 https://github.com/junegunn/vader.vim $@
 
 TEST_VIMRC:=tests/vim/vimrc
 
 testnvim: TEST_VIM:=VADER_OUTPUT_FILE=/dev/stderr nvim --headless
-testnvim: $(VADER_DIR)
+testnvim: $(TESTS_VADER_DIR)
 testnvim: build/neovim-test-home
 	@# Neovim needs a valid HOME (https://github.com/neovim/neovim/issues/5277).
 	HOME=build/neovim-test-home $(TEST_VIM) -nNu $(TEST_VIMRC) -i NONE $(VIM_ARGS)
 	
 testvim: TEST_VIM:=vim -X
-testvim: $(VADER_DIR)
+testvim: $(TESTS_VADER_DIR)
 testvim:
 	HOME=/dev/null $(TEST_VIM) -nNu $(TEST_VIMRC) -i NONE $(VIM_ARGS)
 
@@ -98,7 +98,7 @@ docker_test: DOCKER_VIM:=vim-master
 docker_test: DOCKER_RUN:=$(DOCKER_VIM) '+$(VADER) tests/*.vader'
 docker_test: docker_run
 
-docker_run: $(VADER_DIR)
+docker_run: $(TESTS_VADER_DIR)
 docker_run:
 	$(DOCKER) $(if $(DOCKER_RUN),$(DOCKER_RUN),bash)
 

--- a/tests/vim/vimrc
+++ b/tests/vim/vimrc
@@ -5,7 +5,11 @@ if filereadable('/rtp.vim')
   " Dockerized tests.
   source /rtp.vim
 else
-  set runtimepath+=tests/vim/plugins/vader
+  if exists('$TESTS_VADER_DIR')
+    exe 'set runtimepath+='.$TESTS_VADER_DIR
+  else
+    set runtimepath+=tests/vim/plugins/vader
+  endif
   set runtimepath+=.
 endif
 


### PR DESCRIPTION
I've used a symlink before, but that conflicted with adding Docker
support, which did not resolve the symlink but added it as-is.

This makes it easier to hack on Vader from a local checkout.