### PR TITLE
Fix tcd changing dir

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -173,9 +173,10 @@ function! s:MakeJob(make_id, options) abort
     let cwd = get(maker, 'cwd', s:make_info[a:make_id].cwd)
     if len(cwd)
         let old_wd = getcwd()
+        let cd = haslocaldir() ? 'lcd' : (exists(':tcd') == 2 && haslocaldir(-1, 0)) ? 'tcd' : 'cd'
         let cwd = expand(cwd, 1)
         try
-            exe 'cd' fnameescape(cwd)
+            exe cd fnameescape(cwd)
         " Tests fail with E344, but in reality it is E472?!
         " If uncaught, both are shown.  Let's just catch every error here.
         catch
@@ -265,8 +266,8 @@ function! s:MakeJob(make_id, options) abort
             let r = -1
         endif
     finally
-        if exists('old_wd')
-            exe 'cd' fnameescape(old_wd)
+        if exists('cd') && exists('old_wd')
+            exe cd fnameescape(old_wd)
         endif
     endtry
     return r

--- a/tests/cwd-tcd.vader
+++ b/tests/cwd-tcd.vader
@@ -1,0 +1,49 @@
+Include: include/setup.vader
+
+Before:
+  NeomakeTestsGlobalBefore
+
+  if exists(':tcd') != 2
+    Log 'SKIP: no :tcd'
+  else
+    let sleep_maker = NeomakeTestsCommandMaker('sleep-maker', 'sleep .05')
+
+    for d in ['build/path1', 'build/path2']
+      if !isdirectory(d)
+        call mkdir(d, 'p')
+      endif
+    endfor
+
+    tabnew
+    let tab1 = tabpagenr()
+    tcd build/path1
+    let dir1 = getcwd()
+
+    tabnew
+    tcd ../../build/path2
+    let tab2 = tabpagenr()
+    let dir2 = getcwd()
+  endif
+
+After:
+  NeomakeTestsGlobalAfter
+
+  if exists('tab1')
+    exe 'tabclose' tab1
+    exe 'tabclose' tab2
+    unlet! tab1 tab2 dir1 dir2
+  endif
+
+Execute (tcd is handled properly):
+  if exists(':tcd') == 2
+    call neomake#Make(1, [g:sleep_maker])
+
+    exe 'tabnext' tab1
+    AssertEqual dir1, getcwd()
+    call neomake#Make(1, [g:sleep_maker])
+
+    exe 'tabnext' tab2
+    AssertEqual dir2, getcwd()
+
+    NeomakeTestsWaitForRemovedJobs
+  endif

--- a/tests/neomake.vader
+++ b/tests/neomake.vader
@@ -33,6 +33,9 @@ Include (Css): ft_css.vader
 Include (Idris): ft_idris.vader
 Include (Vim): ft_vim.vader
 
+~ Regression tests
+Include (cwd: tcd): cwd-tcd.vader
+
 * Old/unorganized tests
 Execute (neomake#GetMakers):
   AssertEqual neomake#GetMakers('non-existent'), []
@@ -278,7 +281,8 @@ Execute (neomake#Make handles invalid cwd):
       \ }
   call neomake#Make(1, [maker])
   NeomakeTestsWaitForFinishedJobs
-  AssertNeomakeMessage "custom_maker: could not change to maker's cwd (/doesnotexist): Vim(cd):E344: Can't find directory \"/doesnotexist\" in cdpath", 0
+  let cd = exists(':tcd') ? 'tcd' : 'cd'
+  AssertNeomakeMessage "custom_maker: could not change to maker's cwd (/doesnotexist): Vim(".cd."):E344: Can't find directory \"/doesnotexist\" in cdpath", 0
 
 Execute (Neomake picks up custom maker correctly):
   let g:neomake_c_lint_maker = {


### PR DESCRIPTION
This way the `tcd` won't be overriden to a `cd`, messing with tab-local directory settings.
