### PR TITLE
Fixes #835 Bad default for g:neomake_highlight_lines

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -552,7 +552,7 @@ function! s:AddExprCallback(jobinfo, prev_index) abort
     let file_mode = get(maker, 'file_mode')
     let place_signs = get(g:, 'neomake_place_signs', 1)
     let highlight_columns = get(g:, 'neomake_highlight_columns', 1)
-    let highlight_lines = get(g:, 'neomake_highlight_lines', 1)
+    let highlight_lines = get(g:, 'neomake_highlight_lines', 0)
     let list = file_mode ? getloclist(0) : getqflist()
     let list_modified = 0
     let counts_changed = 0


### PR DESCRIPTION
Fixes #835 

The docs say that `g:neomake_higlight_lines` is 0 by default. It wasn't. Now it is. 

This also fixes `g:neomake_highlight_columns` not being respected.