### PR TITLE
neomake#EchoCurrentError: display nearest entry (sorted by col)

### DIFF
--- a/autoload/neomake/utils.vim
+++ b/autoload/neomake/utils.vim
@@ -367,7 +367,7 @@ endfunction
 
 " Sort quickfix/location list entries by distance to current cursor position's
 " column, but preferring entries starting at or behind the cursor position.
-function! neomake#utils#sort_by_col(a, b, col) abort
+function! neomake#utils#sort_by_col(a, b) abort
     let col = getpos('.')[2]
     if a:a.col > col
         if a:b.col < col

--- a/autoload/neomake/utils.vim
+++ b/autoload/neomake/utils.vim
@@ -364,3 +364,17 @@ function! neomake#utils#diff_dict(d1, d2) abort
     endfor
     return diff
 endfunction
+
+" Sort quickfix/location list entries by distance to current cursor position's
+" column, but preferring entries starting at or behind the cursor position.
+function! neomake#utils#sort_by_col(a, b, col) abort
+    let col = getpos('.')[2]
+    if a:a.col > col
+        if a:b.col < col
+            return 1
+        endif
+    elseif a:b.col > col
+        return -1
+    endif
+    return abs(col - a:a.col) - abs(col - a:b.col)
+endfunction

--- a/tests/utils.vader
+++ b/tests/utils.vader
@@ -194,3 +194,20 @@ Execute (neomake#utils#wstrpart):
   AssertEqual neomake#utils#wstrpart('…', 0, 1), '…'
   AssertEqual neomake#utils#wstrpart('12…45', 1, 3), '2…4'
   AssertEqual neomake#utils#wstrpart('…after', 1, 10), 'after'
+
+Execute (neomake#utils#sort_by_col):
+  function! S(l)
+    call sort(a:l, function('neomake#utils#sort_by_col'))
+    return a:l
+  endfunction
+
+  Log getpos('.')
+  let a = {'col': 1}
+  let b = {'col': 5}
+  AssertEqual S([a, b]), [a, b]
+  norm i1234
+  AssertEqual getpos('.')[2], 4, 'position is correct'
+  AssertEqual S([a, b]), [a, b]
+  norm a5
+  AssertEqual getpos('.')[2], 5, 'position is correct'
+  AssertEqual S([a, b]), [b, a]


### PR DESCRIPTION
This will sort the list of line entries by their distance to the current
column (preferring entries starting at or after the current position).

Previously the first entry (preferring those of type "error") was
displayed always.

Therefore the function needs to be called in neomake#CursorMoved now
always again.