### PR TITLE
Allow stylelint for .less

### DIFF
--- a/autoload/neomake/makers/ft/less.vim
+++ b/autoload/neomake/makers/ft/less.vim
@@ -1,7 +1,7 @@
 " vim: ts=4 sw=4 et
 
 function! neomake#makers#ft#less#EnabledMakers()
-    return ['lessc']
+    return executable('stylelint') ? ['stylelint'] : ['lessc']
 endfunction
 
 function! neomake#makers#ft#less#lessc()
@@ -12,4 +12,8 @@ function! neomake#makers#ft#less#lessc()
             \ '%m in %f:%l:%c,' .
             \ '%-G%.%#'
     \ }
+endfunction
+
+function! neomake#makers#ft#less#stylelint() abort
+    return neomake#makers#ft#css#stylelint()
 endfunction


### PR DESCRIPTION
As stated in the other PR, there must be a better way rather than checking if stylelint is executable. This was modeled to be as similar as possible to the PR #665 . Also, thank you to @rstacruz for mentioning stylelint.