### PR TITLE
Refactor neomake#makers#ft#sh#shellcheck()

### DIFF
--- a/autoload/neomake/makers/ft/sh.vim
+++ b/autoload/neomake/makers/ft/sh.vim
@@ -4,20 +4,23 @@ function! neomake#makers#ft#sh#EnabledMakers() abort
     return ['sh', 'shellcheck']
 endfunction
 
-" IDEA: could be detected once from "shellcheck --help" (since older versions
-" support zsh, and newer might do so again).
-let s:shellcheck_supported = ['sh', 'bash', 'dash', 'ksh']
-
 function! neomake#makers#ft#sh#shellcheck() abort
-    let args = ['-fgcc']
-    let shebang = matchstr(getline(1), '^#!\s*\zs.*$')
-    if !len(shebang)
-        if index(s:shellcheck_supported, &filetype) != -1
-            let args += ['-s', &filetype]
-        endif
+    let ext = expand('%:e')
+    let shebang = getline(1)
+
+    if ext ==# 'dash' || shebang =~# 'dash'
+        let ft = 'dash'
+    elseif exists('g:is_sh') || ext ==# 'sh' || shebang =~# '\<sh'
+        let ft = 'sh'
+    elseif exists('g:is_kornshell') || exists('g:is_posix') || ext ==# 'ksh'
+        \ || shebang =~# 'ksh'
+        let ft = 'ksh'
+    else
+        let ft = 'bash'
     endif
+
     return {
-        \ 'args': args,
+        \ 'args': ['-fgcc', '-s', ft],
         \ 'errorformat':
             \ '%f:%l:%c: %trror: %m,' .
             \ '%f:%l:%c: %tarning: %m,' .

--- a/tests/ft_sh.vader
+++ b/tests/ft_sh.vader
@@ -1,14 +1,48 @@
 Include: include/setup.vader
 
 Execute (shellcheck):
-  AssertEqual neomake#makers#ft#sh#shellcheck()['args'], ['-fgcc']
-  set ft=sh
-  AssertEqual neomake#makers#ft#sh#shellcheck()['args'], ['-fgcc', '-s', 'sh']
-  set ft=bash
-  AssertEqual neomake#makers#ft#sh#shellcheck()['args'], ['-fgcc', '-s', 'bash']
-  set ft=nadda
-  AssertEqual neomake#makers#ft#sh#shellcheck()['args'], ['-fgcc']
+  " By variable...
+  let g:is_sh = 1
+  AssertEqual ['-fgcc', '-s', 'sh'], neomake#makers#ft#sh#shellcheck().args
+  unlet g:is_sh
+  let g:is_kornshell = 1
+  AssertEqual ['-fgcc', '-s', 'ksh'], neomake#makers#ft#sh#shellcheck().args
+  unlet g:is_kornshell
+  let g:is_posix = 1
+  AssertEqual ['-fgcc', '-s', 'ksh'], neomake#makers#ft#sh#shellcheck().args
+  unlet g:is_posix
+  AssertEqual ['-fgcc', '-s', 'bash'], neomake#makers#ft#sh#shellcheck().args
 
-  set ft=sh
-  norm i#!/usr/bin/env bash
-  AssertEqual neomake#makers#ft#sh#shellcheck()['args'], ['-fgcc']
+  " By file extension...
+  silent file test.sh
+  AssertEqual ['-fgcc', '-s', 'sh'], neomake#makers#ft#sh#shellcheck().args
+  silent file test.dash
+  AssertEqual ['-fgcc', '-s', 'dash'], neomake#makers#ft#sh#shellcheck().args
+  silent file test.ksh
+  AssertEqual ['-fgcc', '-s', 'ksh'], neomake#makers#ft#sh#shellcheck().args
+  silent file test.bash
+  AssertEqual ['-fgcc', '-s', 'bash'], neomake#makers#ft#sh#shellcheck().args
+  silent file yay
+  AssertEqual ['-fgcc', '-s', 'bash'], neomake#makers#ft#sh#shellcheck().args
+
+  " By shebang...
+  call setline(1, '#!/bin/sh')
+  AssertEqual ['-fgcc', '-s', 'sh'], neomake#makers#ft#sh#shellcheck().args
+  call setline(1, '#!/bin/ksh')
+  AssertEqual ['-fgcc', '-s', 'ksh'], neomake#makers#ft#sh#shellcheck().args
+  call setline(1, '#!/usr/bin/env ksh')
+  AssertEqual ['-fgcc', '-s', 'ksh'], neomake#makers#ft#sh#shellcheck().args
+  call setline(1, '#!/bin/dash')
+  AssertEqual ['-fgcc', '-s', 'dash'], neomake#makers#ft#sh#shellcheck().args
+  call setline(1, '#!/usr/bin/env dash')
+  AssertEqual ['-fgcc', '-s', 'dash'], neomake#makers#ft#sh#shellcheck().args
+  call setline(1, '#!/bin/bash')
+  AssertEqual ['-fgcc', '-s', 'bash'], neomake#makers#ft#sh#shellcheck().args
+  call setline(1, '#!/usr/bin/env bash')
+  AssertEqual ['-fgcc', '-s', 'bash'], neomake#makers#ft#sh#shellcheck().args
+
+  " The following should never happen in practice.
+  set ft=
+  AssertEqual ['-fgcc', '-s', 'bash'], neomake#makers#ft#sh#shellcheck().args
+  set ft=nadda
+  AssertEqual ['-fgcc', '-s', 'bash'], neomake#makers#ft#sh#shellcheck().args


### PR DESCRIPTION
Simplify the function and also consider filename extensions and global variabes
from `:h ft-sh-syntax`.

Closes #776.