### PR TITLE
Support new compilation warnings format with mix

### DIFF
--- a/autoload/neomake/makers/ft/elixir.vim
+++ b/autoload/neomake/makers/ft/elixir.vim
@@ -59,7 +59,7 @@ function! neomake#makers#ft#elixir#mix() abort
       \ 'postprocess': function('neomake#makers#ft#elixir#PostprocessEnforceMaxBufferLine'),
       \ 'errorformat':
         \ '** %s %f:%l: %m,'.
-        \ '%f:%l: warning: %m'
+        \ '%Ewarning: %m,%C  %f:%l,%Z'
       \ }
 endfunction
 


### PR DESCRIPTION
Hi, semi-related to https://github.com/elixir-lang/elixir/issues/5143

`mix compile --warnings-as-errors` returns a multiline string now:

```
/tmp/foo $ mix compile --warnings-as-errors
Compiling 1 file (.ex)
warning: variable world is unused
  lib/foo.ex:3
```

This PR fixes the `mix` maker, so both warnings and compilation errors are detected properly.