### PR TITLE
Python MyPy requires --fast-parser flag for async/await support

### DIFF
--- a/autoload/neomake/makers/ft/python.vim
+++ b/autoload/neomake/makers/ft/python.vim
@@ -249,6 +249,7 @@ endfunction
 
 " Because this uses --silent-imports it requires mypy >= 0.4
 " It is annoying for new users to use MyPy without --silent-imports
+" For experimental async/await syntax support you'll need --fast-parser
 function! neomake#makers#ft#python#mypy() abort
     return {
         \ 'args': ['--silent-imports'],

--- a/autoload/neomake/makers/ft/python.vim
+++ b/autoload/neomake/makers/ft/python.vim
@@ -1,5 +1,4 @@
 " vim: ts=4 sw=4 et
-let s:is_windows = has('win32') || has('win64') || has('win16') || has('dos32') || has('dos16')
 
 function! neomake#makers#ft#python#EnabledMakers() abort
     if exists('s:python_makers')
@@ -251,9 +250,12 @@ endfunction
 " --fast-parser: adds experimental support for async/await syntax
 " --silent-imports: replaced by --ignore-missing-imports --follow-imports=skip
 function! neomake#makers#ft#python#mypy() abort
-    let defaults = ['--ignore-missing-imports', '--follow-imports=skip']
+    let args = ['--ignore-missing-imports', '--follow-imports=skip']
+    if neomake#utils#IsRunningWindows()
+        let args += ['--fast-parser']
+    endif
     return {
-        \ 'args': s:is_windows ? defaults : defaults + ['--fast-parser'],
+        \ 'args': args,
         \ 'errorformat':
             \ '%E%f:%l: error: %m,' .
             \ '%W%f:%l: warning: %m,' .

--- a/autoload/neomake/makers/ft/python.vim
+++ b/autoload/neomake/makers/ft/python.vim
@@ -1,4 +1,5 @@
 " vim: ts=4 sw=4 et
+let s:is_windows = has('win32') || has('win64') || has('win16') || has('dos32') || has('dos16')
 
 function! neomake#makers#ft#python#EnabledMakers() abort
     if exists('s:python_makers')
@@ -247,12 +248,12 @@ function! neomake#makers#ft#python#vulture() abort
         \ }
 endfunction
 
-" Because this uses --silent-imports it requires mypy >= 0.4
-" It is annoying for new users to use MyPy without --silent-imports
-" For experimental async/await syntax support you'll need --fast-parser
+" --fast-parser: adds experimental support for async/await syntax
+" --silent-imports: replaced by --ignore-missing-imports --follow-imports=skip
 function! neomake#makers#ft#python#mypy() abort
+    let defaults = ['--ignore-missing-imports', '--follow-imports=skip']
     return {
-        \ 'args': ['--silent-imports'],
+        \ 'args': s:is_windows ? defaults : defaults + ['--fast-parser'],
         \ 'errorformat':
             \ '%E%f:%l: error: %m,' .
             \ '%W%f:%l: warning: %m,' .


### PR DESCRIPTION
I had to add the following to my `.vimrc` file to get async/await syntax support working...

```viml
let g:neomake_python_mypy_args = neomake#makers#ft#python#mypy()['args'] + ['--fast-parser']
```

It wasn't immediately obvious when I went sifting through the Neomake python maker code, until I stumbled across a blog post that mentions the need for the `--fast-parser` flag. 

I believe enough people use async/await syntax that we either add this flag by default or - as per this PR (as it's experimental support) - we at least make mention of it somewhere.