### PR TITLE
[RFC] Use file-mode/filetype makers for project mode

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -315,7 +315,7 @@ function! neomake#GetMaker(name_or_maker, ...) abort
                                 let maker.append_file = 0
                                 let maker._forced_append_file = 1
                                 for glob in neomake#utils#GetGlobForFiletypeMaker(maker, ft)
-                                    let maker.args += glob(glob, 0, 1)
+                                    let maker.args += split(glob(glob, 0), "\n")
                                 endfor
                             endif
                         endfor

--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -267,9 +267,6 @@ endfunction
 function! neomake#GetMaker(name_or_maker, ...) abort
     let args = a:000
     let ft = a:0 ? a:1 : &ft
-    if type(ft) != type('')
-        throw "Invalid ft: " string(ft)
-    endif
     let file_mode = a:0 > 1 ? a:2 : (len(get(a:, 1, '')) ? 1 : 0)
 
     let fts = neomake#utils#GetSortedFiletypes(ft)

--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -266,7 +266,6 @@ function! s:GetMakerForFiletype(fts, maker_name) abort
 endfunction
 
 function! neomake#GetMaker(name_or_maker, ...) abort
-    let args = a:000
     let file_mode = a:0 > 1 ? a:2 : (len(get(a:, 1, '')) ? 1 : 0)
     let ft = a:0 ? a:1 : ''
     let fts = neomake#utils#GetSortedFiletypes(ft)

--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -313,7 +313,6 @@ function! neomake#GetMaker(name_or_maker, ...) abort
                             let maker._forced_append_file = 1
                             let maker.args += glob('**/*.'.ft, 0, 1)
                         endif
-                        break
                     endif
                 endif
             endif

--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -305,18 +305,16 @@ function! neomake#GetMaker(name_or_maker, ...) abort
 
                 " No project maker, use it from filetype.
                 if !exists('maker')
-                    for ft in fts
-                        let maker = s:GetMakerForFiletype(fts, maker_name)
-                        if maker !=# {}
-                            let append_file = neomake#utils#GetSetting('append_file', maker, 1, [ft], bufnr('%'))
-                            if append_file
-                                let maker.append_file = 0
-                                let maker._forced_append_file = 1
-                                let maker.args += glob('**/*.'.ft, 0, 1)
-                            endif
-                            break
+                    let maker = s:GetMakerForFiletype(fts, maker_name)
+                    if maker !=# {}
+                        let append_file = neomake#utils#GetSetting('append_file', maker, 1, [ft], bufnr('%'))
+                        if append_file
+                            let maker.append_file = 0
+                            let maker._forced_append_file = 1
+                            let maker.args += glob('**/*.'.ft, 0, 1)
                         endif
-                    endfor
+                        break
+                    endif
                 endif
             endif
         endif

--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -958,9 +958,7 @@ endfunction
 function! neomake#Make(file_mode, enabled_makers, ...) abort
     let options = a:0 ? { 'exit_callback': a:1 } : {}
     let options.file_mode = a:file_mode
-    if a:file_mode
-        let options.ft = &filetype
-    endif
+    let options.ft = &filetype
     let options.enabled_makers = len(a:enabled_makers)
                     \ ? a:enabled_makers
                     \ : neomake#GetEnabledMakers(a:file_mode ? &filetype : '')

--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -307,7 +307,7 @@ function! neomake#GetMaker(name_or_maker, ...) abort
                 if !exists('maker')
                     let maker = s:GetMakerForFiletype(fts, maker_name)
                     if maker !=# {}
-                        let append_file = neomake#utils#GetSetting('append_file', maker, 1, [ft], bufnr('%'))
+                        let append_file = neomake#utils#GetSetting('append_file', maker, 1, [ft], bufnr('%'), type(0))
                         if append_file
                             let maker.append_file = 0
                             let maker._forced_append_file = 1
@@ -339,7 +339,7 @@ function! neomake#GetMaker(name_or_maker, ...) abort
         \ }
     let bufnr = bufnr('%')
     for [key, default] in items(defaults)
-        let maker[key] = neomake#utils#GetSetting(key, maker, default, fts, bufnr)
+        let maker[key] = neomake#utils#GetSetting(key, maker, default, fts, bufnr, type(default))
         unlet! default  " workaround for old Vim (7.3.429)
     endfor
 
@@ -347,7 +347,7 @@ function! neomake#GetMaker(name_or_maker, ...) abort
     " maker from ft maker).
     if !get(maker, '_forced_append_file')
         let s:UNSET = {}
-        let value = neomake#utils#GetSetting('append_file', maker, s:UNSET, fts, bufnr)
+        let value = neomake#utils#GetSetting('append_file', maker, s:UNSET, fts, bufnr, type(0))
         if value isnot s:UNSET
             let maker['append_file'] = value
         endif

--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -323,7 +323,7 @@ function! neomake#GetMaker(name_or_maker, ...) abort
                 endif
             endif
         endif
-        if !exists('maker') || maker == {}
+        if !exists('maker')
             call neomake#utils#ErrorMessage('Maker not found: '.maker_name)
             return {}
         endif

--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -252,6 +252,7 @@ function! s:GetMakerForFiletype(fts, maker_name) abort
     for ft in a:fts
         try
             let maker = eval('neomake#makers#ft#'.ft.'#'.a:maker_name.'()')
+            break
         catch /^Vim\%((\a\+)\)\=:E117/
         endtry
     endfor

--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -981,7 +981,8 @@ function! neomake#CompleteMakers(ArgLead, CmdLine, ...) abort
         return []
     endif
     let file_mode = a:CmdLine =~# '\v^(Neomake|NeomakeFile)\s'
-    let makers = file_mode ? neomake#GetMakers(&filetype) : neomake#GetProjectMakers()
+    let makers = file_mode ? [] : neomake#GetProjectMakers()
+    let makers += neomake#GetMakers(&filetype)
     return filter(makers, "v:val =~? '^".a:ArgLead."'")
 endfunction
 

--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -266,7 +266,7 @@ endfunction
 
 function! neomake#GetMaker(name_or_maker, ...) abort
     let args = a:000
-    let ft = a:0 ? a:1 : &ft
+    let ft = a:0 ? a:1 : &filetype
     let file_mode = a:0 > 1 ? a:2 : (len(get(a:, 1, '')) ? 1 : 0)
 
     let fts = neomake#utils#GetSortedFiletypes(ft)

--- a/autoload/neomake/utils.vim
+++ b/autoload/neomake/utils.vim
@@ -220,7 +220,8 @@ endfunction
 
 " Get a setting by key, based on filetypes, from the buffer or global
 " namespace, defaulting to default.
-function! neomake#utils#GetSetting(key, maker, default, fts, bufnr) abort
+function! neomake#utils#GetSetting(key, maker, default, fts, bufnr, ...) abort
+  let expected_type = a:0 ? a:1 : -1
   let maker_name = has_key(a:maker, 'name') ? '_'.a:maker.name : ''
   if len(a:fts)
     for ft in a:fts
@@ -240,22 +241,36 @@ function! neomake#utils#GetSetting(key, maker, default, fts, bufnr) abort
 
   if exists('config_var')
     if !empty(getbufvar(a:bufnr, config_var))
-      return copy(getbufvar(a:bufnr, config_var))
+      let R = copy(getbufvar(a:bufnr, config_var))
     elseif has_key(g:, config_var)
-      return copy(get(g:, config_var))
+      let R = copy(get(g:, config_var))
     endif
   endif
-  if has_key(a:maker, a:key)
-    return a:maker[a:key]
+  if !exists('R')
+    if has_key(a:maker, a:key)
+      let R = a:maker[a:key]
+    else
+      " Look for 'neomake_'.key in the buffer and global namespace.
+      let bufvar = getbufvar(a:bufnr, 'neomake_'.a:key)
+      if !empty(bufvar)
+        let R = bufvar
+      else
+        let var = get(g:, 'neomake_'.a:key)
+        if !empty(var)
+          let R = var
+        endif
+      endif
+    endif
   endif
-  " Look for 'neomake_'.key in the buffer and global namespace.
-  let bufvar = getbufvar(a:bufnr, 'neomake_'.a:key)
-  if !empty(bufvar)
-      return bufvar
-  endif
-  let var = get(g:, 'neomake_'.a:key)
-  if !empty(var)
-      return var
+  if exists('R')
+    if expected_type > -1
+      let t = type(R)
+      if t !=# 2 && t !=# expected_type
+        throw 'Invalid type for setting '.a:key.': expected type '
+                    \ .expected_type.', but got '.t.': '.string(R).'.'
+      endif
+    endif
+    return R
   endif
   return a:default
 endfunction

--- a/autoload/neomake/utils.vim
+++ b/autoload/neomake/utils.vim
@@ -357,3 +357,20 @@ function! neomake#utils#hook(event, context) abort
         unlet g:neomake_hook_context
     endif
 endfunction
+
+" Get file extension(s) for a given filetype.
+function! neomake#utils#GetGlobForFiletypeMaker(maker, ft) abort
+    let UNSET = []
+    let setting = neomake#utils#GetSetting('projectglob', a:maker, UNSET, [a:ft], bufnr('%'), type([]))
+    if setting != UNSET
+        return setting
+    endif
+    " Incomplete!  Right approach?!
+    let ext_by_ft = {
+                \ 'cpp': ['c', 'h'],
+                \ 'python': ['py'],
+                \ 'javascript': ['js'],
+                \ }
+    let exts = has_key(ext_by_ft, a:ft) ? ext_by_ft[a:ft] : [a:ft]
+    return map(copy(exts), "'**/*.'.v:val")
+endfunction

--- a/tests/neomake.vader
+++ b/tests/neomake.vader
@@ -53,7 +53,9 @@ Execute (neomake#GetMaker uses defaults from b:/g:):
   AssertEqual neomake#GetMaker(maker).remove_invalid_entries, 3
 
 Execute (neomake#GetMaker in project mode uses ft makers):
-  call mkdir('build/tests/vim-project/subdir', 'p')
+  if !isdirectory('build/tests/vim-project/subdir', )
+    call mkdir('build/tests/vim-project/subdir', 'p')
+  endif
   try
     cd build/tests/vim-project
     write! foobar.vim

--- a/tests/neomake.vader
+++ b/tests/neomake.vader
@@ -30,9 +30,11 @@ Execute (neomake#GetMaker with non-existent maker prints errors):
   AssertEqual g:neomake_test_messages[-1], [0, 'Maker not found: nonexistent', {}]
 
 Execute (neomake#GetMaker: uses defined errorformat):
+  Save errorformat
+  let &errorformat = '%G'
   let maker = neomake#GetMaker('makeprg', '')
   AssertEqual maker, {'name': 'makeprg', 'ft': '', 'args': ['-c', 'make'],
-    \ 'errorformat': &errorformat,
+    \ 'errorformat': '%G',
     \ 'exe': &shell, 'remove_invalid_entries': 0, 'buffer_output': 1}
 
 Execute (neomake#GetMaker uses defaults from b:/g:):

--- a/tests/neomake.vader
+++ b/tests/neomake.vader
@@ -74,7 +74,9 @@ Execute (neomake#GetMaker in project mode uses ft makers):
   AssertEqual sh_maker.args, ['-n', 'subdir/test.sh']
 
 Execute (neomake#GetMaker: project: respects append_file):
-  call mkdir('build/tests/typescript-project', 'p')
+  if !isdirectory('build/tests/typescript-project')
+    call mkdir('build/tests/typescript-project', 'p')
+  endif
   try
     cd build/tests/typescript-project
     write! foobar.typescript
@@ -88,7 +90,9 @@ Execute (neomake#GetMaker: project: respects append_file):
   AssertEqual tsc_project_maker.args, ['--noEmit']
 
 Execute (neomake#GetMaker: project: respects append_file setting):
-  call mkdir('build/tests/typescript-project', 'p')
+  if !isdirectory('build/tests/typescript-project')
+    call mkdir('build/tests/typescript-project', 'p')
+  endif
   try
     cd build/tests/typescript-project
     write! foobar.typescript

--- a/tests/neomake.vader
+++ b/tests/neomake.vader
@@ -50,6 +50,45 @@ Execute (neomake#GetMaker uses defaults from b:/g:):
   let b:neomake_test_remove_invalid_entries = 3
   AssertEqual neomake#GetMaker(maker).remove_invalid_entries, 3
 
+Execute (neomake#GetMaker in project mode uses ft makers):
+  call mkdir('build/tests/vim-project/subdir', 'p')
+  cd build/tests/vim-project
+  write! foobar.vim
+  write! foobar2.vim
+  write! subdir/test.sh
+  let vint_maker = neomake#GetMaker('vint', 'vim', 0)
+  let sh_maker = neomake#GetMaker('sh', 'sh', 0)
+  cd -
+
+  AssertEqual vint_maker.append_file, 0, 'append_file is 0'
+  AssertEqual vint_maker.args[-2:-1], ['foobar.vim', 'foobar2.vim']
+
+  AssertEqual sh_maker.append_file, 0, 'append_file is 0'
+  AssertEqual sh_maker.args, ['-n', 'subdir/test.sh']
+
+Execute (neomake#GetMaker: project: respects append_file):
+  call mkdir('build/tests/typescript-project', 'p')
+  cd build/tests/typescript-project
+  write! foobar.typescript
+  let tsc_maker = neomake#GetMaker('tsc', 'typescript', 1)
+  let tsc_project_maker = neomake#GetMaker('tsc', 'typescript', 0)
+  cd -
+  AssertEqual tsc_maker.append_file, 0, 'append_file defaults to 0'
+  AssertEqual tsc_project_maker.append_file, 0, 'append_file is 0'
+  AssertEqual tsc_project_maker.args, ['--noEmit']
+
+Execute (neomake#GetMaker: project: respects append_file setting):
+  call mkdir('build/tests/typescript-project', 'p')
+  cd build/tests/typescript-project
+  write! foobar.typescript
+  let g:neomake_typescript_tsc_append_file = 1
+  let tsc_project_maker = neomake#GetMaker('tsc', 'typescript', 0)
+  cd -
+  AssertEqual tsc_project_maker.append_file, 0, 'append_file is 0'
+  AssertEqual tsc_project_maker._forced_append_file, 1, '_forced_append_file'
+  AssertEqual tsc_project_maker.args, ['--noEmit', 'foobar.typescript']
+
+
 Execute (neomake#Make in file mode with no filetype and no makers):
   AssertEqual &ft, ''
   AssertEqual neomake#Make(1, []), []
@@ -76,6 +115,17 @@ Execute (neomake#GetMaker from g:neomake_foo_maker):
     \ 'exe': 'my-exe'
     \ }
   let maker = neomake#GetMaker('custom')
+  AssertEqual maker.exe, 'my-exe'
+  AssertEqual maker.name, 'custom'
+
+  let maker_2 = neomake#GetMaker('custom', '')
+  AssertEqual maker, maker_2
+
+Execute (neomake#GetMaker from g:neomake_ft_foo_maker):
+  let g:neomake_ft_custom_maker = {
+    \ 'exe': 'my-exe'
+    \ }
+  let maker = neomake#GetMaker('custom', 'ft')
   AssertEqual maker.exe, 'my-exe'
   AssertEqual maker.name, 'custom'
 

--- a/tests/neomake.vader
+++ b/tests/neomake.vader
@@ -52,13 +52,16 @@ Execute (neomake#GetMaker uses defaults from b:/g:):
 
 Execute (neomake#GetMaker in project mode uses ft makers):
   call mkdir('build/tests/vim-project/subdir', 'p')
-  cd build/tests/vim-project
-  write! foobar.vim
-  write! foobar2.vim
-  write! subdir/test.sh
-  let vint_maker = neomake#GetMaker('vint', 'vim', 0)
-  let sh_maker = neomake#GetMaker('sh', 'sh', 0)
-  cd -
+  try
+    cd build/tests/vim-project
+    write! foobar.vim
+    write! foobar2.vim
+    write! subdir/test.sh
+    let vint_maker = neomake#GetMaker('vint', 'vim', 0)
+    let sh_maker = neomake#GetMaker('sh', 'sh', 0)
+  finally
+    cd -
+  endtry
 
   AssertEqual vint_maker.append_file, 0, 'append_file is 0'
   AssertEqual vint_maker.args[-2:-1], ['foobar.vim', 'foobar2.vim']
@@ -68,22 +71,28 @@ Execute (neomake#GetMaker in project mode uses ft makers):
 
 Execute (neomake#GetMaker: project: respects append_file):
   call mkdir('build/tests/typescript-project', 'p')
-  cd build/tests/typescript-project
-  write! foobar.typescript
-  let tsc_maker = neomake#GetMaker('tsc', 'typescript', 1)
-  let tsc_project_maker = neomake#GetMaker('tsc', 'typescript', 0)
-  cd -
+  try
+    cd build/tests/typescript-project
+    write! foobar.typescript
+    let tsc_maker = neomake#GetMaker('tsc', 'typescript', 1)
+    let tsc_project_maker = neomake#GetMaker('tsc', 'typescript', 0)
+  finally
+    cd -
+  endtry
   AssertEqual tsc_maker.append_file, 0, 'append_file defaults to 0'
   AssertEqual tsc_project_maker.append_file, 0, 'append_file is 0'
   AssertEqual tsc_project_maker.args, ['--noEmit']
 
 Execute (neomake#GetMaker: project: respects append_file setting):
   call mkdir('build/tests/typescript-project', 'p')
-  cd build/tests/typescript-project
-  write! foobar.typescript
-  let g:neomake_typescript_tsc_append_file = 1
-  let tsc_project_maker = neomake#GetMaker('tsc', 'typescript', 0)
-  cd -
+  try
+    cd build/tests/typescript-project
+    write! foobar.typescript
+    let g:neomake_typescript_tsc_append_file = 1
+    let tsc_project_maker = neomake#GetMaker('tsc', 'typescript', 0)
+  finally
+    cd -
+  endtry
   AssertEqual tsc_project_maker.append_file, 0, 'append_file is 0'
   AssertEqual tsc_project_maker._forced_append_file, 1, '_forced_append_file'
   AssertEqual tsc_project_maker.args, ['--noEmit', 'foobar.typescript']

--- a/tests/utils.vader
+++ b/tests/utils.vader
@@ -74,6 +74,27 @@ Execute (neomake#utils#GetSetting without name):
   let neomake_myft_setting = {'custom': 1}
   AssertEqual GetSetting('setting'), {'custom': 1}
 
+Execute (neomake#utils#GetSetting: type check):
+  let g:maker = {}
+  function! GetSetting(key, type)
+    return neomake#utils#GetSetting(a:key, g:maker, [],
+                                  \ ['myft'], bufnr('%'), a:type)
+  endfunction
+
+  " Defaults are not type-checked.
+  AssertEqual GetSetting('args', type([])), []
+  AssertEqual GetSetting('args', type(0)), []
+
+  Save neomake_args
+  let neomake_args = 42
+  AssertEqual GetSetting('args', type(0)), 42
+
+  let neomake_args = [1]
+  AssertThrows call GetSetting('args', type(0))
+  AssertEqual vader_exception, 'Invalid type for setting args: expected type 0, but got 3: [1].'
+
+  AssertEqual GetSetting('args', type([])), [1]
+
 Execute(neomake#utils#redir):
   command! NeomakeTestCommand echo 1 | echo 2
   command! NeomakeTestErrorCommand echoerr 'error'

--- a/tests/utils.vader
+++ b/tests/utils.vader
@@ -135,3 +135,22 @@ Execute (Should not expand arguments that start with double %):
 Execute (neomake#utils#MakerIsAvailable):
   AssertEqual neomake#utils#MakerIsAvailable('sh', 'sh'), 1
   AssertEqual neomake#utils#MakerIsAvailable('sh', 'doesnotexist'), 0
+
+
+Execute (neomake#utils#GetGlobForFiletypeMaker):
+  AssertEqual neomake#utils#GetGlobForFiletypeMaker({}, 'python'),
+    \ ['**/*.py']
+  AssertEqual neomake#utils#GetGlobForFiletypeMaker({}, 'vim'),
+    \ ['**/*.vim']
+  AssertEqual neomake#utils#GetGlobForFiletypeMaker({}, 'cpp'),
+    \ ['**/*.c', '**/*.h']
+
+  Save g:neomake_projectglob
+  let g:neomake_projectglob = ['**/*.C']
+  AssertEqual neomake#utils#GetGlobForFiletypeMaker({}, 'cpp'),
+    \ ['**/*.C']
+
+  Save g:neomake_cpp_projectglob
+  let g:neomake_cpp_projectglob = ['**/*.c++']
+  AssertEqual neomake#utils#GetGlobForFiletypeMaker({}, 'cpp'),
+    \ ['**/*.c++']

--- a/tests/utils.vader
+++ b/tests/utils.vader
@@ -88,6 +88,7 @@ Execute (neomake#utils#GetSetting: type check):
   Save neomake_args
   let neomake_args = 42
   AssertEqual GetSetting('args', type(0)), 42
+  unlet neomake_args
 
   let neomake_args = [1]
   AssertThrows call GetSetting('args', type(0))


### PR DESCRIPTION
This allows for `:Neomake! vint` to use the (file-mode) "vint" maker on
all Vim files in the project (via `glob('**/*.vim', 0, 1)`).

Currently this will only look at makers for the current filetype, so `:Neomake! vint` does not work when the filetype is not "vim".  This could be changed to work always?!

What about something like `:Neomake! vint **/*.vim` to specify the files being handled?
This should be made possible through #589.

TODO:
 - [ ] doc
 - [x] fix/adjust command completion
 - [ ] the mapping from &ft to `.ext` (to get the files to act on) does not work in a lot of cases, e.g. `ft=python` => `.py`, `ft=javascript` => `.js`.

