### PR TITLE
fixes MakerIsAvailable function for makers with funcref as exe

### DIFF
--- a/autoload/neomake/utils.vim
+++ b/autoload/neomake/utils.vim
@@ -204,14 +204,21 @@ function! neomake#utils#MakerIsAvailable(ft, maker_name) abort
         " for our purposes
         return 1
     endif
+
     let maker = neomake#GetMaker(a:maker_name, a:ft)
     if empty(maker)
         return 0
     endif
-    if !has_key(s:available_makers, maker.exe)
-        let s:available_makers[maker.exe] = executable(maker.exe)
+
+    if (type(maker.exe) == type(function('tr')))
+        let l:executable = call(maker.exe, [])
+    elseif (type(maker.exe) == type({}))
+        let l:executable = call(maker.exe.fn, [], maker.exe)
+    else
+        let l:executable = maker.exe
     endif
-    return s:available_makers[maker.exe]
+
+    return executable(l:executable)
 endfunction
 
 function! neomake#utils#AvailableMakers(ft, makers) abort

--- a/tests/utils.vader
+++ b/tests/utils.vader
@@ -174,6 +174,16 @@ Execute (neomake#utils#MakerIsAvailable picks up changes):
   let g:neomake_myft_sh_maker.exe = 'sh'
   AssertEqual neomake#utils#MakerIsAvailable('myft', 'sh'), 1
 
+Execute (neomake#utils#MakerIsAvailable with funcrefs):
+  Save g:neomake_myft_sh_maker
+  function! MyExeFunction()
+    return 'sh'
+  endfunction
+  let g:neomake_myft_sh_maker = { 'exe': function('MyExeFunction') }
+  AssertEqual neomake#utils#MakerIsAvailable('myft', 'sh'), 1
+  let g:neomake_myft_sh_maker.exe = { 'fn': function('MyExeFunction') }
+  AssertEqual neomake#utils#MakerIsAvailable('myft', 'sh'), 1
+
 Execute (neomake#utils#diff_dict):
   AssertEqual neomake#utils#diff_dict({}, {}), [{}, {}, {}]
   AssertEqual neomake#utils#diff_dict({'a': 1}, {'a': 2}),


### PR DESCRIPTION
before these changes MakerIsAvailable would fail when trying to test maker.exe if it is a funcref or a dict with a funcref