### PR TITLE
Disable vim8 sleep-hack for Windows

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -143,7 +143,7 @@ function! s:MakeJob(make_id, maker) abort
                 " hopefully not necessary anymore and b) might be needed in
                 " real usage, too.
                 " Fix: https://groups.google.com/d/msg/vim_dev/LhXQJusQScM/_wV4u5y5AAAJ
-                if !has('nvim')
+                if !has('nvim') && !neomake#utils#IsRunningWindows()
                     let argv = ['/bin/sh', '-c', 'sleep .05 & '.join(map(argv, 'shellescape(v:val)'))]
                 endif
                 let job = job_start(argv, {


### PR DESCRIPTION
The "sh -c" wrapper does not work there like it is, and might not be an
issue in normal (non-test) use cases.  Should be fixed by some Vim patch
anyway soon.

Ref: https://www.reddit.com/r/vim/comments/56jall/neomake_async_make_linting_framework_supports_vim/d8knvud.