### PR TITLE
Add g:neomake_place_signs_immediately

### DIFF
--- a/autoload/neomake/signs.vim
+++ b/autoload/neomake/signs.vim
@@ -127,12 +127,21 @@ function! neomake#signs#PlaceVisibleSigns() abort
         endif
         let topline = line('w0')
         let botline = line('w$')
+        let placed_one = 0
         for ln in range(topline, botline)
             if has_key(s:sign_queue[type][buf], ln)
                 call neomake#signs#PlaceSign(s:sign_queue[type][buf][ln], type)
                 unlet s:sign_queue[type][buf][ln]
+                let placed_one = 1
             endif
         endfor
+        " if this buffer has signs pending but none have been placed, force
+        " the placement of at least one to show the sidebar
+        if !placed_one && !has_key(s:placed_signs[type], buf)
+            let first_ln = keys(s:sign_queue[type][buf])[0]
+            call neomake#signs#PlaceSign(s:sign_queue[type][buf][first_ln], type)
+            unlet s:sign_queue[type][buf][first_ln]
+        endif
         if empty(s:sign_queue[type][buf])
             unlet s:sign_queue[type][buf]
         endif


### PR DESCRIPTION
Resolves #834 

This works by, at the end of PlaceVisibleSigns, if we notice that there are signs in the queue but none in the current buffer, pluck the first one in the file out of the queue and make it visible. This should make it fast on large files with a huge number of errors. The option is enabled by default.

This is something that has annoyed me for a long time, until today I got fed up and found that issue, read through the surrounding discussions, and learned enough vimscript to do it myself :)