### PR TITLE
Use debug level for '%s: completed with exit code %d.' messages

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -818,7 +818,7 @@ function! neomake#MakeHandler(job_id, data, event_type) abort
         endif
         call s:CleanJobinfo(jobinfo)
         if neomake#has_async_support()
-            call neomake#utils#QuietMessage(printf(
+            call neomake#utils#DebugMessage(printf(
                         \ '%s: completed with exit code %d.',
                         \ maker.name, status))
         endif

--- a/tests/_setup.vader
+++ b/tests/_setup.vader
@@ -84,6 +84,7 @@ Execute:
             throw printf("Got unexpected value for jobinfo.%s: "
               \  ."expected '%s', but got '%s'.", k, string(expected), string(v))
           endif
+          unlet v  " for old Vim
         endfor
       endif
       return 1

--- a/tests/_setup.vader
+++ b/tests/_setup.vader
@@ -58,7 +58,7 @@ Execute:
   function! s:AssertNeomakeMessage(msg, ...)
     let level = a:0 ? a:1 : -1
     let jobinfo = a:0 > 1 ? a:2 : -1
-    let found_but_other_level = 0
+    let found_but_other_level = -1
     let r = 0
     for [l, m, info] in g:neomake_test_messages
       if m ==# a:msg
@@ -70,7 +70,7 @@ Execute:
             let r = 1
             break
           else
-            let found_but_other_level = 1
+            let found_but_other_level = l
           endif
         endif
       endif
@@ -89,8 +89,8 @@ Execute:
       endif
       return 1
     endif
-    if found_but_other_level
-      throw "Message '".a:msg."' found, but not for level ".level
+    if found_but_other_level != -1
+      throw "Message '".a:msg."' found, but for level ".found_but_other_level
     endif
     throw "Message '".a:msg."' not found: ".string(g:neomake_test_messages)
   endfunction

--- a/tests/integration.vader
+++ b/tests/integration.vader
@@ -110,7 +110,7 @@ Execute (NeomakeSh: non-existing command):
   AssertEqual g:neomake_test_countschanged, [{'file_mode': 0, 'bufnr': bufnr('%')}]
   AssertEqual len(getqflist()), 1
   if neomake#has_async_support()
-    AssertNeomakeMessage 'sh: ''nonexistingcommand'': completed with exit code 127.', 1, {}
+    AssertNeomakeMessage 'sh: ''nonexistingcommand'': completed with exit code 127.', 3, {}
   endif
   AssertNeomakeMessage "exit: sh: 'nonexistingcommand': 127", 3
   AssertNotEqual match(getqflist()[0].text,

--- a/tests/neomake.vader
+++ b/tests/neomake.vader
@@ -78,21 +78,26 @@ Execute (neomake#CancelJob):
     AssertEqual neomake#CancelJob(job_id), 0
   endif
 
-Execute (Reports exit status):
+Execute (Reports exit status: 7):
+  let job_id = neomake#Sh("sh -c 'exit 7'")
   if neomake#has_async_support()
-    let job_id = neomake#Sh("sh -c 'exit 7'")
     let jobinfo = neomake#GetJobs()[job_id]
     NeomakeTestsWaitForFinishedJobs
-
-    AssertNeomakeMessage 'sh: sh -c ''exit 7'': completed with exit code 7.', 1, jobinfo
-    AssertNeomakeMessage 'exit: sh: sh -c ''exit 7'': 7', 3, jobinfo
+    AssertNeomakeMessage 'sh: sh -c ''exit 7'': completed with exit code 7.', 3, jobinfo
+  else
+    let jobinfo = {}
   endif
+  AssertNeomakeMessage 'exit: sh: sh -c ''exit 7'': 7', 3, jobinfo
 
 Execute (neomake#Sh: job_id):
   let job_id = neomake#Sh('true')
   if neomake#has_async_support()
     Assert job_id >= 0, 'Correct job_id for async.'
+    let jobinfo = neomake#GetJobs()[job_id]
     NeomakeTestsWaitForFinishedJobs
+    AssertNeomakeMessage 'sh: true: completed with exit code 0.', 3
   else
     Assert job_id == -1, 'Correct job_id for sync.'
+    let jobinfo = {}
   endif
+  AssertNeomakeMessage 'exit: sh: true: 0', 3, jobinfo


### PR DESCRIPTION
Fixes https://github.com/neomake/neomake/issues/238.
