### PR TITLE
Unlet Vim job in neomake#CancelJob

### DIFF
--- a/doc/neomake.txt
+++ b/doc/neomake.txt
@@ -387,8 +387,7 @@ Invoked via |:NeomakeListJobs|. Echoes a list of running jobs in the format
 (job_id, job_name).
 
 *neomake#CancelJob*
-Invoked via |:NeomakeCancelJob|. Terminate a job identified by its job_id
-Will trigger callback if it was specified when the job was started.
+Invoked via |:NeomakeCancelJob|. Terminate a job identified by its job_id.
 Example: >
     let job_id = neomake#Sh("bash -c 'while true; do sleep 1; done'")
     call neomake#CancelJob(job_id)

--- a/tests/lists.vader
+++ b/tests/lists.vader
@@ -31,7 +31,7 @@ Execute (AddExprCallback with changed windows inbetween):
     \ }
   let maker_1 = neomake#utils#MakerFromCommand('echo 1a; sleep .1; echo 1b')
   call extend(maker_1, extend(copy(options), {'name': 'maker1'}))
-  let maker_2 = neomake#utils#MakerFromCommand('sleep .01; echo 2')
+  let maker_2 = neomake#utils#MakerFromCommand('sleep .05; echo 2')
   call extend(maker_2, extend(copy(options), {'name': 'maker2'}))
 
   " Start 2 makers.

--- a/tests/neomake.vader
+++ b/tests/neomake.vader
@@ -88,12 +88,14 @@ Execute (neomake#CancelJob):
   if neomake#has_async_support()
     let job_id = neomake#Sh("sh -c 'while true; do sleep 0.1; done'")
     AssertEqual neomake#CancelJob(job_id), 1
+    AssertNeomakeMessage 'Stopping job: '.job_id
 
-    " The job is still in the table, therefore 'E900: Invalid job id'.
-    AssertThrows neomake#CancelJob(job_id)
+    AssertEqual neomake#CancelJob(job_id), 0
 
     NeomakeTestsWaitForFinishedJobs
+    let msg_count = len(g:neomake_test_messages)
     AssertEqual neomake#CancelJob(job_id), 0
+    AssertEqual msg_count, len(g:neomake_test_messages), "msg_count: ".msg_count
   endif
 
 Execute (Reports exit status: 7):


### PR DESCRIPTION
It looks like the exit callback is not being called, like with Neovim's
`jobstop()`.