### PR TITLE
Fix overwriting errorformat in MakerFromCommand

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -927,6 +927,7 @@ function! neomake#ShCommand(bang, sh_command, ...) abort
     let maker = neomake#utils#MakerFromCommand(a:sh_command)
     let maker.name = 'sh: '.a:sh_command
     let maker.buffer_output = !a:bang
+    let maker.errorformat = '%m'
     if a:0
         call extend(maker, a:1)
     endif

--- a/autoload/neomake/utils.vim
+++ b/autoload/neomake/utils.vim
@@ -153,7 +153,6 @@ function! neomake#utils#MakerFromCommand(command) abort
         \ 'exe': &shell,
         \ 'args': [&shellcmdflag, command],
         \ 'remove_invalid_entries': 0,
-        \ 'errorformat': '%+G',
         \ }
 endfunction
 

--- a/tests/integration.vader
+++ b/tests/integration.vader
@@ -107,11 +107,29 @@ Execute (Neomake: handle output for removed window):
 
 Execute (NeomakeSh: true):
   call g:NeomakeSetupAutocmdWrappers()
+  AssertEqual g:neomake_test_countschanged, []
   let bufnr = bufnr('%')
   RunNeomakeSh true
   AssertEqual g:neomake_test_countschanged, [{'bufnr': bufnr, 'file_mode': 0}]
   AssertEqual len(g:neomake_test_finished), 1
   AssertEqual getqflist(), []
+
+  call g:NeomakeSetupAutocmdWrappers()
+  RunNeomakeSh true
+  AssertEqual g:neomake_test_countschanged, []
+  AssertEqual len(g:neomake_test_finished), 1
+  AssertEqual getqflist(), []
+
+Execute (NeomakeSh: echo foo):
+  call g:NeomakeSetupAutocmdWrappers()
+  AssertEqual g:neomake_test_countschanged, []
+  let bufnr = bufnr('%')
+  RunNeomakeSh echo foo
+  AssertEqual getqflist(),
+    \ [{'lnum': 0, 'bufnr': 0, 'col': 0, 'valid': 1, 'vcol': 0, 'nr': -1,
+    \   'type': '', 'pattern': '', 'text': 'foo'}]
+  AssertEqual len(g:neomake_test_finished), 1
+  AssertEqual g:neomake_test_countschanged, [{'bufnr': bufnr, 'file_mode': 0}]
 
 Execute (NeomakeSh: non-existing command):
   call g:NeomakeSetupAutocmdWrappers()

--- a/tests/neomake.vader
+++ b/tests/neomake.vader
@@ -11,6 +11,12 @@ Execute (neomake#GetMaker with non-existent maker prints errors):
   AssertEqual neomake#GetMaker('nonexistent'), {}
   AssertEqual g:neomake_test_messages[-1], [0, 'Maker not found: nonexistent']
 
+Execute (neomake#GetMaker: uses defined errorformat):
+  let maker = neomake#GetMaker('makeprg', '')
+  AssertEqual maker, {'name': 'makeprg', 'ft': '', 'args': ['-c', 'make'],
+    \ 'errorformat': &errorformat,
+    \ 'exe': &shell, 'remove_invalid_entries': 0, 'buffer_output': 1}
+
 Execute (neomake#GetMaker uses defaults from b:/g:):
   Save g:neomake_test_remove_invalid_entries
 


### PR DESCRIPTION
Use "%m" instead with neomake#ShCommand, which makes all entries valid
there additionally.

Fixes https://github.com/neomake/neomake/issues/715