### PR TITLE
Ansible file maker

### DIFF
--- a/autoload/neomake/makers/ft/ansible.vim
+++ b/autoload/neomake/makers/ft/ansible.vim
@@ -1,0 +1,13 @@
+" vim: ts=4 sw=4 et
+
+function! neomake#makers#ft#ansible#EnabledMakers() abort
+    return ['ansiblelint']
+endfunction
+
+function! neomake#makers#ft#ansible#ansiblelint() abort
+    return {
+        \ 'exe': 'ansible-lint',
+        \ 'args': ['-p', '--nocolor'],
+        \ 'errorformat': '%f:%l: [%tANSIBLE%n] %m',
+        \ }
+endfunction


### PR DESCRIPTION
Relies on [ansible-lint](https://github.com/willthames/ansible-lint) for linting and [vim-ansible-yaml](https://github.com/chase/vim-ansible-yaml) for filetype detection.