### PR TITLE
sort javascript makers, add ternlint maker

### DIFF
--- a/autoload/neomake/makers/ft/javascript.vim
+++ b/autoload/neomake/makers/ft/javascript.vim
@@ -1,24 +1,14 @@
 " vim: ts=4 sw=4 et
 
-function! neomake#makers#ft#javascript#EnabledMakers()
-    return ['jshint', 'jscs', 'eslint']
+function! neomake#makers#ft#javascript#EnabledMakers() abort
+    return ['eslint', 'jshint']
 endfunction
 
-function! neomake#makers#ft#javascript#jshint()
-    return {
-        \ 'args': ['--verbose'],
-        \ 'errorformat': '%A%f: line %l\, col %v\, %m \(%t%*\d\)',
-        \ }
-endfunction
+" ============================================================================
+" Makers sorted alphabetically
+" ============================================================================
 
-function! neomake#makers#ft#javascript#jscs()
-    return {
-        \ 'args': ['--no-colors', '--reporter', 'inline'],
-        \ 'errorformat': '%E%f: line %l\, col %c\, %m',
-        \ }
-endfunction
-
-function! neomake#makers#ft#javascript#eslint()
+function! neomake#makers#ft#javascript#eslint() abort
     return {
         \ 'args': ['-f', 'compact'],
         \ 'errorformat': '%E%f: line %l\, col %c\, Error - %m,' .
@@ -26,7 +16,7 @@ function! neomake#makers#ft#javascript#eslint()
         \ }
 endfunction
 
-function! neomake#makers#ft#javascript#eslint_d()
+function! neomake#makers#ft#javascript#eslint_d() abort
     return {
         \ 'args': ['-f', 'compact'],
         \ 'errorformat': '%E%f: line %l\, col %c\, Error - %m,' .
@@ -34,13 +24,7 @@ function! neomake#makers#ft#javascript#eslint_d()
         \ }
 endfunction
 
-function! neomake#makers#ft#javascript#standard()
-    return {
-        \ 'errorformat': '%E%f:%l:%c: %m'
-        \ }
-endfunction
-
-function! neomake#makers#ft#javascript#flow()
+function! neomake#makers#ft#javascript#flow() abort
     " Replace "\n" by space.
     let mapexpr = 'substitute(v:val, "\\\\n", " ", "g")'
     return {
@@ -50,7 +34,47 @@ function! neomake#makers#ft#javascript#flow()
         \ }
 endfunction
 
-function! neomake#makers#ft#javascript#xo()
+function! neomake#makers#ft#javascript#jshint() abort
+    return {
+        \ 'args': ['--verbose'],
+        \ 'errorformat': '%A%f: line %l\, col %v\, %m \(%t%*\d\)',
+        \ }
+endfunction
+
+function! neomake#makers#ft#javascript#jscs() abort
+    return {
+        \ 'args': ['--no-colors', '--reporter', 'inline'],
+        \ 'errorformat': '%E%f: line %l\, col %c\, %m',
+        \ }
+endfunction
+
+function! neomake#makers#ft#javascript#standard() abort
+    return {
+        \ 'errorformat': '%E%f:%l:%c: %m'
+        \ }
+endfunction
+
+" Requires tern-lint npm module >= 1.0.0
+" so `npm install -g tern-lint`
+function! neomake#makers#ft#javascript#ternlint() abort
+    let l:tern_pattern = '\([^:]\+:\)\([^:]\+\)\(.*\)'
+    let l:tern_replace = '\=submatch(1) . byte2line(submatch(2)) . submatch(3) . " [tern-lint]"'
+    let l:tern_mapexpr = 'substitute('
+          \.   'v:val, '
+          \.   "'" . l:tern_pattern . "', "
+          \.   "'" . l:tern_replace . "', "
+          \.   "''"
+          \. ')'
+    return {
+        \ 'exe':          'tern-lint',
+        \ 'args':         [ '--format=vim' ],
+        \ 'mapexpr':      l:tern_mapexpr,
+        \ 'errorformat':  '%f:%l: %trror: %m,'
+        \               . '%f:%l: %tarning: %m',
+        \ }
+endfunction
+
+function! neomake#makers#ft#javascript#xo() abort
     return {
         \ 'args': ['--compact'],
         \ 'errorformat': '%E%f: line %l\, col %c\, Error - %m,' .

--- a/autoload/neomake/makers/ft/javascript.vim
+++ b/autoload/neomake/makers/ft/javascript.vim
@@ -1,7 +1,7 @@
 " vim: ts=4 sw=4 et
 
 function! neomake#makers#ft#javascript#EnabledMakers() abort
-    return ['eslint', 'jshint']
+    return ['eslint', 'jscs', 'jshint', 'ternlint']
 endfunction
 
 " ============================================================================


### PR DESCRIPTION
- FIX: #287 -- add tern-lint support as the `ternlint` maker
- CHANGED: sort javascript makers alphabetically (there's no logic currently)
- CHANGED: add `ternlint` maker to default makers

blocked by https://github.com/angelozerr/tern-lint/issues/76