### PR TITLE
Restore `parse-only` to rustc

### DIFF
--- a/autoload/neomake/makers/ft/rust.vim
+++ b/autoload/neomake/makers/ft/rust.vim
@@ -6,6 +6,7 @@ endfunction
 
 function! neomake#makers#ft#rust#rustc() abort
     return {
+        \ 'args': ['-Z', 'parse-only'],
         \ 'errorformat':
             \ '%-Gerror: aborting due to previous error,'.
             \ '%-Gerror: aborting due to %\\d%\\+ previous errors,'.


### PR DESCRIPTION
It seems that https://github.com/neomake/neomake/pull/613 deleted the args passed to `rustc`, as introduced in https://github.com/neomake/neomake/pull/276, causing a regression as described in https://github.com/neomake/neomake/issues/275.

This PR restores the args (`-Z parse-only`).