### PR TITLE
[RFC] more powerful filename functionality

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -127,6 +127,10 @@ function! s:AddJobinfoForCurrentWin(job_id) abort
     call settabwinvar(tabpagenr, winnr, 'neomake_jobs', win_jobs)
 endfunction
 
+function! s:DefaultFilename() abort
+    return expand('%:p')
+endfunction
+
 function! s:MakeJob(make_id, options) abort
     let job_id = s:job_id
     let s:job_id += 1
@@ -158,11 +162,12 @@ function! s:MakeJob(make_id, options) abort
     let args_is_list = type(args) == type([])
 
     if a:options.file_mode && get(maker, 'append_file', 1)
+        let MakeFilename = get(maker, 'make_filename', function('s:DefaultFilename'))
         if args_is_list
             call neomake#utils#ExpandArgs(args)
-            call add(args, expand('%:p'))
+            call add(args, MakeFilename())
         else
-            let args .= ' '.fnameescape(expand('%:p'))
+            let args .= ' '.fnameescape(MakeFilename())
         endif
     endif
 
@@ -364,12 +369,12 @@ function! neomake#GetMaker(name_or_maker, ...) abort
         unlet! default  " workaround for old Vim (7.3.429)
     endfor
     let s:UNSET = {}
-    for key in ['append_file']
-        let value = neomake#utils#GetSetting(key, maker, s:UNSET, fts, bufnr)
-        if value isnot s:UNSET
-            let maker[key] = value
+    for key in ['append_file', 'make_filename']
+        let Value = neomake#utils#GetSetting(key, maker, s:UNSET, fts, bufnr)
+        if Value isnot s:UNSET
+            let maker[key] = Value
         endif
-        unlet! value  " workaround for old Vim (7.3.429)
+        unlet! Value  " workaround for old Vim (7.3.429)
     endfor
     if exists('real_ft')
         let maker.ft = real_ft

--- a/autoload/neomake/makers/ft/go.vim
+++ b/autoload/neomake/makers/ft/go.vim
@@ -4,9 +4,10 @@ function! neomake#makers#ft#go#EnabledMakers()
     return ['go', 'golint', 'govet']
 endfunction
 
-" The mapexprs in these are needed because cwd will make the command print out
-" the wrong path (it will just be ./%:h in the output), so the mapexpr turns
-" that back into the relative path
+
+function! s:RelativeModulePath() abort
+    return './' . expand('%:.:h')
+endfunction
 
 function! neomake#makers#ft#go#go()
     return {
@@ -14,9 +15,7 @@ function! neomake#makers#ft#go#go()
             \ 'test', '-c',
             \ '-o', neomake#utils#DevNull(),
         \ ],
-        \ 'append_file': 0,
-        \ 'cwd': '%:h',
-        \ 'mapexpr': 'neomake_bufdir . "/" . v:val',
+        \ 'make_filename': function('s:RelativeModulePath'),
         \ 'errorformat':
             \ '%W%f:%l: warning: %m,' .
             \ '%E%f:%l:%c:%m,' .
@@ -38,9 +37,7 @@ function! neomake#makers#ft#go#govet()
     return {
         \ 'exe': 'go',
         \ 'args': ['vet'],
-        \ 'append_file': 0,
-        \ 'cwd': '%:h',
-        \ 'mapexpr': 'neomake_bufdir . "/" . v:val',
+        \ 'make_filename': function('s:RelativeModulePath'),
         \ 'errorformat':
             \ '%Evet: %.%\+: %f:%l:%c: %m,' .
             \ '%W%f:%l: %m,' .


### PR DESCRIPTION
This is an RFC for some new functionality; I haven't documented it or written unit tests for it yet, pending approval from upstream :)

This is one approach to solving the problems I list below. Another solution is actually just to set args to a function, so this may be overly complex, but I figured I'd send it off anyway.. Copying the comment from the commit:

This adds a new maker key, `make_filename`, which is expected to
return the filename to append (when append_file is set).

This approach allows two problems to be solved:

1) Running pylint on a single file is useful, but weak. Running pylint
   on a whole project (using a project maker) can be quite slow. A
   good middle ground is to run pylint on the module; in this case,
   make_filename can return something like expand('%:p:h'). This also
   applies to makers for other languages with strong
   module-as-directory semantics (such as go).

2) The current go makers rely on cwd changes, which can cause weird
   problems (#688) particularly if two linters are in use with
   different cwds.

   make_filename allows for a different approach- if make_filename is
   `return './' . expand('%:.:h')`, no cwd changes are necessary.

   Note: this in particular is why make_filename takes a function and
   not an expand() directive; the go tool requires the ./ prefix on
   the directory name or it searches the GOPATH for the argument,
   rather than interpreting it as a directory.