### PR TITLE
tests: use lgetexpr instead of laddexpr

### DIFF
--- a/tests/ft_idris.vader
+++ b/tests/ft_idris.vader
@@ -12,7 +12,7 @@ Execute (idris: errorformat):
 
   Save &errorformat
   let &errorformat = neomake#makers#ft#idris#idris().errorformat
-  laddexpr idris_output
+  lgetexpr idris_output
   AssertEqual len(getloclist(0)), 1
   AssertEqual getloclist(0)[0].text, "4:When checking left hand side of xor:\n
     \Type mismatch between\n

--- a/tests/processing.vader
+++ b/tests/processing.vader
@@ -64,7 +64,7 @@ Execute (Output is only processed in normal/insert mode (from loclist)):
 Execute (Output gets not processed from loclist):
   if !NeomakeAsyncTestsSetup() | finish | endif
 
-  laddexpr ''
+  lgetexpr ''
   call neomake#Make(1, [g:neomake_test_sleep_efm_maker])
   lopen
   AssertEqual &buftype, 'quickfix'

--- a/tests/serialize.vader
+++ b/tests/serialize.vader
@@ -72,7 +72,7 @@ Execute (NeomakeSh: serialized with previous buffer overriding global abort):
   call neomake#Make(1, [g:sleep_maker, g:maker_error, g:maker_success])
 
   let bufnr = bufnr('%')
-  laddexpr ''
+  lgetexpr ''
   new
   NeomakeTestsWaitForFinishedJobs
   AssertEqual getloclist(0), []


### PR DESCRIPTION
Makes tests more predictable.

Ref: https://github.com/neomake/neomake/pull/939#issuecomment-273302414.