### PR TITLE
mapping credo error types to neomake

### DIFF
--- a/autoload/neomake/makers/ft/elixir.vim
+++ b/autoload/neomake/makers/ft/elixir.vim
@@ -7,7 +7,7 @@
 " D -> Software design suggestions
 " R -> Readability suggestions
 " Map structure {CredoError: NeomakeType, ...}
-let s:neomake_elixir_credo_type_map = {
+let s:neomake_elixir_credo_config_typemap = {
     \ 'F': 'W',
     \ 'C': 'W',
     \ 'D': 'I',
@@ -22,8 +22,8 @@ endfunction
 
 function! neomake#makers#ft#elixir#PostprocessCredo(entry) abort
     let type = toupper(a:entry.type)
-    let type_map = extend(s:neomake_elixir_credo_type_map,
-                \ get(g:, 'neomake_elixir_credo_type_map', {}))
+    let type_map = extend(s:neomake_elixir_credo_config_typemap,
+                \ get(g:, 'neomake_elixir_credo_config_typemap', {}))
     if has_key(type_map, type)
         let a:entry.type = type_map[type]
     endif

--- a/autoload/neomake/makers/ft/elixir.vim
+++ b/autoload/neomake/makers/ft/elixir.vim
@@ -1,5 +1,7 @@
 " vim: ts=4 sw=4 et
 
+let g:neomake_elixir_credo_type_map= get(g:, 'neomake_elixir_credo_type_map', {'F': 'W','C': 'W','D': 'I','R': 'I'})
+
 function! neomake#makers#ft#elixir#PostprocessEnforceMaxBufferLine(entry) abort
     let buffer_lines = str2nr(line('$'))
     if (buffer_lines < a:entry.lnum)
@@ -7,21 +9,18 @@ function! neomake#makers#ft#elixir#PostprocessEnforceMaxBufferLine(entry) abort
     endif
 endfunction
 
+" Credo error types
+" F -> Refactoring opportunities
+" W -> Warnings
+" C -> Convention violation
+" D -> Software design suggestions
+" R -> Readability suggestions
 function! neomake#makers#ft#elixir#PostprocessCredoErrorType(entry) abort
-    if a:entry.type ==# 'F'      " Refactoring opportunities
-        let type = 'W'
-    elseif a:entry.type ==# 'D'  " Software design suggestions
-        let type = 'I'
-    elseif a:entry.type ==# 'W'  " Warnings
-        let type = 'W'
-    elseif a:entry.type ==# 'R'  " Readability suggestions
-        let type = 'I'
-    elseif a:entry.type ==# 'C'  " Convention violation
-        let type = 'W'
-    else
-        let type = 'M'           " Everything else is a message
+    let type = toupper(a:entry.type)
+    let type_map = g:neomake_elixir_credo_type_map
+    if has_key(type_map, type)
+        let a:entry.type = type_map[type]
     endif
-    let a:entry.type = type
 endfunction
 
 function! neomake#makers#ft#elixir#EnabledMakers() abort

--- a/autoload/neomake/makers/ft/elixir.vim
+++ b/autoload/neomake/makers/ft/elixir.vim
@@ -1,6 +1,17 @@
 " vim: ts=4 sw=4 et
 
-let g:neomake_elixir_credo_type_map= get(g:, 'neomake_elixir_credo_type_map', {'F': 'W','C': 'W','D': 'I','R': 'I'})
+" Credo error types
+" F -> Refactoring opportunities
+" W -> Warnings
+" C -> Convention violation
+" D -> Software design suggestions
+" R -> Readability suggestions
+" Map structure {CredoError: NeomakeType, ...}
+let s:neomake_elixir_credo_type_map = get(
+    \ g:,
+    \ 'neomake_elixir_credo_type_map',
+    \ {'F': 'W','C': 'W','D': 'I','R': 'I'}
+\ )
 
 function! neomake#makers#ft#elixir#PostprocessEnforceMaxBufferLine(entry) abort
     let buffer_lines = str2nr(line('$'))
@@ -9,15 +20,9 @@ function! neomake#makers#ft#elixir#PostprocessEnforceMaxBufferLine(entry) abort
     endif
 endfunction
 
-" Credo error types
-" F -> Refactoring opportunities
-" W -> Warnings
-" C -> Convention violation
-" D -> Software design suggestions
-" R -> Readability suggestions
-function! neomake#makers#ft#elixir#PostprocessCredoErrorType(entry) abort
+function! neomake#makers#ft#elixir#PostprocessCredo(entry) abort
     let type = toupper(a:entry.type)
-    let type_map = g:neomake_elixir_credo_type_map
+    let type_map = s:neomake_elixir_credo_type_map
     if has_key(type_map, type)
         let a:entry.type = type_map[type]
     endif
@@ -39,7 +44,7 @@ function! neomake#makers#ft#elixir#credo() abort
     return {
       \ 'exe': 'mix',
       \ 'args': ['credo', 'list', '%:p', '--format=oneline'],
-      \ 'postprocess': function('neomake#makers#ft#elixir#PostprocessCredoErrorType'),
+      \ 'postprocess': function('neomake#makers#ft#elixir#PostprocessCredo'),
       \ 'errorformat':
           \'[%t] %. %f:%l:%c %m,' .
           \'[%t] %. %f:%l %m'

--- a/autoload/neomake/makers/ft/elixir.vim
+++ b/autoload/neomake/makers/ft/elixir.vim
@@ -1,17 +1,17 @@
 " vim: ts=4 sw=4 et
 
-" Credo error types
+" Credo error types.
 " F -> Refactoring opportunities
 " W -> Warnings
 " C -> Convention violation
 " D -> Software design suggestions
 " R -> Readability suggestions
 " Map structure {CredoError: NeomakeType, ...}
-let s:neomake_elixir_credo_type_map = get(
-    \ g:,
-    \ 'neomake_elixir_credo_type_map',
-    \ {'F': 'W','C': 'W','D': 'I','R': 'I'}
-\ )
+let s:neomake_elixir_credo_type_map = {
+    \ 'F': 'W',
+    \ 'C': 'W',
+    \ 'D': 'I',
+    \ 'R': 'I'}
 
 function! neomake#makers#ft#elixir#PostprocessEnforceMaxBufferLine(entry) abort
     let buffer_lines = str2nr(line('$'))
@@ -22,7 +22,8 @@ endfunction
 
 function! neomake#makers#ft#elixir#PostprocessCredo(entry) abort
     let type = toupper(a:entry.type)
-    let type_map = s:neomake_elixir_credo_type_map
+    let type_map = extend(s:neomake_elixir_credo_type_map,
+                \ get(g:, 'neomake_elixir_credo_type_map', {}))
     if has_key(type_map, type)
         let a:entry.type = type_map[type]
     endif

--- a/autoload/neomake/makers/ft/elixir.vim
+++ b/autoload/neomake/makers/ft/elixir.vim
@@ -7,6 +7,23 @@ function! neomake#makers#ft#elixir#PostprocessEnforceMaxBufferLine(entry) abort
     endif
 endfunction
 
+function! neomake#makers#ft#elixir#PostprocessCredoErrorType(entry) abort
+    if a:entry.type ==# 'F'      " Refactoring opportunities
+        let type = 'W'
+    elseif a:entry.type ==# 'D'  " Software design suggestions
+        let type = 'I'
+    elseif a:entry.type ==# 'W'  " Warnings
+        let type = 'W'
+    elseif a:entry.type ==# 'R'  " Readability suggestions
+        let type = 'I'
+    elseif a:entry.type ==# 'C'  " Convention violation
+        let type = 'W'
+    else
+        let type = 'M'           " Everything else is a message
+    endif
+    let a:entry.type = type
+endfunction
+
 function! neomake#makers#ft#elixir#EnabledMakers() abort
     return ['mix']
 endfunction
@@ -23,6 +40,7 @@ function! neomake#makers#ft#elixir#credo() abort
     return {
       \ 'exe': 'mix',
       \ 'args': ['credo', 'list', '%:p', '--format=oneline'],
+      \ 'postprocess': function('neomake#makers#ft#elixir#PostprocessCredoErrorType'),
       \ 'errorformat':
           \'[%t] %. %f:%l:%c %m,' .
           \'[%t] %. %f:%l %m'

--- a/tests/ft_elixir.vader
+++ b/tests/ft_elixir.vader
@@ -1,0 +1,16 @@
+Include: include/setup.vader
+
+Execute (Credo: postprocess: type):
+  function! F(entry)
+    call neomake#makers#ft#elixir#PostprocessCredo(a:entry)
+    return a:entry
+  endfunction
+  AssertEqual F({'type': 'F'}).type, 'W'
+
+Execute (Credo: postprocess: global configuration):
+  function! F(entry)
+    call neomake#makers#ft#elixir#PostprocessCredo(a:entry)
+    return a:entry
+  endfunction
+  let g:neomake_elixir_credo_type_map = {'F': 'Z'}
+  AssertEqual F({'type': 'F'}).type, 'Z'

--- a/tests/ft_elixir.vader
+++ b/tests/ft_elixir.vader
@@ -5,16 +5,11 @@ Execute (Credo: postprocess: type):
     call neomake#makers#ft#elixir#PostprocessCredo(a:entry)
     return a:entry
   endfunction
+  AssertEqual F({'type': 'C'}).type, 'W'
   AssertEqual F({'type': 'F'}).type, 'W'
 
-Execute (Credo: postprocess: global configuration):
-  function! F(entry)
-    call neomake#makers#ft#elixir#PostprocessCredo(a:entry)
-    return a:entry
-  endfunction
-  let g:neomake_elixir_credo_type_map = {'F': 'Z'}
+  let g:neomake_elixir_credo_config_typemap = {'F': 'Z'}
   AssertEqual F({'type': 'F'}).type, 'Z'
-  AssertEqual F({'type': 'C'}).type, 'W'
 
 Given (A file with 2 lines):
   some
@@ -25,14 +20,4 @@ Execute (Mix: postprocess: line is never higher than buffer size):
     return a:entry
   endfunction
   AssertEqual F({'lnum': 3}).lnum, 2
-
-Given (A file with 2 lines):
-  some
-  lines
-Execute (Mix: postprocess: line inside buffer is not modified):
-  function! F(entry)
-    call neomake#makers#ft#elixir#PostprocessEnforceMaxBufferLine(a:entry)
-    return a:entry
-  endfunction
   AssertEqual F({'lnum': 1}).lnum, 1
-

--- a/tests/ft_elixir.vader
+++ b/tests/ft_elixir.vader
@@ -14,6 +14,7 @@ Execute (Credo: postprocess: global configuration):
   endfunction
   let g:neomake_elixir_credo_type_map = {'F': 'Z'}
   AssertEqual F({'type': 'F'}).type, 'Z'
+  AssertEqual F({'type': 'C'}).type, 'W'
 
 Given (A file with 2 lines):
   some

--- a/tests/ft_elixir.vader
+++ b/tests/ft_elixir.vader
@@ -14,3 +14,24 @@ Execute (Credo: postprocess: global configuration):
   endfunction
   let g:neomake_elixir_credo_type_map = {'F': 'Z'}
   AssertEqual F({'type': 'F'}).type, 'Z'
+
+Given (A file with 2 lines):
+  some
+  lines
+Execute (Mix: postprocess: line is never higher than buffer size):
+  function! F(entry)
+    call neomake#makers#ft#elixir#PostprocessEnforceMaxBufferLine(a:entry)
+    return a:entry
+  endfunction
+  AssertEqual F({'lnum': 3}).lnum, 2
+
+Given (A file with 2 lines):
+  some
+  lines
+Execute (Mix: postprocess: line inside buffer is not modified):
+  function! F(entry)
+    call neomake#makers#ft#elixir#PostprocessEnforceMaxBufferLine(a:entry)
+    return a:entry
+  endfunction
+  AssertEqual F({'lnum': 1}).lnum, 1
+

--- a/tests/neomake.vader
+++ b/tests/neomake.vader
@@ -23,6 +23,7 @@ Include (Perl): ft_perl.vader
 Include (Python): ft_python.vader
 Include (Shell): ft_sh.vader
 Include (Text): ft_text.vader
+Include (Elixir): ft_elixir.vader
 
 * Old/unorganized tests
 Execute (neomake#GetMakers):


### PR DESCRIPTION
Adding missing mapping of entry types from elixir credo to neomake.

Full credit to @emilsoman in https://github.com/neomake/neomake/pull/300#issuecomment-244722296