### PR TITLE
scss: scsslint: errorformat: handle missing column

### DIFF
--- a/autoload/neomake/makers/ft/scss.vim
+++ b/autoload/neomake/makers/ft/scss.vim
@@ -17,7 +17,8 @@ endfunction
 function! neomake#makers#ft#scss#scsslint() abort
     return {
         \ 'exe': 'scss-lint',
-        \ 'errorformat': '%A%f:%l:%v [%t] %m'
+        \ 'errorformat': '%A%f:%l:%v [%t] %m,' .
+        \                '%A%f:%l [%t] %m'
     \ }
 endfunction
 


### PR DESCRIPTION
Column information was added in scss-lint 0.49.0.

Fixes https://github.com/neomake/neomake/issues/910.