### PR TITLE
Fix neomake#utils#WideMessage for multibyte strings

### DIFF
--- a/autoload/neomake/utils.vim
+++ b/autoload/neomake/utils.vim
@@ -105,6 +105,10 @@ function! neomake#utils#DebugObject(msg, obj) abort
     call neomake#utils#DebugMessage(a:msg.' '.neomake#utils#Stringify(a:obj))
 endfunction
 
+function! neomake#utils#wstrpart(mb_string, start, len) abort
+  return matchstr(a:mb_string, '.\{,'.a:len.'}', 0, a:start+1)
+endfunction
+
 " This comes straight out of syntastic.
 "print as much of a:msg as possible without "Press Enter" prompt appearing
 function! neomake#utils#WideMessage(msg) abort " {{{2
@@ -119,7 +123,7 @@ function! neomake#utils#WideMessage(msg) abort " {{{2
     "width as the proper amount of characters
     let chunks = split(msg, "\t", 1)
     let msg = join(map(chunks[:-2], "v:val . repeat(' ', &tabstop - strwidth(v:val) % &tabstop)"), '') . chunks[-1]
-    let msg = strpart(msg, 0, &columns - 1)
+    let msg = neomake#utils#wstrpart(msg, 0, &columns - 1)
 
     set noruler noshowcmd
     redraw

--- a/tests/utils.vader
+++ b/tests/utils.vader
@@ -182,3 +182,15 @@ Execute (neomake#utils#diff_dict):
     \ [{'a': ['1', 1]}, {}, {}]
   AssertEqual neomake#utils#diff_dict({'a': []}, {'a': {}}),
     \ [{'a': [[], {}]}, {}, {}]
+
+Execute (neomake#utils#wstrpart):
+  AssertEqual neomake#utils#wstrpart('123', 0, 0), ''
+  AssertEqual neomake#utils#wstrpart('123', 0, 1), '1'
+  AssertEqual neomake#utils#wstrpart('123', 0, 2), '12'
+  AssertEqual neomake#utils#wstrpart('123', 1, 2), '23'
+  AssertEqual neomake#utils#wstrpart('123', 1, 1), '2'
+  AssertEqual neomake#utils#wstrpart('123', 1, 0), ''
+
+  AssertEqual neomake#utils#wstrpart('…', 0, 1), '…'
+  AssertEqual neomake#utils#wstrpart('12…45', 1, 3), '2…4'
+  AssertEqual neomake#utils#wstrpart('…after', 1, 10), 'after'


### PR DESCRIPTION
`strpart` handles bytes, which might cut strings like the following in
the middle of multibyte characters, resulting in a longer string (and
causing a hit-ENTER prompt):

> typography.symbols.ellipsis '...' is an approximation, use the ellipsis symbol '…'.