### PR TITLE
Dockerfile.tests: build vim-master separately

### DIFF
--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -1,22 +1,23 @@
 # From https://github.com/tweekmonster/vim-testbed.
 FROM testbed/vim:latest
 
+# Install make and openssl for docker_vimhelplint.
+# openssl for https support with wget.
+RUN apk --update add make openssl \
+    && rm -rf /var/cache/apk/* /tmp/* /var/tmp/*
+
 # Currently tested versions:
 #  - v7.3.429 (Ubuntu Precise, 12.04LTS; same as on Travis currently)
 #  - v7.4.052 (Ubuntu Trusty, 14.04LTS)
 #  - v7.4.1689 (Ubuntu Xenial, 16.04LTS)
 #  - v8.0.0000 (Vim 8, for reference)
 #  - v8.0.0027 (Vim 8, real async support)
-#  - Git master
+RUN install_vim \
+        -tag v7.3.429 -name vim73 -build \
+        -tag v7.4.052 -name vim74-trusty -build \
+        -tag v7.4.1689 -name vim74-xenial -build \
+        -tag v8.0.0000 -name vim8000 -build \
+        -tag v8.0.0027 -name vim8027 -build
 
-RUN install_vim -tag v7.3.429 -name vim73 -build \
-                -tag v7.4.052 -name vim74-trusty -build \
-                -tag v7.4.1689 -name vim74-xenial -build \
-                -tag v8.0.0000 -name vim8000 -build \
-                -tag v8.0.0027 -name vim8027 -build \
-                -tag master -build
-
-# Install make and openssl for docker_vimhelplint.
-# openssl for https support with wget.
-RUN apk --update add make openssl \
-    && rm -rf /var/cache/apk/* /tmp/* /var/tmp/*
+# Git master in a separate layer, since the above is meant to be stable.
+RUN install_vim -tag master -name vim-master -build


### PR DESCRIPTION
While this removes and installs build deps twice on a clean run, it
helps when only updating master.

In the long run there should be a separate Dockerfile for vim-master
probably, and this should be moved to the vim-testbed repo probably.