### PR TITLE
Refactor output processing to only be done in insert/normal mode

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -822,24 +822,13 @@ function! s:RegisterJobOutput(jobinfo, lines, source) abort
     endif
 
     " Process the window directly if we can.
-    if s:CanProcessJobOutput()
-        let called_from_qf = &filetype ==# 'qf'
-        let winnr_has_jobs = index(get(w:, 'neomake_jobs', []), a:jobinfo.id) != -1
-        if called_from_qf || winnr_has_jobs
-            " Process the previous window if we are in a qf window.
-            " XXX: noautocmd, restore alt window.
-            if called_from_qf
-                wincmd p
-            endif
-            call s:ProcessJobOutput(a:jobinfo, a:lines, a:source)
-            call neomake#signs#PlaceVisibleSigns()
-            call neomake#highlights#ShowHighlights()
-            if called_from_qf
-                wincmd p
-            endif
-            return
-        endif
+    if s:CanProcessJobOutput() && index(get(w:, 'neomake_jobs', []), a:jobinfo.id) != -1
+        call s:ProcessJobOutput(a:jobinfo, a:lines, a:source)
+        call neomake#signs#PlaceVisibleSigns()
+        call neomake#highlights#ShowHighlights()
+        return
     endif
+
     " file mode: append lines to jobs's window's output.
     let [t, w] = s:GetTabWinForJob(a:jobinfo.id)
     if w == -1

--- a/autoload/neomake/utils.vim
+++ b/autoload/neomake/utils.vim
@@ -32,9 +32,9 @@ function! neomake#utils#LogMessage(level, msg, ...) abort
     if a:0
         let jobinfo = a:1
         if has_key(jobinfo, 'id')
-            let msg = printf('[%d.%d] %s', jobinfo.make_id, jobinfo.id, a:msg)
+            let msg = printf('[%s.%d] %s', get(jobinfo, 'make_id', '-'), jobinfo.id, a:msg)
         else
-            let msg = printf('[%d] %s', jobinfo.make_id, a:msg)
+            let msg = printf('[%s] %s', get(jobinfo, 'make_id', '?'), a:msg)
         endif
     else
         let jobinfo = {}

--- a/plugin/neomake.vim
+++ b/plugin/neomake.vim
@@ -37,7 +37,8 @@ endfunction
 
 augroup neomake
   au!
-  au WinEnter,CursorHold * call neomake#ProcessCurrentWindow()
+  au WinEnter * call neomake#ProcessCurrentWindow()
+  au CursorHold * call neomake#ProcessPendingOutput()
   au BufEnter * call neomake#highlights#ShowHighlights()
   au CursorMoved * call neomake#CursorMoved()
   au ColorScheme,VimEnter * call s:neomake_init()

--- a/tests/include/setup.vader
+++ b/tests/include/setup.vader
@@ -189,6 +189,14 @@ Before:
     Log "SKIP: no async support."
   endfunction
 
+  " Fixtures
+  let g:neomake_test_sleep_maker = {
+      \ 'name': 'sleep_maker',
+      \ 'exe': 'sh',
+      \ 'args': ['-c', 'sleep 0.1; echo finished'],
+      \ 'remove_invalid_entries': 0,
+      \ }
+
   doautocmd VimEnter
 
 After:

--- a/tests/include/setup.vader
+++ b/tests/include/setup.vader
@@ -190,11 +190,11 @@ Before:
   endfunction
 
   " Fixtures
-  let g:neomake_test_sleep_maker = {
-      \ 'name': 'sleep_maker',
+  let g:neomake_test_sleep_efm_maker = {
+      \ 'name': 'sleep_efm_maker',
       \ 'exe': 'sh',
-      \ 'args': ['-c', 'sleep 0.1; echo finished'],
-      \ 'remove_invalid_entries': 0,
+      \ 'args': ['-c', 'sleep 0.1; echo file1:1:E:error message; echo file1:2:W:warning'],
+      \ 'errorformat': '%f:%l:%t:%m',
       \ }
 
   doautocmd VimEnter

--- a/tests/include/setup.vader
+++ b/tests/include/setup.vader
@@ -8,19 +8,26 @@ Before:
   if exists(':NeomakeTestsWaitForFinishedJobs') == 2
     finish
   endif
-  function! s:wait_for_finished_jobs()
+  function! s:wait_for_jobs(filter)
     let max = 60
-    let filter = "!get(v:val, 'finished')"
-    while len(filter(copy(neomake#GetJobs()), filter))
+    let filter = a:filter
+    while 1
       let max -= 1
-      sleep 50m
+      let jobs = copy(neomake#GetJobs())
+      if len(a:filter)
+        let jobs = filter(jobs, a:filter)
+      endif
+      if !len(jobs)
+        break
+      endif
       if max == 0
-        let jobs = neomake#GetJobs()
         throw "Jobs did not finish after 3s: ".string(jobs)
       endif
+      sleep 50m
     endwhile
   endfunction
-  command! NeomakeTestsWaitForFinishedJobs call s:wait_for_finished_jobs()
+  command! NeomakeTestsWaitForFinishedJobs call s:wait_for_jobs("!get(v:val, 'finished')")
+  command! NeomakeTestsWaitForRemovedJobs call s:wait_for_jobs('')
 
   function! s:wait_for_next_message()
     let max = 60
@@ -193,7 +200,8 @@ Before:
   let g:neomake_test_sleep_efm_maker = {
       \ 'name': 'sleep_efm_maker',
       \ 'exe': 'sh',
-      \ 'args': ['-c', 'sleep 0.1; echo file1:1:E:error message; echo file1:2:W:warning'],
+      \ 'args': ['-c', 'sleep 0.1; echo file1:1:E:error message; '
+      \         .'echo file1:2:W:warning; echo file1:1:E:error2'],
       \ 'errorformat': '%f:%l:%t:%m',
       \ }
 
@@ -214,4 +222,13 @@ After:
 
   if exists('#neomake_tests')
     autocmd! neomake_tests
+  endif
+
+  if !get(g:, '_neomake_test_thrown_win_assertion', 0)
+    if winnr('$') > 1
+      let g:_neomake_test_thrown_win_assertion = 1
+      throw "More than 1 window after tests: "
+        \ .string(map(range(1, winnr('$')),
+        \ "[bufname(winbufnr(v:val)), getbufvar(winbufnr(v:val), '&bt')]"))
+    endif
   endif

--- a/tests/integration.vader
+++ b/tests/integration.vader
@@ -24,9 +24,9 @@ Execute (Test Neomake on errors.sh with one maker):
   endfor
 
   " Basic verification that signs are placed.
-  AssertNeomakeMessage 'Placing sign: sign place 5000 line=5 name=neomake_err buffer=4', 3, {}
-  AssertNeomakeMessage 'Unplacing sign: sign unplace 5000 buffer=4', 3, {}
-  AssertNeomakeMessage 'Placing sign: sign place 5000 line=5 name=neomake_err buffer=4', 3, {}
+  AssertNeomakeMessage 'Placing sign: sign place 5000 line=5 name=neomake_err buffer='.bufnr, 3, {}
+  AssertNeomakeMessage 'Unplacing sign: sign unplace 5000 buffer='.bufnr, 3, {}
+  AssertNeomakeMessage 'Placing sign: sign place 5000 line=5 name=neomake_err buffer='.bufnr, 3, {}
 
   let signs = split(neomake#utils#redir('sign place'), '\n')
   call map(signs, "substitute(substitute(v:val, '\\m^\\s\\+', '', ''), '\\m\\s\\+$', '', '')")
@@ -79,6 +79,7 @@ Execute (Neomake: handle output for removed window):
   AssertNeomakeMessage 'No window found for output!', 2, jobinfo
 
 Execute (NeomakeSh: true):
+  call neomake#statusline#ResetCounts()
   call g:NeomakeSetupAutocmdWrappers()
   AssertEqual g:neomake_test_countschanged, []
   let bufnr = bufnr('%')

--- a/tests/integration.vader
+++ b/tests/integration.vader
@@ -47,13 +47,7 @@ Execute (Test Neomake on errors.sh with two makers):
 Execute (Neomake: handle result for current window):
   call g:NeomakeSetupAutocmdWrappers()
   let orig_winnr = winnr()
-  let sleep_maker = {
-      \ 'name': 'sleep_maker',
-      \ 'exe': 'sh',
-      \ 'args': ['-c', 'sleep 0.1; echo finished'],
-      \ 'remove_invalid_entries': 0,
-      \ }
-  call neomake#Make(1, [sleep_maker])
+  call neomake#Make(1, [neomake_test_sleep_maker])
   if neomake#has_async_support()
     new
     NeomakeTestsWaitForFinishedJobs
@@ -72,13 +66,7 @@ Execute (Neomake: handle output for removed window):
 
   call g:NeomakeSetupAutocmdWrappers()
   let orig_winnr = winnr()
-  let sleep_maker = {
-      \ 'name': 'sleep_maker',
-      \ 'exe': 'sh',
-      \ 'args': ['-c', 'sleep 0.1; echo finished'],
-      \ 'remove_invalid_entries': 0,
-      \ }
-  call neomake#Make(1, [sleep_maker])
+  call neomake#Make(1, [neomake_test_sleep_maker])
   let jobinfo = neomake#GetJobs()[0]
   let bufnr = bufnr('%')
   new

--- a/tests/integration.vader
+++ b/tests/integration.vader
@@ -47,7 +47,7 @@ Execute (Test Neomake on errors.sh with two makers):
 Execute (Neomake: handle result for current window):
   call g:NeomakeSetupAutocmdWrappers()
   let orig_winnr = winnr()
-  call neomake#Make(1, [neomake_test_sleep_maker])
+  call neomake#Make(1, [neomake_test_sleep_efm_maker])
   if neomake#has_async_support()
     new
     NeomakeTestsWaitForFinishedJobs
@@ -56,7 +56,7 @@ Execute (Neomake: handle result for current window):
     AssertEqual map(copy(getloclist(0)), 'v:val.text'), []
     quit
     AssertEqual winnr(), orig_winnr
-    AssertEqual map(copy(getloclist(0)), 'v:val.text'), ['finished']
+    AssertEqual map(copy(getloclist(0)), 'v:val.text'), ['error message', 'warning']
   endif
   AssertEqual len(g:neomake_test_finished), 1
   AssertEqual len(g:neomake_test_countschanged), 1
@@ -66,7 +66,7 @@ Execute (Neomake: handle output for removed window):
 
   call g:NeomakeSetupAutocmdWrappers()
   let orig_winnr = winnr()
-  call neomake#Make(1, [neomake_test_sleep_maker])
+  call neomake#Make(1, [neomake_test_sleep_efm_maker])
   let jobinfo = neomake#GetJobs()[0]
   let bufnr = bufnr('%')
   new

--- a/tests/integration.vader
+++ b/tests/integration.vader
@@ -41,8 +41,9 @@ Execute (Test Neomake on errors.sh with two makers):
   e! tests/fixtures/errors.sh
   RunNeomake sh shellcheck
   AssertEqual len(g:neomake_test_countschanged), 2
-  AssertNeomakeMessage 'Running makers: [''sh'', ''shellcheck'']', 3,
-    \ {'make_id': neomake#GetStatus().last_make_id}
+
+  Assert len(filter(copy(g:neomake_test_messages),
+    \ "v:val[1] =~# '^Running makers: sh, shellcheck (.*)'")) == 1, '"Running makers" message found'
 
 Execute (Neomake: handle result for current window):
   call g:NeomakeSetupAutocmdWrappers()
@@ -52,11 +53,11 @@ Execute (Neomake: handle result for current window):
     new
     NeomakeTestsWaitForFinishedJobs
     AssertEqual len(g:neomake_test_countschanged), 0
-    AssertEqual len(g:neomake_test_finished), 1, "tests finished"
+    AssertEqual len(g:neomake_test_finished), 0, "output pending"
     AssertEqual map(copy(getloclist(0)), 'v:val.text'), []
     quit
     AssertEqual winnr(), orig_winnr
-    AssertEqual map(copy(getloclist(0)), 'v:val.text'), ['error message', 'warning']
+    AssertEqual map(copy(getloclist(0)), 'v:val.text'), ['error message', 'warning', 'error2']
   endif
   AssertEqual len(g:neomake_test_finished), 1
   AssertEqual len(g:neomake_test_countschanged), 1

--- a/tests/lists.vader
+++ b/tests/lists.vader
@@ -6,12 +6,12 @@ Execute (Postprocessing should update list):
   let list = getloclist(0)
   AssertNotEqual list, [], 'loclist is not empty'
 
-  let s:efm = neomake#makers#ft#sh#sh()
+  let s:sh_maker = neomake#makers#ft#sh#sh()
   function g:Postprocess(entry)
     let a:entry.text .= ' SUFFIX'
   endfunction
   function! neomake#makers#ft#sh#sh()
-    return extend(s:efm, {'postprocess': function('g:Postprocess')})
+    return extend(s:sh_maker, {'postprocess': function('g:Postprocess')})
   endfunction
   let expected_list = map(list, 'extend(v:val, {"text": v:val.text." SUFFIX"})')
   RunNeomake sh

--- a/tests/lists.vader
+++ b/tests/lists.vader
@@ -53,3 +53,4 @@ Execute (AddExprCallback with changed windows inbetween):
     \ loclist_texts + ['1b SUFFIX:1']
   wincmd k
   AssertEqual map(copy(getloclist(0)), 'v:val.text'), ['2 SUFFIX:1']
+  q

--- a/tests/neomake.vader
+++ b/tests/neomake.vader
@@ -157,7 +157,7 @@ Execute (neomake#CancelJob! with invalid job):
   AssertNeomakeMessageAbsent 'Stopping job: '.job_id, 3
 
   NeomakeTestsWaitForFinishedJobs
-  AssertNeomakeMessageAbsent 'neomake#MakeHandler: exit: job not found: 1'
+  AssertNeomakeMessageAbsent 'neomake#MakeHandler: exit: job not found: '.job_id
 
   NeomakeTestsWaitForNextMessage
   AssertNeomakeMessage 'neomake#MakeHandler: exit: job not found: '.job_id, 1

--- a/tests/neomake.vader
+++ b/tests/neomake.vader
@@ -11,8 +11,8 @@ Include (Maker args): args.vader
 Include (Mapexpr): mapexpr.vader
 Include (Signs): signs.vader
 Include (Statusline): statusline.vader
+Include (Processing): processing.vader
 Include (Utils): utils.vader
-
 
 ~ Filetype specific
 Include (Haskell): ft_haskell.vader

--- a/tests/processing.vader
+++ b/tests/processing.vader
@@ -1,0 +1,29 @@
+Execute (Output is only processed in normal/insert mode (loclist)):
+  call neomake#Make(1, [neomake_test_sleep_efm_maker])
+  norm! V
+  if neomake#has_async_support()
+    NeomakeTestsWaitForFinishedJobs
+    AssertEqual getloclist(0), [], 'Location list has not been updated'
+    AssertNeomakeMessage 'sleep_efm_maker: completed with exit code 0.'
+  endif
+  AssertEqual mode(), 'V'
+  exe "norm! \<Esc>"
+  AssertEqual mode(), 'n'
+  doautocmd CursorHold
+  AssertNeomakeMessage 'sleep_efm_maker: processing 2 lines of output.'
+  AssertEqual map(copy(getloclist(0)), 'v:val.text'), ['error message', 'warning']
+
+Execute (Output is only processed in normal/insert mode (qflist)):
+  call neomake#Make(0, [neomake_test_sleep_efm_maker])
+  norm! V
+  if neomake#has_async_support()
+    NeomakeTestsWaitForFinishedJobs
+    AssertEqual getqflist(), [], 'Quickfix list has not been updated'
+    AssertNeomakeMessage 'sleep_efm_maker: completed with exit code 0.'
+  endif
+  AssertEqual mode(), 'V'
+  exe "norm! \<Esc>"
+  AssertEqual mode(), 'n'
+  doautocmd CursorHold
+  AssertNeomakeMessage 'sleep_efm_maker: processing 2 lines of output.'
+  AssertEqual map(copy(getqflist()), 'v:val.text'), ['error message', 'warning']

--- a/tests/processing.vader
+++ b/tests/processing.vader
@@ -1,11 +1,11 @@
 Execute (Output is only processed in normal/insert mode (loclist)):
+  if !NeomakeAsyncTestsSetup() | finish | endif
+
   call neomake#Make(1, [neomake_test_sleep_efm_maker])
   norm! V
-  if neomake#has_async_support()
-    NeomakeTestsWaitForFinishedJobs
-    AssertEqual getloclist(0), [], 'Location list has not been updated'
-    AssertNeomakeMessage 'sleep_efm_maker: completed with exit code 0.'
-  endif
+  NeomakeTestsWaitForFinishedJobs
+  AssertEqual getloclist(0), [], 'Location list has not been updated'
+  AssertNeomakeMessage 'sleep_efm_maker: completed with exit code 0.'
   AssertEqual mode(), 'V'
   exe "norm! \<Esc>"
   AssertEqual mode(), 'n'
@@ -14,16 +14,54 @@ Execute (Output is only processed in normal/insert mode (loclist)):
   AssertEqual map(copy(getloclist(0)), 'v:val.text'), ['error message', 'warning']
 
 Execute (Output is only processed in normal/insert mode (qflist)):
+  if !NeomakeAsyncTestsSetup() | finish | endif
+
   call neomake#Make(0, [neomake_test_sleep_efm_maker])
   norm! V
-  if neomake#has_async_support()
-    NeomakeTestsWaitForFinishedJobs
-    AssertEqual getqflist(), [], 'Quickfix list has not been updated'
-    AssertNeomakeMessage 'sleep_efm_maker: completed with exit code 0.'
-  endif
+  NeomakeTestsWaitForFinishedJobs
+  AssertEqual getqflist(), [], 'Quickfix list has not been updated'
+  AssertNeomakeMessage 'sleep_efm_maker: completed with exit code 0.'
   AssertEqual mode(), 'V'
   exe "norm! \<Esc>"
   AssertEqual mode(), 'n'
   doautocmd CursorHold
   AssertNeomakeMessage 'sleep_efm_maker: processing 2 lines of output.'
   AssertEqual map(copy(getqflist()), 'v:val.text'), ['error message', 'warning']
+
+Execute (Output is only processed in normal/insert mode (from loclist)):
+  if !NeomakeAsyncTestsSetup() | finish | endif
+
+  call neomake#Make(1, [neomake_test_sleep_efm_maker])
+  lopen
+  AssertEqual &buftype, 'quickfix'
+  AssertEqual winnr(), 2
+  AssertEqual line('$'), 1
+  norm! V
+  NeomakeTestsWaitForFinishedJobs
+  AssertEqual getloclist(0), [], 'Location list has not been updated'
+  AssertNeomakeMessage 'sleep_efm_maker: completed with exit code 0.'
+  AssertEqual mode(), 'V'
+  exe "norm! \<Esc>"
+  AssertEqual mode(), 'n'
+  doautocmd CursorHold
+  AssertEqual getloclist(0), []
+  wincmd p
+  AssertNeomakeMessage 'sleep_efm_maker: processing 2 lines of output.'
+  AssertEqual map(copy(getloclist(0)), 'v:val.text'), ['error message', 'warning']
+
+Execute (Output gets not processed from loclist):
+  if !NeomakeAsyncTestsSetup() | finish | endif
+
+  laddexpr ''
+  call neomake#Make(1, [neomake_test_sleep_efm_maker])
+  lopen
+  AssertEqual &buftype, 'quickfix'
+  AssertEqual winnr(), 2
+  NeomakeTestsWaitForFinishedJobs
+  AssertEqual winnr(), 2
+
+  AssertEqual len(g:neomake_test_finished), 1
+  AssertEqual getloclist(0), []
+
+  lclose
+  AssertEqual map(copy(getloclist(0)), 'v:val.text'), ['error message', 'warning']

--- a/tests/processing.vader
+++ b/tests/processing.vader
@@ -1,3 +1,5 @@
+Include: include/setup.vader
+
 Execute (Output is only processed in normal/insert mode (loclist)):
   if !NeomakeAsyncTestsSetup() | finish | endif
 
@@ -9,14 +11,19 @@ Execute (Output is only processed in normal/insert mode (loclist)):
   AssertEqual mode(), 'V'
   exe "norm! \<Esc>"
   AssertEqual mode(), 'n'
+  AssertEqual len(g:neomake_test_countschanged), 0
+  AssertEqual len(g:neomake_test_finished), 0
   doautocmd CursorHold
-  AssertNeomakeMessage 'sleep_efm_maker: processing 2 lines of output.'
-  AssertEqual map(copy(getloclist(0)), 'v:val.text'), ['error message', 'warning']
+  AssertEqual len(g:neomake_test_countschanged), 1, "a"
+  AssertEqual len(g:neomake_test_finished), 1, "b"
+  AssertNeomakeMessage 'sleep_efm_maker: processing 3 lines of output.'
+  AssertEqual map(copy(getloclist(0)), 'v:val.text'), ['error message', 'warning', 'error2']
 
 Execute (Output is only processed in normal/insert mode (qflist)):
   if !NeomakeAsyncTestsSetup() | finish | endif
 
-  call neomake#Make(0, [neomake_test_sleep_efm_maker])
+  call neomake#Make(0, [neomake_test_sleep_efm_maker])[0]
+  let jobinfo = neomake#GetJobs()[-1]
   norm! V
   NeomakeTestsWaitForFinishedJobs
   AssertEqual getqflist(), [], 'Quickfix list has not been updated'
@@ -25,8 +32,10 @@ Execute (Output is only processed in normal/insert mode (qflist)):
   exe "norm! \<Esc>"
   AssertEqual mode(), 'n'
   doautocmd CursorHold
-  AssertNeomakeMessage 'sleep_efm_maker: processing 2 lines of output.'
-  AssertEqual map(copy(getqflist()), 'v:val.text'), ['error message', 'warning']
+  AssertNeomakeMessage 'sleep_efm_maker: processing 3 lines of output.'
+  AssertNeomakeMessage 'Processed pending output', 3, jobinfo
+  AssertEqual map(copy(getqflist()), 'v:val.text'), ['error message', 'warning', 'error2']
+  NeomakeTestsWaitForRemovedJobs
 
 Execute (Output is only processed in normal/insert mode (from loclist)):
   if !NeomakeAsyncTestsSetup() | finish | endif
@@ -46,8 +55,9 @@ Execute (Output is only processed in normal/insert mode (from loclist)):
   doautocmd CursorHold
   AssertEqual getloclist(0), []
   wincmd p
-  AssertNeomakeMessage 'sleep_efm_maker: processing 2 lines of output.'
-  AssertEqual map(copy(getloclist(0)), 'v:val.text'), ['error message', 'warning']
+  AssertNeomakeMessage 'sleep_efm_maker: processing 3 lines of output.'
+  AssertEqual map(copy(getloclist(0)), 'v:val.text'), ['error message', 'warning', 'error2']
+  lclose
 
 Execute (Output gets not processed from loclist):
   if !NeomakeAsyncTestsSetup() | finish | endif
@@ -60,8 +70,55 @@ Execute (Output gets not processed from loclist):
   NeomakeTestsWaitForFinishedJobs
   AssertEqual winnr(), 2
 
-  AssertEqual len(g:neomake_test_finished), 1
+  AssertEqual len(g:neomake_test_finished), 0
+  AssertEqual len(g:neomake_test_countschanged), 0
   AssertEqual getloclist(0), []
 
   lclose
-  AssertEqual map(copy(getloclist(0)), 'v:val.text'), ['error message', 'warning']
+  AssertEqual len(g:neomake_test_finished), 1
+  AssertEqual len(g:neomake_test_countschanged), 1
+  AssertEqual map(copy(getloclist(0)), 'v:val.text'), ['error message', 'warning', 'error2']
+
+Execute (Unbuffered output handled correctly (loclist)):
+  if !NeomakeAsyncTestsSetup() | finish | endif
+
+  let maker_1 = extend(neomake#utils#MakerFromCommand(
+    \ 'for i in $(seq 1 5); do echo $i; sleep 0.01; done'), {
+    \ 'buffer_output': 0, 'errorformat': '%m'})
+  let maker_2 = extend(neomake#utils#MakerFromCommand(
+    \ 'for i in $(seq 1 5); do echo 2_$i; sleep 0.01; done'), {
+    \ 'buffer_output': 0, 'errorformat': '%m'})
+
+  let job_ids = neomake#Make(1, [maker_1, maker_2])
+  let [jobinfo1, jobinfo2] = neomake#GetJobs(job_ids)
+  Assert jobinfo1.id < jobinfo2.id, "jobinfo1 before jobinfo2"
+  new
+  NeomakeTestsWaitForFinishedJobs
+  AssertNeomakeMessage 'Output left to be processed, not cleaning job yet.', 3
+  wincmd p
+  NeomakeTestsWaitForRemovedJobs
+  AssertNeomakeMessage 'Processed pending output', 3, jobinfo1
+  AssertNeomakeMessage 'Processed pending output', 3, jobinfo2
+  AssertEqual len(g:neomake_test_countschanged), 2
+  AssertEqual map(copy(getloclist(0)), 'v:val.text'),
+    \ ['1', '2', '3', '4', '5', '2_1', '2_2', '2_3', '2_4', '2_5']
+  wincmd p
+  q
+
+Execute (Unbuffered output handled correctly (qflist)):
+  call neomake#statusline#ResetCounts()
+  if !NeomakeAsyncTestsSetup() | finish | endif
+
+  let maker_1 = extend(neomake#utils#MakerFromCommand(
+    \ 'for i in $(seq 1 5); do echo $i; sleep 0.01; done'), {
+    \ 'buffer_output': 0, 'errorformat': '%m'})
+
+  call neomake#Make(0, [maker_1])
+  norm! V
+  NeomakeTestsWaitForFinishedJobs
+  AssertNeomakeMessage 'Output left to be processed, not cleaning job yet.', 3
+  exe "norm! <Esc>"
+  doautocmd CursorHold
+  NeomakeTestsWaitForRemovedJobs
+  AssertEqual len(g:neomake_test_countschanged), 1
+  AssertEqual map(copy(getqflist()), 'v:val.text'), map(range(1, 5), 'v:val . ""')

--- a/tests/signs.vader
+++ b/tests/signs.vader
@@ -38,10 +38,14 @@ Execute (neomake#signs#RedefineErrorSign):
   " Test #736.
   call neomake#signs#RedefineErrorSign({'text': '✗', 'texthl': 'ErrorMsg'})
 
+  call neomake#Make(1, [neomake_test_sleep_efm_maker])
+  NeomakeTestsWaitForFinishedJobs
+  AssertNeomakeMessage 'Cleaning old signs in buffer '.bufnr.':  {'.bufnr.': {2: 5000}}', 3, {}
+
   bd!
   call neomake#signs#Reset(bufnr, 'file')
   call neomake#signs#CleanAllOldSigns('file')
-  AssertNeomakeMessage 'Cleaning old signs in buffer '.bufnr.':  {'.bufnr.': {2: 5000}}', 3, {}
+  AssertNeomakeMessage 'Removing signs {file: {}, project: {}}', 3
 
 
 Execute (neomake#signs#PlaceVisibleSigns in project mode):


### PR DESCRIPTION
https://github.com/neomake/neomake/issues/805

TODO
 - [x] only trigger NeomakeFinished after output has been processed, and/or add a new User autocommand?  My use case is automatically closing the location/quickfix list if they are empty.  But currently they will be in case of delayed processing, since they were cleared in the beginning.  The fix for this could also be https://github.com/neomake/neomake/issues/741.