### PR TITLE
Add write-good support

### DIFF
--- a/autoload/neomake/makers/ft/markdown.vim
+++ b/autoload/neomake/makers/ft/markdown.vim
@@ -1,6 +1,6 @@
 function! neomake#makers#ft#markdown#EnabledMakers() abort
-    let makers = executable('mdl') ? ['mdl'] : ['markdownlint']
-    return makers + ['proselint']
+    let l:makers = executable('mdl') ? ['mdl'] : ['markdownlint']
+    return l:makers + ['proselint', 'writegood']
 endfunction
 
 function! neomake#makers#ft#markdown#mdl() abort
@@ -13,6 +13,13 @@ endfunction
 function! neomake#makers#ft#markdown#proselint() abort
     return {
                 \ 'errorformat': '%f:%l:%c: %m'
+                \ }
+endfunction
+
+function! neomake#makers#ft#markdown#writegood() abort
+    return {
+                \ 'args': ['--parse'],
+                \ 'errorformat': '%W%f:%l:%c:%m'
                 \ }
 endfunction
 

--- a/autoload/neomake/makers/ft/pandoc.vim
+++ b/autoload/neomake/makers/ft/pandoc.vim
@@ -12,4 +12,7 @@ endfunction
 
 function! neomake#makers#ft#pandoc#markdownlint() abort
     return neomake#makers#ft#markdown#markdownlint()
+
+function! neomake#makers#ft#pandoc#writegood() abort
+    return neomake#makers#ft#markdown#writegood()
 endfunction

--- a/autoload/neomake/makers/ft/text.vim
+++ b/autoload/neomake/makers/ft/text.vim
@@ -1,5 +1,5 @@
 function! neomake#makers#ft#text#EnabledMakers() abort
-    return neomake#makers#ft#markdown#EnabledMakers()
+    return ['writegood', 'proselint']
 endfunction
 
 function! neomake#makers#ft#text#writegood() abort

--- a/autoload/neomake/makers/ft/text.vim
+++ b/autoload/neomake/makers/ft/text.vim
@@ -1,9 +1,11 @@
-function! neomake#makers#ft#text#EnabledMakers()
-    return ['proselint']
+function! neomake#makers#ft#text#EnabledMakers() abort
+    return neomake#makers#ft#markdown#EnabledMakers()
 endfunction
 
-function! neomake#makers#ft#text#proselint()
-    return {
-                \ 'errorformat': '%f:%l:%c: %m'
-                \ }
+function! neomake#makers#ft#text#writegood() abort
+    return neomake#makers#ft#markdown#writegood()
+endfunction
+
+function! neomake#makers#ft#text#proselint() abort
+    return neomake#makers#ft#markdown#proselint()
 endfunction


### PR DESCRIPTION
I accidentally had `neomake#makers#ft#text#EnabledMakers` in  `autoload/neomake/makers/ft/text.vim` return `neomake#makers#ft#markdown#EnabledMakers()` instead of just `['proselint']`, but I think you can edit that line. Sorry about that.