### PR TITLE
makers: python: improve preprocessing of flake8 entries

### DIFF
--- a/autoload/neomake/makers/ft/python.vim
+++ b/autoload/neomake/makers/ft/python.vim
@@ -72,8 +72,17 @@ function! neomake#makers#ft#python#flake8() abort
 endfunction
 
 function! neomake#makers#ft#python#Flake8EntryProcess(entry) abort
-    if a:entry.type ==# 'F'  " PyFlake errors
-        let type = 'E'
+    if a:entry.type ==# 'F'  " pyflakes
+        " Ref: http://flake8.pycqa.org/en/latest/user/error-codes.html
+        if a:entry.nr > 400 && a:entry.nr < 500
+            if a:entry.nr == 407
+                let type = 'E'  " 'an undefined __future__ feature name was imported'
+            else
+                let type = 'W'
+            endif
+        else
+            let type = 'E'
+        endif
     elseif a:entry.type ==# 'E' && a:entry.nr >= 900  " PEP8 runtime errors (E901, E902)
         let type = 'E'
     elseif a:entry.type ==# 'E' || a:entry.type ==# 'W'  " PEP8 errors & warnings


### PR DESCRIPTION
All the F4* (apart from F407) should be warnings, and not errors.