### PR TITLE
Fix flow output

### DIFF
--- a/autoload/neomake/makers/ft/javascript.vim
+++ b/autoload/neomake/makers/ft/javascript.vim
@@ -61,7 +61,7 @@ function! neomake#makers#ft#javascript#flow() abort
     " Replace "\n" by space.
     let mapexpr = 'substitute(v:val, "\\\\n", " ", "g")'
     return {
-        \ 'args': ['--old-output-format'],
+        \ 'args': ['--from-vim'],
         \ 'errorformat': '%E%f:%l:%c\,%n: %m',
         \ 'mapexpr': mapexpr,
         \ }


### PR DESCRIPTION
Remove [deprecated](https://github.com/facebook/flow/issues/2844) `--old-output-format` in favor of `--from-vim`. Output looks alright now.

Should fix #241.