### PR TITLE
Adds c clang-tools to cpp makers

### DIFF
--- a/autoload/neomake/makers/ft/cpp.vim
+++ b/autoload/neomake/makers/ft/cpp.vim
@@ -1,7 +1,7 @@
 " vim: ts=4 sw=4 et
 
 function! neomake#makers#ft#cpp#EnabledMakers()
-    return executable('clang++') ? ['clang'] : ['gcc']
+    return executable('clang++') ? ['clang', 'clangtidy', 'clangcheck'] : ['gcc']
 endfunction
 
 function! neomake#makers#ft#cpp#clang()


### PR DESCRIPTION
These checkers should be enabled by default for C++ files as well as C files