### PR TITLE
Add golint as Warning instead of Error

### DIFF
--- a/autoload/neomake/makers/ft/go.vim
+++ b/autoload/neomake/makers/ft/go.vim
@@ -29,7 +29,7 @@ endfunction
 function! neomake#makers#ft#go#golint()
     return {
         \ 'errorformat':
-            \ '%f:%l:%c: %m,' .
+            \ '%W%f:%l:%c: %m,' .
             \ '%-G%.%#'
         \ }
 endfunction


### PR DESCRIPTION
According to golint the linter is giving style errors which imho should be considered as warnings instead of errors.

```
Golint differs from gofmt. Gofmt reformats Go source code, whereas golint prints out style mistakes.

Golint differs from govet. Govet is concerned with correctness, whereas golint is concerned with coding style. Golint is in use at Google, and it seeks to match the accepted style of the open source Go project.

The suggestions made by golint are exactly that: suggestions.```