### PR TITLE
Use typeinformation from s:placed_signs in RedefineSign

### DIFF
--- a/autoload/neomake/signs.vim
+++ b/autoload/neomake/signs.vim
@@ -158,11 +158,13 @@ function! neomake#signs#RedefineSign(name, opts) abort
     endfor
     exe sign_define
 
-    for buf in keys(s:placed_signs)
-        for ln in keys(s:placed_signs[buf])
-            let sign_id = s:placed_signs[buf][ln]
-            exe 'sign place '.sign_id.' name=neomake_invisible buffer='.buf
-            exe 'sign place '.sign_id.' name='.a:name.' buffer='.buf
+    for type in keys(s:placed_signs)
+        for buf in keys(s:placed_signs[type])
+            for ln in keys(s:placed_signs[type][buf])
+                let sign_id = s:placed_signs[type][buf][ln]
+                exe 'sign place '.sign_id.' name=neomake_invisible buffer='.buf
+                exe 'sign place '.sign_id.' name='.a:name.' buffer='.buf
+            endfor
         endfor
     endfor
 endfunction


### PR DESCRIPTION
The structure of the `s:placed_signs` dictionary appears to be
    `s:placed_signs[type][buffer][line]`
where type is either 'file' or 'project', buffer the buffer id and line
the linenumber of the placed sign. However, `neomake#signs#RedefineSign`
did only iterate over the first two levels of the hash, resulting in an
attempt to use a dictionary as an string/sign_id, which fails with:

```
E15: Invalid expression: 'sign place '.sign_id.' name=neomake_invisible buffer='.buf
```

This commit should fix that issue.
