### PR TITLE
Execute mapexpr in ProcessJobOutput for the buffer context

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,9 @@ CDPATH:=
 
 test: testnvim testvim
 
+# This is expected in tests.
+export SHELL:=/bin/bash
+
 VADER:=Vader!
 VADER_ARGS:=tests/*.vader
 VIM_ARGS='+$(VADER) $(VADER_ARGS)'
@@ -28,7 +31,7 @@ testvim: TEST_VIM_PREFIX+=HOME=/dev/null
 testvim: _run_vim
 
 _REDIR_STDOUT:=>/dev/null
-_run_vim: $(TESTS_VADER_DIR)
+_run_vim: | build $(TESTS_VADER_DIR)
 _run_vim:
 	$(TEST_VIM_PREFIX) $(TEST_VIM) -u $(TEST_VIMRC) -i NONE $(VIM_ARGS) $(_REDIR_STDOUT)
 
@@ -129,8 +132,8 @@ $(_DOCKER_VIM_TARGETS):
 
 docker_test: DOCKER_VIM:=vim-master
 docker_test: DOCKER_STREAMS:=-a stderr
-docker_test: DOCKER_RUN:=$(DOCKER_VIM) $(VIM_ARGS)
-docker_test: docker_run
+docker_test: DOCKER_MAKE_TARGET:=testvim TEST_VIM=/vim-build/bin/$(DOCKER_VIM) VIM_ARGS="$(VIM_ARGS)"
+docker_test: docker_make
 
 docker_run: $(TESTS_VADER_DIR)
 docker_run:

--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -643,11 +643,21 @@ function! s:neomake_hook(event, context) abort
     endif
 endfunction
 
-function! s:ProcessJobOutput(jobinfo, lines) abort
+function! s:ProcessJobOutput(jobinfo, lines, source) abort
     let maker = a:jobinfo.maker
     call neomake#utils#DebugMessage(printf(
                 \ '%s: processing %d lines of output.',
                 \ maker.name, len(a:lines)), a:jobinfo)
+
+    if has_key(maker, 'mapexpr')
+        if maker.file_mode
+            let l:neomake_bufname = bufname(maker.bufnr)
+            let l:neomake_bufdir = fnamemodify(neomake_bufname, ':h')
+        endif
+        let l:neomake_output_source = a:source
+        call map(a:lines, maker.mapexpr)
+    endif
+
     let olderrformat = &errorformat
     let &errorformat = maker.errorformat
     try
@@ -679,7 +689,7 @@ function! neomake#ProcessCurrentWindow() abort
     if len(outputs)
         unlet w:neomake_jobs_output
         for output in outputs
-            call s:ProcessJobOutput(output.jobinfo, output.lines)
+            call s:ProcessJobOutput(output.jobinfo, output.lines, output.source)
         endfor
         call neomake#signs#PlaceVisibleSigns()
     endif
@@ -697,15 +707,12 @@ function! s:GetTabWinForJob(job_id) abort
     return [-1, -1]
 endfunction
 
-function! s:RegisterJobOutput(jobinfo, lines) abort
+function! s:RegisterJobOutput(jobinfo, lines, source) abort
     let lines = copy(a:lines)
     let maker = a:jobinfo.maker
-    if has_key(maker, 'mapexpr')
-        let lines = map(lines, maker.mapexpr)
-    endif
 
     if !get(maker, 'file_mode')
-        return s:ProcessJobOutput(a:jobinfo, lines)
+        return s:ProcessJobOutput(a:jobinfo, lines, a:source)
     endif
 
     " file mode: append lines to jobs's window's output.
@@ -715,8 +722,9 @@ function! s:RegisterJobOutput(jobinfo, lines) abort
         return
     endif
     let w_output = s:gettabwinvar(t, w, 'neomake_jobs_output', []) + [{
-          \ 'jobinfo': a:jobinfo,
-          \ 'lines': lines }]
+                \ 'source': a:source,
+                \ 'jobinfo': a:jobinfo,
+                \ 'lines': lines }]
     call settabwinvar(t, w, 'neomake_jobs_output', w_output)
 
     " Process the window on demand if we can.
@@ -764,34 +772,40 @@ function! neomake#MakeHandler(job_id, data, event_type) abort
         let last_event_type = get(jobinfo, 'event_type', a:event_type)
         let jobinfo.event_type = a:event_type
 
-        " a:data is a List of 'lines' read. Each element *after* the first
-        " element represents a newline
-        if has_key(jobinfo, 'lines')
+        " a:data is a list of 'lines' read. Each element *after* the first
+        " element represents a newline.
+        if has_key(jobinfo, a:event_type)
+            let lines = jobinfo[a:event_type]
             " As per https://github.com/neovim/neovim/issues/3555
-            let jobinfo.lines = jobinfo.lines[:-2]
-                        \ + [jobinfo.lines[-1] . get(a:data, 0, '')]
+            let jobinfo[a:event_type] = lines[:-2]
+                        \ + [lines[-1] . get(a:data, 0, '')]
                         \ + a:data[1:]
         else
-            let jobinfo.lines = a:data
+            let jobinfo[a:event_type] = a:data
         endif
 
         if !maker.buffer_output || last_event_type !=# a:event_type
-            let lines = jobinfo.lines[:-2]
+            let lines = jobinfo[a:event_type][:-2]
             if len(lines)
-                call s:RegisterJobOutput(jobinfo, lines)
+                call s:RegisterJobOutput(jobinfo, lines, a:event_type)
             endif
-            let jobinfo.lines = jobinfo.lines[-1:]
+            let jobinfo[a:event_type] = jobinfo[a:event_type][-1:]
         endif
     elseif a:event_type ==# 'exit'
         " Handle any unfinished lines from stdout/stderr callbacks.
-        if has_key(jobinfo, 'lines')
-            if len(jobinfo.lines) && jobinfo.lines[-1] ==# ''
-                call remove(jobinfo.lines, -1)
+        for event_type in ['stdout', 'stderr']
+            if has_key(jobinfo, event_type)
+                let lines = jobinfo[event_type]
+                if len(lines)
+                    if lines[-1] ==# ''
+                        call remove(lines, -1)
+                    endif
+                    if len(lines)
+                        call s:RegisterJobOutput(jobinfo, lines, event_type)
+                    endif
+                endif
             endif
-            if len(jobinfo.lines)
-                call s:RegisterJobOutput(jobinfo, jobinfo.lines)
-            endif
-        endif
+        endfor
 
         let status = a:data
         if has_key(maker, 'exit_callback')

--- a/autoload/neomake/makers/ft/go.vim
+++ b/autoload/neomake/makers/ft/go.vim
@@ -16,7 +16,7 @@ function! neomake#makers#ft#go#go()
         \ ],
         \ 'append_file': 0,
         \ 'cwd': '%:h',
-        \ 'mapexpr': 'expand("%:h") . "/" . v:val',
+        \ 'mapexpr': 'neomake_bufdir . "/" . v:val',
         \ 'errorformat':
             \ '%W%f:%l: warning: %m,' .
             \ '%E%f:%l:%c:%m,' .
@@ -40,7 +40,7 @@ function! neomake#makers#ft#go#govet()
         \ 'args': ['vet'],
         \ 'append_file': 0,
         \ 'cwd': '%:h',
-        \ 'mapexpr': 'expand("%:h") . "/" . v:val',
+        \ 'mapexpr': 'neomake_bufdir . "/" . v:val',
         \ 'errorformat':
             \ '%Evet: %.%\+: %f:%l:%c: %m,' .
             \ '%W%f:%l: %m,' .

--- a/doc/neomake.txt
+++ b/doc/neomake.txt
@@ -95,10 +95,10 @@ a dictionary with an expected entry `fn` (which has to be a function).
 The function must return a string, and the function will be called with no
 arguments.
 
-In the above example, the exe argument isn't strictly necessary, since neomake
+In the above example, the exe argument isn't strictly necessary, since Neomake
 uses the name of the maker as the default value for it.  If you want it to be
-usable on an individual file, you should also include the filetype in the name:
->
+usable on an individual file, you should also include the filetype in the
+name: >
     let g:neomake_c_lint_maker = {
         \ 'exe': 'lint',
         \ 'args': ['--option', 'x'],
@@ -152,8 +152,8 @@ argument like so: >
 
 The following variables are available in the `mapexpr`:
 
- - `neomake_output_source`: either `'stderr'` or `'stdout'`, depending on
-   where the output is coming from.  This will be `'stdout'` always for
+ - `neomake_output_source`: either "stderr" or "stdout", depending on
+   where the output is coming from.  This will be "stdout" always for
    non-async Vim.
  - `neomake_bufname` and `neomake_bufdir`: the buffer's name (|bufname()|) and
    directory, respectively.  This is only set in file mode.

--- a/doc/neomake.txt
+++ b/doc/neomake.txt
@@ -140,6 +140,7 @@ This can be useful for makers that are filetype dependent but are typically
 run on an whole project rather than a specific file.
 
                                                    *neomake-makers-processing*
+                                                      *neomake-makers-mapexpr*
 You can define two optional properties on a maker object to process the maker
 output: `mapexpr` is applied to the maker output before any processing, and
 `postprocess` is applied to the quickfix or location list entry.
@@ -148,9 +149,23 @@ The `mapexpr` property will be passed directly into |map()| as the expr
 argument like so: >
     call map(lines, maker.mapexpr)
 <where `lines` contains the maker output.
-This allows you to manipulate the lines as needed. Currently this is called
-on stdout and stderr lines alike.
 
+The following variables are available in the `mapexpr`:
+
+ - `neomake_output_source`: either `'stderr'` or `'stdout'`, depending on
+   where the output is coming from.  This will be `'stdout'` always for
+   non-async Vim.
+ - `neomake_bufname` and `neomake_bufdir`: the buffer's name (|bufname()|) and
+   directory, respectively.  This is only set in file mode.
+
+The `mapexpr` itself is being evaluated in the context of the affected buffer
+in file mode, and in the context of the buffer that is current when the maker
+finished otherwise.
+
+The following `mapexpr` could be used to prefix the output type: >
+    "printf('[%s] %s', neomake_output_source, v:val)"
+<
+                                                  *neomake-makers-postprocess*
 The `postprocess` property is a function reference that will be applied to the
 entry in the location or quickfix list.
 Example: change the entry type to a warning. >

--- a/tests/_setup.vader
+++ b/tests/_setup.vader
@@ -77,9 +77,13 @@ Execute:
     endfor
     if r == 1
       if type(jobinfo) == type({})
+        let l:UNDEF = {}
         for [k, v] in items(info)
-          let expected = get(jobinfo, k)
-          AssertEqual v, expected, "Correct value for jobinfo.".k
+          let expected = get(jobinfo, k, l:UNDEF)
+          if expected isnot l:UNDEF && v !=# expected
+            throw printf("Got unexpected value for jobinfo.%s: "
+              \  ."expected '%s', but got '%s'.", k, string(expected), string(v))
+          endif
         endfor
       endif
       return 1

--- a/tests/_setup.vader
+++ b/tests/_setup.vader
@@ -91,6 +91,32 @@ Execute:
   endfunction
   command! -nargs=+ AssertNeomakeMessage call s:AssertNeomakeMessage(<args>)
 
+  function! g:NeomakeSetupAutocmdWrappers()
+    let g:neomake_test_finished = []
+    function! s:OnNeomakeFinished(context)
+      let g:neomake_test_finished += [a:context]
+    endfunction
+
+    let g:neomake_test_countschanged = []
+    function! s:OnNeomakeCountsChanged(context)
+      let g:neomake_test_countschanged += [a:context]
+    endfunction
+
+    augroup neomake_tests
+      au!
+      au User NeomakeFinished call s:OnNeomakeFinished(g:neomake_hook_context)
+      au User NeomakeCountsChanged call s:OnNeomakeCountsChanged(g:neomake_hook_context)
+    augroup END
+  endfunction
+
+  function! NeomakeAsyncTestsSetup()
+    if neomake#has_async_support()
+      call g:NeomakeSetupAutocmdWrappers()
+      return 1
+    endif
+    Log "SKIP: no async support."
+  endfunction
+
 Before:
   let g:neomake_test_messages = []
   Assert !len(neomake#GetJobs()), 'There were jobs left from the previous test!'

--- a/tests/integration.vader
+++ b/tests/integration.vader
@@ -1,32 +1,5 @@
 Include: _setup.vader
 
-Execute (Setup autocmd wrappers):
-  function! g:NeomakeSetupAutocmdWrappers()
-    let g:neomake_test_finished = []
-    function! s:OnNeomakeFinished(context)
-      let g:neomake_test_finished += [a:context]
-    endfunction
-
-    let g:neomake_test_countschanged = []
-    function! s:OnNeomakeCountsChanged(context)
-      let g:neomake_test_countschanged += [a:context]
-    endfunction
-
-    augroup neomake_tests
-      au!
-      au User NeomakeFinished call s:OnNeomakeFinished(g:neomake_hook_context)
-      au User NeomakeCountsChanged call s:OnNeomakeCountsChanged(g:neomake_hook_context)
-    augroup END
-  endfunction
-
-  function! NeomakeAsyncTestsSetup()
-    if neomake#has_async_support()
-      call g:NeomakeSetupAutocmdWrappers()
-      return 1
-    endif
-    Log "SKIP: no async support."
-  endfunction
-
 Execute (Test Neomake on errors.sh with one maker):
   call g:NeomakeSetupAutocmdWrappers()
   e! tests/fixtures/errors.sh

--- a/tests/integration.vader
+++ b/tests/integration.vader
@@ -109,8 +109,12 @@ Execute (NeomakeSh: non-existing command):
   AssertEqual len(g:neomake_test_finished), 1
   AssertEqual g:neomake_test_countschanged, [{'file_mode': 0, 'bufnr': bufnr('%')}]
   AssertEqual len(getqflist()), 1
-  AssertNotEqual match(getqflist()[0].text, 'nonexistingcommand'), -1
-  AssertNotEqual match(getqflist()[0].text, 'command not found'), -1
+  if neomake#has_async_support()
+    AssertNeomakeMessage 'sh: ''nonexistingcommand'': completed with exit code 127.', 1, {}
+  endif
+  AssertNeomakeMessage "exit: sh: 'nonexistingcommand': 127", 3
+  AssertNotEqual match(getqflist()[0].text,
+    \ '/bin/bash: nonexistingcommand: command not found'), -1, "error in qflist"
 
 Execute (NeomakeSh!: handle unfinished output on exit):
   call g:NeomakeSetupAutocmdWrappers()

--- a/tests/mapexpr.vader
+++ b/tests/mapexpr.vader
@@ -1,0 +1,36 @@
+Include: _setup.vader
+
+Execute (mapexpr: output source in mapexpr):
+  let maker = neomake#utils#MakerFromCommand('echo on_stdout; echo on_stderr>&2')
+  let maker.mapexpr = "printf('[%s] %s', neomake_output_source, v:val)"
+  call neomake#Make(0, [maker])
+  NeomakeTestsWaitForFinishedJobs
+
+  let stderr_source = neomake#has_async_support() ? 'stderr' : 'stdout'
+
+  AssertEqual sort(map(copy(getqflist()), 'v:val.text')), sort(
+    \ ['['.stderr_source.'] on_stderr', '[stdout] on_stdout'])
+
+Execute (mapexpr: file mode vars):
+  let maker = neomake#utils#MakerFromCommand('echo on_stdout')
+  e! tests/fixtures/errors.sh
+  let maker.mapexpr = "printf('%s (%s): %s', neomake_bufname, neomake_bufdir, v:val)"
+  call neomake#Make(1, [maker])
+  NeomakeTestsWaitForFinishedJobs
+
+  AssertEqual map(copy(getloclist(0)), 'v:val.text'), [
+    \ 'tests/fixtures/errors.sh (tests/fixtures): on_stdout']
+
+Execute (mapexpr: file mode vars with cd):
+  if !NeomakeAsyncTestsSetup() | finish | endif
+
+  let maker = neomake#utils#MakerFromCommand('sleep 0.1; echo on_stdout')
+  e! tests/fixtures/errors.sh
+  let maker.mapexpr = "printf('%s (%s): %s', neomake_bufname, neomake_bufdir, v:val)"
+  let start_cwd = getcwd()
+  call neomake#Make(1, [maker])
+  cd build
+  NeomakeTestsWaitForFinishedJobs
+
+  AssertEqual map(copy(getloclist(0)), 'v:val.text'), [
+    \ start_cwd.'/tests/fixtures/errors.sh ('.start_cwd.'/tests/fixtures): on_stdout']


### PR DESCRIPTION
This sets neomake_bufname, neomake_bufdir and neomake_output_source
('stdout'/'stderr') during the execution of `mapexpr`.

This combines #630 and #734.