### PR TITLE
Fix/simplify neomake#utils#ExpandArgs

### DIFF
--- a/autoload/neomake/utils.vim
+++ b/autoload/neomake/utils.vim
@@ -326,7 +326,7 @@ endfunction
 
 function! neomake#utils#ExpandArgs(args) abort
     " Only expand those args that start with \ and a single %
-    call map(a:args, "v:val =~# '\\(^\\\\\\|^%$\\|^%[^%]\\)' ? expand(v:val) : v:val")
+    call map(a:args, "v:val =~# '\\(^%$\\|^%:\\l\\+$\\)' ? expand(v:val) : v:val")
 endfunction
 
 function! neomake#utils#hook(event, context) abort

--- a/tests/utils.vader
+++ b/tests/utils.vader
@@ -88,26 +88,10 @@ Execute(neomake#utils#redir):
   AssertEqual neomake#utils#redir(['NeomakeTestCommand', 'echon 3']), "\n1\n23"
   AssertThrows neomake#utils#redir(['NeomakeTestCommand', 'echoerr 3'])
 
-Execute (Should expand arguments that start with %):
-  let param1 = '%'
-  let param2 = '%:h'
-  let param3 = '--param1=%:h'
-  let args = [param1, param2, param3]
-  let expected_args = [expand(param1), expand(param2), param3]
-  call neomake#utils#ExpandArgs(args)
-  AssertEqual expected_args, args
-
-Execute (Should expand arguments that start with escape char \):
-  let param1 = '\%'
-  let param2 = '\%:p'
-  let args = [param1, param2]
-  let expected_args = [expand(param1), expand(param2)]
-  call neomake#utils#ExpandArgs(args)
-  AssertEqual expected_args, args
-
-Execute (Should not expand arguments that start with double %):
-  let args = ['%%:h', '%%']
-  let expected_args = ['%%:h', '%%']
+Execute (neomake#utils#ExpandArgs):
+  file file1.ext
+  let args = ['%', '%:h', '%:rt', '--foo=%:h', '%s', '\%', '%%']
+  let expected_args = ['file1.ext', '.', 'file1', '--foo=%:h', '%s', '\%', '%%']
   call neomake#utils#ExpandArgs(args)
   AssertEqual expected_args, args
 


### PR DESCRIPTION
This allows for using '%s' as argument, e.g. with ['printf', '%s\n',
'1', '2'], and removes the weird rule to expand items starting with
backslash, but not with backslashes only inside.