### PR TITLE
Improve neomake#signs#DefineHighlights to switch bg/fg

### DIFF
--- a/autoload/neomake/signs.vim
+++ b/autoload/neomake/signs.vim
@@ -233,21 +233,22 @@ function! neomake#signs#DefineHighlights() abort
     let guibg = neomake#utils#GetHighlight('SignColumn', 'bg#')
     let bg = 'ctermbg='.ctermbg.' guibg='.guibg
 
-    for [group, fgs] in items({
-                \ 'NeomakeErrorSign': [
-                \   neomake#utils#GetHighlight('Error', 'bg'),
-                \   neomake#utils#GetHighlight('Error', 'bg#')],
-                \ 'NeomakeWarningSign': [
-                \   neomake#utils#GetHighlight('Todo', 'fg'),
-                \   neomake#utils#GetHighlight('Todo', 'fg#')],
-                \ 'NeomakeInfoSign': [
-                \   neomake#utils#GetHighlight('Question', 'fg'),
-                \   neomake#utils#GetHighlight('Question', 'fg#')],
-                \ 'NeomakeMessageSign': [
-                \   neomake#utils#GetHighlight('ModeMsg', 'fg'),
-                \   neomake#utils#GetHighlight('ModeMsg', 'fg#')],
+    for [group, fg_from] in items({
+                \ 'NeomakeErrorSign': ['Error', 'bg'],
+                \ 'NeomakeWarningSign': ['Todo', 'fg'],
+                \ 'NeomakeInfoSign': ['Question', 'fg'],
+                \ 'NeomakeMessageSign': ['ModeMsg', 'fg']
                 \ })
-        let [ctermfg, guifg] = fgs
+        let [fg_group, fg_attr] = fg_from
+        let ctermfg = neomake#utils#GetHighlight(fg_group, fg_attr)
+        let guifg = neomake#utils#GetHighlight(fg_group, fg_attr.'#')
+        " Ensure that we're not using SignColumn bg as fg (as with gotham
+        " colorscheme, issue https://github.com/neomake/neomake/pull/659).
+        if ctermfg == ctermbg && guifg == guibg
+            let fg_attr = neomake#utils#ReverseSynIDattr(fg_attr)
+            let ctermfg = neomake#utils#GetHighlight(fg_group, fg_attr)
+            let guifg = neomake#utils#GetHighlight(fg_group, fg_attr.'#')
+        endif
         exe 'hi '.group.'Default ctermfg='.ctermfg.' guifg='.guifg.' '.bg
         if !neomake#signs#HlexistsAndIsNotCleared(group)
             exe 'hi link '.group.' '.group.'Default'

--- a/autoload/neomake/utils.vim
+++ b/autoload/neomake/utils.vim
@@ -220,15 +220,7 @@ function! neomake#utils#GetHighlight(group, what) abort
   let reverse = synIDattr(synIDtrans(hlID(a:group)), 'reverse')
   let what = a:what
   if reverse
-    if what ==# 'fg'
-      let what = 'bg'
-    elseif what ==# 'bg'
-      let what = 'fg'
-    elseif what ==# 'fg#'
-      let what = 'bg#'
-    elseif what ==# 'bg#'
-      let what = 'fg#'
-    endif
+    let what = neomake#utils#ReverseSynIDattr(what)
   endif
   if what[-1:] ==# '#'
       let val = synIDattr(synIDtrans(hlID(a:group)), what, 'gui')
@@ -239,6 +231,19 @@ function! neomake#utils#GetHighlight(group, what) abort
     let val = 'NONE'
   endif
   return val
+endfunction
+
+function! neomake#utils#ReverseSynIDattr(attr) abort
+  if a:attr ==# 'fg'
+    return 'bg'
+  elseif a:attr ==# 'bg'
+    return 'fg'
+  elseif a:attr ==# 'fg#'
+    return 'bg#'
+  elseif a:attr ==# 'bg#'
+    return 'fg#'
+  endif
+  return a:attr
 endfunction
 
 function! neomake#utils#CompressWhitespace(entry) abort

--- a/doc/neomake.txt
+++ b/doc/neomake.txt
@@ -297,7 +297,7 @@ Neomake uses the following defaults: >
 <
 
 Default 'texthl' groups are created with those names, but only if they do not
-exist already.  This allows you to customize them.  This should typically be
+exist already, which allows you to customize them.  This should typically be
 done through the |ColorScheme| autoevent, which applies it after any color
 scheme: >
 


### PR DESCRIPTION
If e.g. "Error" is defined to have red for the fg (as with the gotham
theme (https://github.com/whatyouhide/vim-gotham/issues/27)), then
switch the "fg"/"bg" attributes.

Fixes https://github.com/neomake/neomake/pull/659.