### PR TITLE
Add maker.name to neomake#ListJobs() output

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -54,7 +54,7 @@ endfunction
 function! neomake#ListJobs() abort
     call neomake#utils#DebugMessage('call neomake#ListJobs()')
     for jobinfo in values(s:jobs)
-        echom jobinfo.id.' '.jobinfo.name
+        echom jobinfo.id.' '.jobinfo.name.' '.jobinfo.maker.name
     endfor
 endfunction
 


### PR DESCRIPTION
As per the title: when using `:NeomakeListJobs` to manage errant jobs, it can be hard to figure out which one was which. This proposed change simply adds the `maker.name` value on the output for each job.