### PR TITLE
Add jsonlint-py maker

### DIFF
--- a/autoload/neomake/makers/ft/json.vim
+++ b/autoload/neomake/makers/ft/json.vim
@@ -2,6 +2,16 @@ function! neomake#makers#ft#json#EnabledMakers()
     return ['jsonlint']
 endfunction
 
+function! neomake#makers#ft#json#jsonlintpy()
+    return {
+        \ 'exe': 'jsonlint-py',
+        \ 'args': ['--strict'],
+        \ 'errorformat':
+            \ '%f:%l:%c: %trror: %m,' .
+            \ '%f:%l:%c: %tarning: %m,',
+        \ }
+endfunction
+
 function! neomake#makers#ft#json#jsonlint()
     return {
         \ 'args': ['--compact'],


### PR DESCRIPTION
ref http://deron.meranda.us/python/demjson/
It is installed as `jsonlint-py` on Debian like to not conflict with PHP `jsonlint`