### PR TITLE
Puppet: Add errorformat with column

### DIFF
--- a/autoload/neomake/makers/ft/puppet.vim
+++ b/autoload/neomake/makers/ft/puppet.vim
@@ -13,6 +13,8 @@ endfunction
 function! neomake#makers#ft#puppet#puppet()
     return {
         \ 'args': ['parser', 'validate', '--color=false'],
-        \ 'errorformat': '%t%*[a-zA-Z]: %m at %f:%l',
+        \ 'errorformat':
+        \   '%t%*[a-zA-Z]: %m at %f:%l:%c,'.
+        \   '%t%*[a-zA-Z]: %m at %f:%l'
         \ }
 endfunction


### PR DESCRIPTION
The output isn't parsed correctly, because the errorformat is missing the column. 

https://github.com/vim-syntastic/syntastic/blob/master/syntax_checkers/puppet/puppet.vim