### PR TITLE
allow dict function for maker.args

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -149,7 +149,7 @@ function! s:MakeJob(make_id, options) abort
         let exe = maker.exe
     endif
     if type(maker.args) == type(function('tr'))
-        let args = call(maker.args, [])
+        let args = call(maker.args, [], maker)
     elseif type(maker.args) == type({})
         let args = call(maker.args.fn, [], maker.args)
     else

--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -142,7 +142,7 @@ function! s:MakeJob(make_id, options) abort
 
     " Resolve exe/args, which might be a function or dictionary.
     if type(maker.exe) == type(function('tr'))
-        let exe = call(maker.exe, [])
+        let exe = call(maker.exe, [], maker)
     elseif type(maker.exe) == type({})
         let exe = call(maker.exe.fn, [], maker.exe)
     else

--- a/tests/args.vader
+++ b/tests/args.vader
@@ -26,13 +26,27 @@ Execute (neomake#GetMakers):
 
 Execute (dict function given as maker args value):
   let g:makerdict = {
-        \ 'exe': '/usr/bin/printf',
-        \ 'errorformat': '%f: %m',
-        \ 'append_file': 0,
-        \ }
+    \ 'exe': '/usr/bin/printf',
+    \ 'errorformat': '%f: %m',
+    \ 'append_file': 0,
+    \ }
   function! g:makerdict.args()
     return ['%s: %s', 'file1', 'exe: '.self.exe]
   endfunction
   call neomake#Make(1, [makerdict])
   NeomakeTestsWaitForFinishedJobs
   AssertEqual map(copy(getloclist(0)), 'v:val.text'), ['exe: /usr/bin/printf']
+
+Execute (exe function given as maker exe value):
+  function! g:Eref() dict
+    return '/usr/bin/printf'
+  endfunction
+  let g:makerexe = {
+    \ 'exe': function('g:Eref'),
+    \ 'args':['%s %s\n', 'curfile:', 'exe'],
+    \ 'errorformat': '%f: %m',
+    \ 'append_file': 0,
+    \ }
+  call neomake#Make(1, [makerexe])
+  NeomakeTestsWaitForFinishedJobs
+  AssertEqual map(copy(getloclist(0)), 'v:val.text'), ['exe']

--- a/tests/args.vader
+++ b/tests/args.vader
@@ -23,3 +23,16 @@ Execute (neomake#GetMakers):
   NeomakeTestsWaitForFinishedJobs
   AssertEqual map(copy(getloclist(0)), 'v:val.text'),
     \ ['1', '2', '3a 3b', '4', fname_abs]
+
+Execute (dict function given as maker args value):
+  let g:makerdict = {
+        \ 'exe': '/usr/bin/printf',
+        \ 'errorformat': '%f: %m',
+        \ 'append_file': 0,
+        \ }
+  function! g:makerdict.args()
+    return ['%s: %s', 'file1', 'exe: '.self.exe]
+  endfunction
+  call neomake#Make(1, [makerdict])
+  NeomakeTestsWaitForFinishedJobs
+  AssertEqual map(copy(getloclist(0)), 'v:val.text'), ['exe: /usr/bin/printf']


### PR DESCRIPTION
for example (by the way, i can make a pr for this maker if you want):
```
let g:neomake_javascript_emacs_maker = {
      \ 'append_file': 0,
      \ 'errorformat': '%f line %l: %m',
      \ 'mapexpr': 'expand("%:p") . " " . v:val',
      \ }
function! g:neomake_javascript_emacs_maker.args()
  return join([expand('%:p'),'--quick','--batch',
        \ "--eval=\"(progn(package-initialize)(require 'js2-mode)(setq js2-include-node-externs t js2-include-rhino-externs t js2-include-browser-externs t js2-strict-missing-semi-warning nil)(js2-mode)(js2-reparse t)(js2-display-error-list)(princ(with-current-buffer \\\"*js-lint*\\\"(buffer-substring-no-properties(point-min)(point-max))))(terpri))\"" ,
        \ '2>/dev/null'])
endfunction
```