### PR TITLE
Add support for "Sphinx-doc" for RST files

### DIFF
--- a/autoload/neomake/makers/ft/rst.vim
+++ b/autoload/neomake/makers/ft/rst.vim
@@ -1,7 +1,7 @@
 " vim: ts=4 sw=4 et
 
 function! neomake#makers#ft#rst#EnabledMakers()
-    return ['rstlint', 'rstcheck']
+    return ['rstlint', 'rstcheck', 'sphinx']
 endfunction
 
 function! neomake#makers#ft#rst#rstlint()
@@ -21,5 +21,21 @@ function! neomake#makers#ft#rst#rstcheck()
             \ '%W%f:%l: (WARNING/2) %m,'.
             \ '%E%f:%l: (ERROR/3) %m,'.
             \ '%E%f:%l: (SEVERE/4) %m',
+        \ }
+endfunction
+
+" TODO: determine proper path of current .rst file upwards in sear for conf.py file, use that instead of "docs"
+" TODO: ask noomake for a temporary folder instead of /tmp/neomake-sphinx
+" TODO: split arguments and make them configurable
+" TODO: support more errors
+" TODO: add test-suite
+
+function! neomake#makers#ft#rst#sphinx()
+    return {
+        \ 'exe': 'sphinx-build',
+        \ 'args': '-n -E -q -N -b pseudoxml docs /tmp/neomake-sphinx',
+        \ 'errorformat':
+            \ '%f:%l: %tRROR: %m,' .
+            \ '%f:%l: %tARNING: %m,' ,
         \ }
 endfunction


### PR DESCRIPTION
In documentation, RST files are used in conjunction with domain-specific extensions that expand the default syntax. None of the default linters help. Additionally it enables cross-referencing files.

sphinx-build can be used for checking. A similar plugin exists for syntastic: https://github.com/vim-syntastic/syntastic/blob/master/syntax_checkers/rst/sphinx.vim. 

I started a proof-of-oncept PR, but I hope I can get some help and pointers how to implement some of my TODO's and improve quality of this PR.