### PR TITLE
Allow for maker.args to be a string, skipping quotation/escaping

### DIFF
--- a/doc/neomake.txt
+++ b/doc/neomake.txt
@@ -89,11 +89,15 @@ Here is a sample maker definition: >
     " Use the maker like this:
     :Neomake! make
 <
-All `args` will be |expand()|ed if they use wildcards (see |expand()|). The
-`exe` and `args` entries can be a function reference (see |Funcref|) or a
-dictionary with an expected entry `fn` (which has to be a function). The
-function must return a string, and the function will be called with no
-arguments.
+The `exe` and `args` entries can be a function reference (see |Funcref|) or a
+dictionary with an expected entry `fn` (which has to be a function).
+The function will be called with no arguments, and should return the value to
+use.
+
+`exe` has to be a string, while `args` can be a list or a string.
+If `args` is a list, entries like '%' and '%:p' will be |expand()|ed, and
+quoting/escaping is applied automatically.  If you want to handle escaping
+yourself, `args` should be a string.
 
 In the above example, the exe argument isn't strictly necessary, since Neomake
 uses the name of the maker as the default value for it.  If you want it to be

--- a/tests/args.vader
+++ b/tests/args.vader
@@ -1,0 +1,26 @@
+Include: include/setup.vader
+
+Execute (neomake#GetMakers):
+  let maker = {
+        \ 'exe': '/usr/bin/printf',
+        \ 'args': ['%s\n', '1', '2', '3a 3b'],
+        \ 'errorformat': '%f: %m',
+        \ 'mapexpr': 'expand("%:p") . ": " . v:val',
+        \ }
+
+  let fname = 'a filename with spaces'
+  file a\ filename\ with\ spaces
+  AssertEqual bufname('%'), fname
+  let fname_abs = expand('%:p')
+
+  call neomake#Make(1, [maker])
+  NeomakeTestsWaitForFinishedJobs
+  Log getloclist(0)
+  AssertEqual map(copy(getloclist(0)), 'v:val.text'),
+    \ ['1', '2', '3a 3b', fname_abs]
+
+  let maker.args = "'%s\\n' 1 2 '3a 3b' 4"
+  call neomake#Make(1, [maker])
+  NeomakeTestsWaitForFinishedJobs
+  AssertEqual map(copy(getloclist(0)), 'v:val.text'),
+    \ ['1', '2', '3a 3b', '4', fname_abs]

--- a/tests/args.vader
+++ b/tests/args.vader
@@ -15,7 +15,6 @@ Execute (neomake#GetMakers):
 
   call neomake#Make(1, [maker])
   NeomakeTestsWaitForFinishedJobs
-  Log getloclist(0)
   AssertEqual map(copy(getloclist(0)), 'v:val.text'),
     \ ['1', '2', '3a 3b', fname_abs]
 

--- a/tests/neomake.vader
+++ b/tests/neomake.vader
@@ -6,6 +6,7 @@ Include (Integration tests): integration.vader
 ~ Features
 Include (Lists): lists.vader
 Include (Makers): makers.vader
+Include (Maker args): args.vader
 Include (Mapexpr): mapexpr.vader
 Include (Signs): signs.vader
 Include (Statusline): statusline.vader


### PR DESCRIPTION
Fixes https://github.com/neomake/neomake/issues/837.
Closes https://github.com/neomake/neomake/pull/841.

TODO
 - [ ] probably does not work as expected on Windows?!  Could somebody test it?