### PR TITLE
clangcheck: removed flags not accepted by clang-check

### DIFF
--- a/autoload/neomake/makers/ft/c.vim
+++ b/autoload/neomake/makers/ft/c.vim
@@ -23,7 +23,7 @@ endfunction
 function! neomake#makers#ft#c#clangcheck()
     return {
         \ 'exe': 'clang-check',
-        \ 'args': ['%:p', '--', '-Wall', '-Wextra'],
+        \ 'args': ['%:p'],
         \ 'errorformat':
             \ '%-G%f:%s:,' .
             \ '%f:%l:%c: %trror: %m,' .


### PR DESCRIPTION
The extra cmd line flags "-- -Wall -Wextra" are not accepted and
processed by clang-check, moreover they actually prevent it from working
correctly.