### PR TITLE
Add bufnr into the hook context of NeomakeFinished

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -532,10 +532,10 @@ function! s:Make(options, ...) abort
         endif
     endfor
     if !len(job_ids)
-        let l:hook_context = {'file_mode': file_mode,
-                            \ 'bufnr': buf,
-                            \}
-        call neomake#utils#hook('NeomakeFinished', l:hook_context)
+        call neomake#utils#hook('NeomakeFinished', {
+                    \ 'file_mode': file_mode,
+                    \ 'bufnr': buf,
+                    \ })
     endif
     return job_ids
 endfunction
@@ -874,10 +874,10 @@ function! neomake#MakeHandler(job_id, data, event_type) abort
         " Trigger autocmd if all jobs for a s:Make instance have finished.
         if neomake#has_async_support()
             if !len(filter(copy(s:jobs), 'v:val.make_id == jobinfo.make_id'))
-                let l:hook_context = {'file_mode': maker.file_mode,
-                                    \ 'bufnr': get(jobinfo, 'bufnr', -1),
-                                    \}
-                call neomake#utils#hook('NeomakeFinished', l:hook_context)
+                call neomake#utils#hook('NeomakeFinished', {
+                            \ 'file_mode': maker.file_mode,
+                            \ 'bufnr': get(jobinfo, 'bufnr', -1),
+                            \ })
             endif
         endif
     endif

--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -532,8 +532,10 @@ function! s:Make(options, ...) abort
         endif
     endfor
     if !len(job_ids)
-        call neomake#utils#hook('NeomakeFinished', {
-                    \ 'file_mode': file_mode})
+        let l:hook_context = {'file_mode': file_mode,
+                            \ 'bufnr': buf,
+                            \}
+        call neomake#utils#hook('NeomakeFinished', l:hook_context)
     endif
     return job_ids
 endfunction
@@ -872,8 +874,10 @@ function! neomake#MakeHandler(job_id, data, event_type) abort
         " Trigger autocmd if all jobs for a s:Make instance have finished.
         if neomake#has_async_support()
             if !len(filter(copy(s:jobs), 'v:val.make_id == jobinfo.make_id'))
-                call neomake#utils#hook('NeomakeFinished', {
-                            \ 'file_mode': maker.file_mode})
+                let l:hook_context = {'file_mode': maker.file_mode,
+                                    \ 'bufnr': get(jobinfo, 'bufnr', -1),
+                                    \}
+                call neomake#utils#hook('NeomakeFinished', l:hook_context)
             endif
         endif
     endif

--- a/doc/neomake.txt
+++ b/doc/neomake.txt
@@ -452,17 +452,20 @@ You can register your own function as a callback like this: >
 The |NeomakeFinished| autocommand is triggered after all jobs for a call to
 |:Neomake| etc have finished.  This can be used to e.g. close an empty
 location or quickfix window.
-For this event `g:neomake_hook_context.file_mode` will be set, indicating if
-this was run for a file or the project.
+For this event, `g:neomake_hook_context.file_mode` and
+`g:neomake_hook_context.bufnr` will be set, indicating if this was run for
+a file or the project (`file_mode`) and the buffer on which |:Neomake| was
+invoked (`bufnr`), respectively.
 
                                                         *NeomakeCountsChanged*
 The |NeomakeCountsChanged| autocommand is triggered after counts for the
 location/quickfix list have changed, i.e. the list got reset or new errors
 have been added.  This can be used to e.g. update the statusline.
-For this event `g:neomake_hook_context.file_mode` and
-`g:neomake_hook_context.bufnr` will be set.  If counts changed because of a
-maker's output being processed, the maker object itself will be passed in
-(which also has these attributes).
+For this event, `g:neomake_hook_context.file_mode` and
+`g:neomake_hook_context.bufnr` will be set (see |NeomakeFinished| for the
+meaning).
+If counts changed because of a maker's output being processed,
+the maker object itself will be passed in (which also has these attributes).
 
 ==============================================================================
 6. Frequently Asked Questions (FAQ)                              *neomake-faq*

--- a/tests/integration.vader
+++ b/tests/integration.vader
@@ -177,7 +177,7 @@ Execute (NeomakeSh: project: handle removed window on exit (quit)):
   endif
   AssertEqual len(g:neomake_test_finished), 1
   AssertEqual map(copy(getqflist()), 'v:val.text'), ['finished']
-  AssertEqual g:neomake_test_finished, [{'file_mode': 0}]
+  AssertEqual g:neomake_test_finished, [{'bufnr': bufnr, 'file_mode': 0}]
   AssertEqual g:neomake_test_countschanged, [{'bufnr': bufnr, 'file_mode': 0}]
 
 Execute (NeomakeSh: project: handle removed window on exit (bwipe)):
@@ -192,7 +192,7 @@ Execute (NeomakeSh: project: handle removed window on exit (bwipe)):
     NeomakeTestsWaitForFinishedJobs
   endif
   AssertEqual map(copy(getqflist()), 'v:val.text'), ['finished']
-  AssertEqual g:neomake_test_finished, [{'file_mode': 0}]
+  AssertEqual g:neomake_test_finished, [{'bufnr': bufnr, 'file_mode': 0}]
   AssertEqual g:neomake_test_countschanged, [{'bufnr': bufnr, 'file_mode': 0}]
 
 Execute (NeomakeInfo):


### PR DESCRIPTION
Let the `g:neomake_hook_context` dictionary on the event 'NeomakeFinished' contain `bufnr`.

Tests and docs are updated accordingly.