### PR TITLE
ruby: rubocop: improve errorformat

### DIFF
--- a/autoload/neomake/makers/ft/ruby.vim
+++ b/autoload/neomake/makers/ft/ruby.vim
@@ -7,7 +7,7 @@ endfunction
 function! neomake#makers#ft#ruby#rubocop()
     return {
         \ 'args': ['--format', 'emacs'],
-        \ 'errorformat': '%f:%l:%c: %t: %m',
+        \ 'errorformat': '%f:%l:%c: %t: %m,%E%f:%l: %m',
         \ 'postprocess': function('neomake#makers#ft#ruby#RubocopEntryProcess')
         \ }
 endfunction


### PR DESCRIPTION
I had this from somewhere in my local stash - maybe from Syntastic?!

@Neki 
Does it make sense?