### PR TITLE
fix the default error sign color

### DIFF
--- a/autoload/neomake/signs.vim
+++ b/autoload/neomake/signs.vim
@@ -235,8 +235,8 @@ function! neomake#signs#DefineHighlights() abort
 
     for [group, fgs] in items({
                 \ 'NeomakeErrorSign': [
-                \   neomake#utils#GetHighlight('Error', 'bg'),
-                \   neomake#utils#GetHighlight('Error', 'bg#')],
+                \   neomake#utils#GetHighlight('ErrorMsg', 'fg'),
+                \   neomake#utils#GetHighlight('ErrorMsg', 'fg#')],
                 \ 'NeomakeWarningSign': [
                 \   neomake#utils#GetHighlight('Todo', 'fg'),
                 \   neomake#utils#GetHighlight('Todo', 'fg#')],


### PR DESCRIPTION
use `fg` and `fg#` for NeomakeErrorSignDefault not `bg` and `bg#`