### PR TITLE
Make the erlc maker distinguish warnings from errors

### DIFF
--- a/autoload/neomake/makers/ft/erlang.vim
+++ b/autoload/neomake/makers/ft/erlang.vim
@@ -6,6 +6,7 @@ endfunction
 function! neomake#makers#ft#erlang#erlc()
     return {
         \ 'errorformat':
-            \ '%f:%l: %m'
+            \ '%W%f:%l: Warning: %m,' .
+            \ '%E%f:%l: %m'
         \ }
 endfunction


### PR DESCRIPTION
Without this patch the erlc maker treats warning as errors.