### PR TITLE
[Vint] Treat style_problem as info message

### DIFF
--- a/autoload/neomake/makers/ft/vim.vim
+++ b/autoload/neomake/makers/ft/vim.vim
@@ -14,7 +14,7 @@ function! neomake#makers#ft#vim#vint() abort
 
     return {
         \ 'args': l:args,
-        \ 'errorformat': '%f:%l:%c:%t%*[^:]:%m'
+        \ 'errorformat': '%I%f:%l:%c:style_problem:%m,%f:%l:%c:%t%*[^:]:%m'
         \ }
 endfunction
 


### PR DESCRIPTION
Currently, neomake's `errorformat` for vint makes it  treat `style_problem` as an error. This is because the `%t%*[^:]` part of `errorformat` successfully matches `style_problem`. More acurately, `%t` matches `s` and `%*[^]` matches `tyle_problem`. Since `s` is not a valid type (ie. neither `e` for error nor `w` for warning, nor `m` for message) vim, and thus neomake, treats it as error by default. Style issues can hardly be considered errors, so this change makes vim and neomake treat `style_problem` as info.

- `%I` marks the start of a multiline info message
- `%f` matches a filename
- `%l` matches the line of `style_problem`
- `%c` matches the column of `style_problem`
- `style_problem` matches a litteral "style_problem", just like ':' matches a litteral ':'
- `%m` matches the message itself