### PR TITLE
Added MSBuild maker

### DIFF
--- a/autoload/neomake/makers/ft/cs.vim
+++ b/autoload/neomake/makers/ft/cs.vim
@@ -1,12 +1,22 @@
 " vim: ts=4 sw=4 et
 
-function! neomake#makers#ft#cs#EnabledMakers()
+function! neomake#makers#ft#cs#EnabledMakers() abort
     return ['mcs']
 endfunction
 
-function! neomake#makers#ft#cs#mcs()
+function! neomake#makers#ft#cs#mcs() abort
     return {
         \ 'args': ['--parse', '--unsafe'],
         \ 'errorformat': '%f(%l\,%c): %trror %m',
+        \ }
+endfunction
+
+function! neomake#makers#ft#cs#msbuild() abort
+    return {
+        \ 'exe': 'msbuild',
+        \ 'args': ['-nologo', '-v:q', '-property:GenerateFullPaths=true', neomake#utils#FindGlobFile(expand('%:p:h'), '*.sln')],
+        \ 'errorformat': '%E%f(%l\,%c): error CS%n: %m [%.%#],'.
+        \                '%W%f(%l\,%c): warning CS%n: %m [%.%#]',
+        \ 'append_file' : 0,
         \ }
 endfunction

--- a/autoload/neomake/utils.vim
+++ b/autoload/neomake/utils.vim
@@ -423,3 +423,22 @@ endfunction
 function! neomake#utils#path_sep() abort
     return neomake#utils#IsRunningWindows() ? ';' : ':'
 endfunction
+
+" Find a file by going up the directories from the start directory
+" and performing glob search for the file.
+function! neomake#utils#FindGlobFile(startDir, file) abort
+    let currDir = a:startDir
+    let fileFound = ''
+
+    while empty(fileFound)
+        let fileFound = globpath(currDir, a:file, 1)
+        let lastFolder = currDir
+        let currDir = fnamemodify(currDir, ':h')
+
+        if currDir ==# lastFolder
+            break
+        endif
+    endwhile
+
+    return fileFound
+endfunction

--- a/tests/ft_cs.vader
+++ b/tests/ft_cs.vader
@@ -1,0 +1,30 @@
+Include: include/setup.vader
+
+Execute (cs: msbuild: errorformat):
+  Save &errorformat
+  let &errorformat = neomake#makers#ft#cs#msbuild().errorformat
+  file FooBar.cs
+
+  lgetexpr "FooBar.cs(21,63): error CS1002: ; expected [Foo\Foobar.csproj]"
+  AssertEqual getloclist(0), [{
+    \ 'lnum': 21,
+    \ 'bufnr': bufnr('%'),
+    \ 'col': 63,
+    \ 'valid': 1,
+    \ 'vcol': 0,
+    \ 'nr': 1002,
+    \ 'type': 'E',
+    \ 'pattern': '',
+    \ 'text': "; expected"}]
+
+  lgetexpr "FooBar.cs(25,29): warning CS0168: The variable 'ex' is declared but never used [Foo\Foobar.csproj]"
+  AssertEqual getloclist(0), [{
+    \ 'lnum': 25,
+    \ 'bufnr': bufnr('%'),
+    \ 'col': 29,
+    \ 'valid': 1,
+    \ 'vcol': 0,
+    \ 'nr': 168,
+    \ 'type': 'W',
+    \ 'pattern': '',
+    \ 'text': "The variable 'ex' is declared but never used"}]

--- a/tests/neomake.vader
+++ b/tests/neomake.vader
@@ -26,6 +26,7 @@ Include (Shell): ft_sh.vader
 Include (Text): ft_text.vader
 Include (Elixir): ft_elixir.vader
 Include (PHP): ft_php.vader
+Include (Cs): ft_cs.vader
 
 * Old/unorganized tests
 Execute (neomake#GetMakers):


### PR DESCRIPTION
The MSBuild uses the solution file (.sln) or the .csproj to build, so to the maker works it was needed to add a function to find the .sln file. To this maker works as well it is needed to add the MSBuild on the
environmental variable PATH.