### PR TITLE
Add support for "#shellcheck shell=" directive

### DIFF
--- a/autoload/neomake/makers/ft/sh.vim
+++ b/autoload/neomake/makers/ft/sh.vim
@@ -15,6 +15,7 @@ function! neomake#makers#ft#sh#shellcheck() abort
         \ }
 
     if match(getline(1), '\v^#!.*<%(sh|dash|bash|ksh)') >= 0
+                \ || match(getline(1), '\v^#\s*shellcheck\s+shell\=') >= 0
         " shellcheck reads the shebang by itself
     elseif ext ==# 'ksh'
         let maker.args += ['-s', 'ksh']

--- a/tests/ft_sh.vader
+++ b/tests/ft_sh.vader
@@ -11,6 +11,10 @@ Execute (shellcheck):
   AssertEqual ['-fgcc'], neomake#makers#ft#sh#shellcheck().args
   call setline(1, '#!/bin/ksh')
   AssertEqual ['-fgcc'], neomake#makers#ft#sh#shellcheck().args
+
+  " Shellcheck also checks for a directive denoting the appropriate shell
+  call setline(1, '#shellcheck shell=sh')
+  AssertEqual ['-fgcc'], neomake#makers#ft#sh#shellcheck().args
   call setline(1, '') " reset shebang for next tests
 
   " If extension is .ksh, force 'ksh'.


### PR DESCRIPTION
I've added support for the [shellcheck] directive [#shellcheck shell=].

See #747 and the thread beginning at [my last comment](https://github.com/neomake/neomake/pull/747#issuecomment-268690807) for more information on this request. The reason I added support for testing the version of shellcheck in #747 was that the [#shellcheck shell=] directive was only added in 0.4.4. Considering that caused so much discussion I guess we can make the assumption that if a user is editing a file with a [#shellcheck shell=] directive then they have the appropriate version of shellcheck.

[shellcheck]: https://github.com/koalaman/shellcheck
[#shellcheck shell=]: https://github.com/koalaman/shellcheck/wiki/Directive