### PR TITLE
Python: Use fix for flake8 column for redefinition error as well

### DIFF
--- a/autoload/neomake/makers/ft/python.vim
+++ b/autoload/neomake/makers/ft/python.vim
@@ -101,8 +101,9 @@ function! neomake#makers#ft#python#Flake8EntryProcess(entry) abort
     if strlen(l:token)
         " remove quotes
         let l:token = substitute(l:token, "'", '', 'g')
-        if a:entry.type ==# 'F' && a:entry.nr == 401
-            " The unused import error column is incorrect
+        if a:entry.type ==# 'F' && (a:entry.nr == 401 ||  a:entry.nr == 811)
+            " The unused column is incorrect for import errors and redefinition
+            " errors.
             let l:view = winsaveview()
             call cursor(a:entry.lnum, a:entry.col)
 

--- a/tests/ft_python.vader
+++ b/tests/ft_python.vader
@@ -38,3 +38,31 @@ Execute (python: pylama: errorformat):
   \ 'type': 'I',
   \ 'pattern': '',
   \ 'text': "C901 'load_library' is too complex (13) [mccabe]"}
+
+Execute (python: flake8: errorformat/postprocess: F811):
+  Save &errorformat
+  let &errorformat = neomake#makers#ft#python#flake8().errorformat
+
+  file file1.py
+  norm Iimport os
+  norm oimport os.path as os
+  lgetexpr "file1.py:2:1: F811 redefinition of unused 'os' from line 1"
+
+  AssertEqual getloclist(0), [
+  \ {'lnum': 2, 'bufnr': bufnr('%'), 'col': 1, 'valid': 1, 'vcol': 0,
+  \  'nr': 811, 'type': 'F', 'pattern': '',
+  \  'text': "redefinition of unused 'os' from line 1"}]
+
+  let e = copy(getloclist(0))[0]
+  call neomake#makers#ft#python#Flake8EntryProcess(e)
+  AssertEqual e, {
+  \ 'lnum': 2,
+  \ 'bufnr': bufnr('%'),
+  \ 'col': 8,
+  \ 'pattern': '',
+  \ 'valid': 1,
+  \ 'vcol': 0,
+  \ 'nr': '',
+  \ 'length': 2,
+  \ 'type': 'E',
+  \ 'text': "F811 redefinition of unused 'os' from line 1"}

--- a/tests/ft_python.vader
+++ b/tests/ft_python.vader
@@ -45,24 +45,46 @@ Execute (python: flake8: errorformat/postprocess: F811):
 
   file file1.py
   norm Iimport os
-  norm oimport os.path as os
+  norm oimport os . path as os
+  norm ofrom os import os
   lgetexpr "file1.py:2:1: F811 redefinition of unused 'os' from line 1"
 
-  AssertEqual getloclist(0), [
+  AssertEqual [
   \ {'lnum': 2, 'bufnr': bufnr('%'), 'col': 1, 'valid': 1, 'vcol': 0,
   \  'nr': 811, 'type': 'F', 'pattern': '',
-  \  'text': "redefinition of unused 'os' from line 1"}]
+  \  'text': "redefinition of unused 'os' from line 1"}], getloclist(0)
 
   let e = copy(getloclist(0))[0]
   call neomake#makers#ft#python#Flake8EntryProcess(e)
-  AssertEqual e, {
+  AssertEqual {
   \ 'lnum': 2,
   \ 'bufnr': bufnr('%'),
-  \ 'col': 8,
+  \ 'col': 21,
   \ 'pattern': '',
   \ 'valid': 1,
   \ 'vcol': 0,
   \ 'nr': '',
   \ 'length': 2,
   \ 'type': 'E',
-  \ 'text': "F811 redefinition of unused 'os' from line 1"}
+  \ 'text': "F811 redefinition of unused 'os' from line 1"}, e
+
+  lgetexpr "file1.py:3:1: F811 redefinition of unused 'os' from line 2"
+
+  AssertEqual [
+  \ {'lnum': 3, 'bufnr': bufnr('%'), 'col': 1, 'valid': 1, 'vcol': 0,
+  \  'nr': 811, 'type': 'F', 'pattern': '',
+  \  'text': "redefinition of unused 'os' from line 2"}], getloclist(0)
+
+  let e = copy(getloclist(0))[0]
+  call neomake#makers#ft#python#Flake8EntryProcess(e)
+  AssertEqual {
+  \ 'lnum': 3,
+  \ 'bufnr': bufnr('%'),
+  \ 'col': 16,
+  \ 'pattern': '',
+  \ 'valid': 1,
+  \ 'vcol': 0,
+  \ 'nr': '',
+  \ 'length': 2,
+  \ 'type': 'E',
+  \ 'text': "F811 redefinition of unused 'os' from line 2"}, e


### PR DESCRIPTION
This had a similar bug, where the col (and thus also the underline) was put at
the def or import already instead of under the actual redefinition.