### PR TITLE
tslint maker: use %E in errorformat

### DIFF
--- a/autoload/neomake/makers/ft/typescript.vim
+++ b/autoload/neomake/makers/ft/typescript.vim
@@ -24,6 +24,6 @@ function! neomake#makers#ft#typescript#tslint() abort
         \ 'args': [
             \ '%:p', '--format verbose'
         \ ],
-        \ 'errorformat': '%f[%l\, %c]: %m'
+        \ 'errorformat': '%E%f[%l\, %c]: %m'
         \ }
 endfunction


### PR DESCRIPTION
Same as here: https://github.com/neomake/neomake/pull/532
I was able to get airline support only when enabled %E in error format
And it's related to https://github.com/neomake/neomake/issues/336