### PR TITLE
neomake#Make: only set ft for file_mode

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -951,7 +951,9 @@ endfunction
 function! neomake#Make(file_mode, enabled_makers, ...) abort
     let options = a:0 ? { 'exit_callback': a:1 } : {}
     let options.file_mode = a:file_mode
-    let options.ft = &filetype
+    if a:file_mode
+        let options.ft = &filetype
+    endif
     let options.enabled_makers = len(a:enabled_makers)
                     \ ? a:enabled_makers
                     \ : neomake#GetEnabledMakers(a:file_mode ? &filetype : '')


### PR DESCRIPTION
This partly reverts 02e9912a (https://github.com/neomake/neomake/pull/762).
Fixes https://github.com/neomake/neomake/issues/782.