### PR TITLE
tests: handle non-bash shell (set in Makefile) better

### DIFF
--- a/tests/integration.vader
+++ b/tests/integration.vader
@@ -135,8 +135,8 @@ Execute (NeomakeSh: non-existing command):
   if neomake#has_async_support()
     AssertNeomakeMessage 'sh: ''nonexistingcommand'': completed with exit code 127.', 3
   endif
-  AssertNotEqual match(getqflist()[0].text,
-    \ '/bin/bash: nonexistingcommand: command not found'), -1, "error in qflist"
+  let qflist_text = getqflist()[0].text
+  AssertNotEqual match(qflist_text, 'command not found'), -1, "error in qflist: ".qflist_text
 
 Execute (NeomakeSh!: handle unfinished output on exit):
   call g:NeomakeSetupAutocmdWrappers()

--- a/tests/utils.vader
+++ b/tests/utils.vader
@@ -248,11 +248,11 @@ Execute (neomake#utils#MakerFromCommand appends args for file_mode):
   let jobinfo = {'file_mode': 0}
 
   AssertEqual maker.fn(jobinfo), {
-  \ 'args': ['-c', 'foo'], 'exe': '/bin/bash', 'remove_invalid_entries': 0}
+  \ 'args': [&shellcmdflag, 'foo'], 'exe': &shell, 'remove_invalid_entries': 0}
 
   file file\ with\ space
   let fname = expand('%:p')
   let jobinfo = {'maker': maker, 'file_mode': 1, 'bufnr': bufnr('%')}
   AssertEqual maker.fn(jobinfo), {
-  \ 'args': ['-c', 'foo '.fnameescape(fname)], 'append_file': 0,
-  \ 'exe': '/bin/bash', 'remove_invalid_entries': 0}
+  \ 'args': [&shellcmdflag, 'foo '.fnameescape(fname)], 'append_file': 0,
+  \ 'exe': &shell, 'remove_invalid_entries': 0}


### PR DESCRIPTION
Makes `vim -u tests/vim/vimrc '+Vader!' tests/integration.vader` work on
Zsh.