### PR TITLE
Vim-async: cherry-pick sleep hack for neomake#CancelJob

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -37,6 +37,11 @@ function! neomake#CancelJob(job_id) abort
         if has('nvim')
             call jobstop(a:job_id)
         else
+            " HACK: Vim might fail to stop a job right away.
+            " So let's just wait a bit, which is OK since this is not really
+            " a user facing function anyway.
+            " https://github.com/vim/vim/issues/1155
+            sleep 50m
             call job_stop(s:jobs[a:job_id].vim_job)
         endif
         return 1


### PR DESCRIPTION
This causes spurious build failures.

> HACK: Vim might fail to stop a job right away.
> So let's just wait a bit, which is OK since this is not really
> a user facing function anyway.
> https://github.com/vim/vim/issues/1155

From: https://github.com/neomake/neomake/pull/697.