### PR TITLE
Do not add jobid to QuietMessage for "completed with"

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -717,8 +717,8 @@ function! neomake#MakeHandler(job_id, data, event_type) abort
         if has('nvim')
             " Only report completion for neovim, since it is asynchronous
             call neomake#utils#QuietMessage(printf(
-                        \ '[#%d] %s: completed with exit code %d.',
-                        \ jobinfo.id, maker.name, status))
+                        \ '%s: completed with exit code %d.',
+                        \ maker.name, status))
         endif
 
         " If signs were not cleared before this point, then the maker did not return

--- a/tests/neomake.vader
+++ b/tests/neomake.vader
@@ -72,8 +72,7 @@ Execute (Reports exit status):
     let job_id = neomake#Sh("sh -c 'exit 7'")
     NeomakeTestsWaitForFinishedJobs
 
-    let msg = printf('[#%d] sh: sh -c ''exit 7'': completed with exit code 7.', job_id)
-    AssertNeomakeMessage msg, 1
+    AssertNeomakeMessage 'sh: sh -c ''exit 7'': completed with exit code 7.', 1
 
     let msg = printf('[#%d] exit: sh: sh -c ''exit 7'': 7', job_id)
     AssertNeomakeMessage msg, 3


### PR DESCRIPTION
This gets displayed by default and the job id is not relevant and rather
confusing there.