### PR TITLE
bufexists() function expects a number as a parameter.

### DIFF
--- a/autoload/neomake/signs.vim
+++ b/autoload/neomake/signs.vim
@@ -111,7 +111,7 @@ function! neomake#signs#CleanOldSigns(bufnr, type) abort
         return
     endif
     call neomake#utils#DebugObject('Cleaning old signs in buffer '.a:bufnr.': ', s:last_placed_signs[a:type])
-    if bufexists(a:bufnr)
+    if bufexists(str2nr(a:bufnr))
         for ln in keys(s:last_placed_signs[a:type][a:bufnr])
             let cmd = 'sign unplace '.s:last_placed_signs[a:type][a:bufnr][ln].' buffer='.a:bufnr
             call neomake#utils#DebugMessage('Unplacing sign: '.cmd)


### PR DESCRIPTION
Since bufnr is used as a key to various dicts like s:sign_queue,
s:placed_signs, etc. its value is converted to string. So we have to
explicitly convert it back to number when calling bufexists() function.

It fixes an issue when calling `:Neomake! clippy` doesn't clean the old signs. Introduced by #935 PR.