### PR TITLE
Allow stylelint in .scss

### DIFF
--- a/autoload/neomake/makers/ft/scss.vim
+++ b/autoload/neomake/makers/ft/scss.vim
@@ -1,7 +1,7 @@
 " vim: ts=4 sw=4 et
 
 function! neomake#makers#ft#scss#EnabledMakers() abort
-    return executable('sass-lint') ? ['sasslint'] : ['scsslint']
+    return executable('stylelint') ? ['stylelint'] : executable('sass-lint') ? ['sasslint'] : ['scsslint']
 endfunction
 
 function! neomake#makers#ft#scss#sasslint() abort
@@ -20,3 +20,8 @@ function! neomake#makers#ft#scss#scsslint() abort
         \ 'errorformat': '%A%f:%l:%v [%t] %m'
     \ }
 endfunction
+
+function! neomake#makers#ft#scss#stylelint() abort
+    return neomake#makers#ft#css#stylelint()
+endfunction
+


### PR DESCRIPTION
Stylelint (http://stylelint.io/) supports CSS, SCSS, and Less. In fact, it has more [rules](http://stylelint.io/user-guide/rules/), more [published configs](https://www.npmjs.com/search?q=stylelint-config), and even more GitHub stars compared to sass-lint—I would consider it a better-supported project than the alternatives.

This adds support for Stylelint in SCSS.
