### PR TITLE
Javascript: Fix flow argument and add support for entry.length

### DIFF
--- a/autoload/neomake/makers/ft/javascript.vim
+++ b/autoload/neomake/makers/ft/javascript.vim
@@ -58,13 +58,19 @@ function! neomake#makers#ft#javascript#semistandard() abort
 endfunction
 
 function! neomake#makers#ft#javascript#flow() abort
-    " Replace "\n" by space.
-    let mapexpr = 'substitute(v:val, "\\\\n", " ", "g")'
     return {
-        \ 'args': ['--from vim'],
-        \ 'errorformat': '%E%f:%l:%c\,%n: %m',
-        \ 'mapexpr': mapexpr,
+        \ 'args': ['--from=vim', '--show-all-errors'],
+        \ 'errorformat': '%EFile "%f"\, line %l\, characters %c-%m,%C%m,%Z%m',
+        \ 'postprocess': function('neomake#makers#ft#javascript#FlowProcess')
         \ }
+endfunction
+
+function! neomake#makers#ft#javascript#FlowProcess(entry) abort
+    let l:lines = split(a:entry.text, '\n')
+    if len(l:lines)
+        let a:entry.text = join(l:lines[1:])
+        let a:entry.length = l:lines[0] - a:entry.col + 1
+    endif
 endfunction
 
 function! neomake#makers#ft#javascript#xo() abort


### PR DESCRIPTION
Flow support was totally broken `'--from vim'` did not work, it should either be `'--from', 'vim'` or like I did `'--from=vim'`. This also improves the error message in general and adds support for the length of underline.