### PR TITLE
Fix post processing of jobs when changing windows

### DIFF
--- a/tests/lists.vader
+++ b/tests/lists.vader
@@ -31,7 +31,7 @@ Execute (AddExprCallback with changed windows inbetween):
     \ }
   let maker_1 = neomake#utils#MakerFromCommand('echo 1a; sleep .1; echo 1b')
   call extend(maker_1, extend(copy(options), {'name': 'maker1'}))
-  let maker_2 = neomake#utils#MakerFromCommand('echo 2')
+  let maker_2 = neomake#utils#MakerFromCommand('sleep .01; echo 2')
   call extend(maker_2, extend(copy(options), {'name': 'maker2'}))
 
   " Start 2 makers.

--- a/tests/lists.vader
+++ b/tests/lists.vader
@@ -16,3 +16,41 @@ Execute (Postprocessing should update list):
   let expected_list = map(list, 'extend(v:val, {"text": v:val.text." SUFFIX"})')
   RunNeomake sh
   AssertEqual getloclist(0), expected_list
+
+Execute (AddExprCallback with changed windows inbetween):
+  if !NeomakeAsyncTestsSetup() | finish | endif
+  let g:neomake_tests_postprocess_count = 0
+  function! g:Postprocess(entry)
+    let g:neomake_tests_postprocess_count += 1
+    let a:entry.text .= ' SUFFIX:'.g:neomake_tests_postprocess_count
+  endfunction
+
+  let options = {
+    \ 'postprocess': function('g:Postprocess'),
+    \ 'buffer_output': 0,
+    \ }
+  let maker_1 = neomake#utils#MakerFromCommand('echo 1a; sleep .1; echo 1b')
+  call extend(maker_1, extend(copy(options), {'name': 'maker1'}))
+  let maker_2 = neomake#utils#MakerFromCommand('echo 2')
+  call extend(maker_2, extend(copy(options), {'name': 'maker2'}))
+
+  " Start 2 makers.
+  call neomake#Make(1, [maker_1, maker_2])
+  " Wait until partly finished.
+  while g:neomake_tests_postprocess_count < 2
+    sleep 10m
+  endwhile
+  AssertEqual map(copy(getloclist(0)), 'v:val.text'), [
+    \ '1a SUFFIX:1', '2 SUFFIX:2']
+
+  " Start maker in new window (same winnr!)
+  topleft new
+  call neomake#Make(1, [maker_2])
+  " Go to previous window, let previous job finish.
+  wincmd j
+  NeomakeTestsWaitForFinishedJobs
+  AssertEqual map(copy(getloclist(0)), 'v:val.text'), [
+    \ '1a SUFFIX:1', '2 SUFFIX:2', '1b SUFFIX:3']
+  wincmd k
+  AssertEqual map(copy(getloclist(0)), 'v:val.text'), [
+    \ '2 SUFFIX:4']


### PR DESCRIPTION
This removes s:{loc,qf}list_nr, where s:loclist_nr was using the
(unstable) winnr of the maker.