### PR TITLE
Call neomake#signs#DefineHighlights on VimEnter

### DIFF
--- a/plugin/neomake.vim
+++ b/plugin/neomake.vim
@@ -17,8 +17,7 @@ augroup neomake
   au!
   au WinEnter,CursorHold * call neomake#ProcessCurrentWindow()
   au CursorMoved * call neomake#CursorMoved()
-  au ColorScheme * call neomake#signs#DefineHighlights()
+  au ColorScheme,VimEnter * call neomake#signs#DefineHighlights()
 augroup END
-call neomake#signs#DefineHighlights()
 
 " vim: sw=2 et


### PR DESCRIPTION
Doing in the plugin file directly seems unclean, but only doing it for
ColorScheme will not be triggered for the `:colorscheme` in a vimrc.