### PR TITLE
[RFC] Entry removal in post-processing

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -674,8 +674,8 @@ function! s:AddExprCallback(jobinfo, prev_index) abort
             endif
         endif
 
-        if !entry.valid
-            if maker.remove_invalid_entries
+        if entry.valid <= 0
+            if entry.valid < 0 || maker.remove_invalid_entries
                 let index -= 1
                 call remove(list, index)
                 let list_modified = 1

--- a/doc/neomake.txt
+++ b/doc/neomake.txt
@@ -195,6 +195,13 @@ This can also be used to set the `length` property of an entry, which is used
 to highlight entries in the text (|neomake-highlight|).
 See `neomake#makers#ft#text#PostprocessWritegood` for an example.
 
+Entries can be selectively removed in post-processing by setting its "valid"
+property to `-1`.  This removal will happen even if `remove_invalid_entries`
+is disabled.  This feature is meant for conditional removals and a simpler way
+for end users to filter list entries.  Makers should handle removals through
+|errorformat| using '%-G' to remove items that should never appear in the
+error list.
+
                                                 *neomake-makers-buffer_output*
 Default: 1
 By default Neomake will only process the output from makers when either the

--- a/tests/integration.vader
+++ b/tests/integration.vader
@@ -358,6 +358,27 @@ Execute (Neomake: remove_invalid_entries):
   AssertEqual getloclist(0),
     \ [{'lnum': 0, 'bufnr': 0, 'col': 0, 'valid': 0, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'valid'}]
 
+Execute (Neomake: entry.valid < 0):
+  let maker = neomake#utils#MakerFromCommand('echo invalid; echo "E: valid"')
+  call extend(maker, {
+      \ 'name': 'custom_maker',
+      \ 'remove_invalid_entries': 0,
+      \ 'errorformat': 'E: %m',
+      \ 'append_file': 0,
+      \ })
+
+  function maker.postprocess(entry) abort
+    if !a:entry.valid
+      let a:entry.valid = -1
+    endif
+  endfunction
+
+  call neomake#Make(1, [maker])
+  NeomakeTestsWaitForFinishedJobs
+  AssertNeomakeMessage "Removing invalid entry: invalid ({'lnum': 0, 'bufnr': 0, 'col': 0, 'valid': -1, 'vcol': 0, 'nr': -1, 'type': '', 'maker_name': 'custom_maker', 'pattern': ''})"
+  AssertEqual getloclist(0),
+    \ [{'lnum': 0, 'bufnr': 0, 'col': 0, 'valid': 0, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'valid'}]
+
 Execute (Neomake: append_file from settings):
   let maker = {
       \ 'exe': 'echo',


### PR DESCRIPTION
This allows entries to be explicitly removed by a `postprocess` function.

In the future, I want to add support for a user-defined `NeomakePostProcess(maker, entry)` function that's called after the maker's `postprocess` function.  This will reduce the cognitive load and the need for maintenance for an end user that just wants to alter/remove some entries without worrying about dealing with a built-in maker directly.