### PR TITLE
elixir mix. enforce lnum line is inside buffer length

### DIFF
--- a/autoload/neomake/makers/ft/elixir.vim
+++ b/autoload/neomake/makers/ft/elixir.vim
@@ -1,5 +1,12 @@
 " vim: ts=4 sw=4 et
 
+function! neomake#makers#ft#elixir#PostprocessEnforceMaxBufferLine(entry) abort
+    let buffer_lines = str2nr(line('$'))
+    if (buffer_lines < a:entry.lnum)
+        let a:entry.lnum = buffer_lines
+    endif
+endfunction
+
 function! neomake#makers#ft#elixir#EnabledMakers() abort
     return ['mix']
 endfunction
@@ -26,6 +33,7 @@ function! neomake#makers#ft#elixir#mix() abort
     return {
       \ 'exe' : 'mix',
       \ 'args': ['compile', '--warnings-as-errors'],
+      \ 'postprocess': function('neomake#makers#ft#elixir#PostprocessEnforceMaxBufferLine'),
       \ 'errorformat':
         \ '** %s %f:%l: %m,'.
         \ '%f:%l: warning: %m'


### PR DESCRIPTION
closes #960 

Let me know if this is the way to go, or if you prefer the function inside `neomake#utils#EnforceMaxBufferLine`
