### PR TITLE
[RFC] Do not enable makers by default for ft=text

### DIFF
--- a/autoload/neomake/makers/ft/text.vim
+++ b/autoload/neomake/makers/ft/text.vim
@@ -1,5 +1,6 @@
 function! neomake#makers#ft#text#EnabledMakers() abort
-    return ['proselint']
+    " No makers enabled by default, since text is used as fallback often.
+    return []
 endfunction
 
 function! neomake#makers#ft#text#proselint() abort


### PR DESCRIPTION
It is used as fallback often, and e.g. 'proselint' does not make sense
then.