### PR TITLE
javascript: fix typo on flow args

### DIFF
--- a/autoload/neomake/makers/ft/javascript.vim
+++ b/autoload/neomake/makers/ft/javascript.vim
@@ -61,7 +61,7 @@ function! neomake#makers#ft#javascript#flow() abort
     " Replace "\n" by space.
     let mapexpr = 'substitute(v:val, "\\\\n", " ", "g")'
     return {
-        \ 'args': ['--from-vim'],
+        \ 'args': ['--from vim'],
         \ 'errorformat': '%E%f:%l:%c\,%n: %m',
         \ 'mapexpr': mapexpr,
         \ }


### PR DESCRIPTION
`--from-vim` → `--from vim`

Sorry about that.

Closes #876.