### PR TITLE
Fix incorrect lookup for default highlight color

### DIFF
--- a/autoload/neomake/highlights.vim
+++ b/autoload/neomake/highlights.vim
@@ -96,7 +96,7 @@ endfunction
 
 function! neomake#highlights#DefineHighlights() abort
     for [group, fg_from] in items({
-                \ 'NeomakeError': ['Error', 'bg'],
+                \ 'NeomakeError': ['Error', 'fg'],
                 \ 'NeomakeWarning': ['Todo', 'fg'],
                 \ 'NeomakeInfo': ['Question', 'fg'],
                 \ 'NeomakeMessage': ['ModeMsg', 'fg']

--- a/autoload/neomake/signs.vim
+++ b/autoload/neomake/signs.vim
@@ -220,7 +220,7 @@ function! neomake#signs#DefineHighlights() abort
     let bg = 'ctermbg='.ctermbg.' guibg='.guibg
 
     for [group, fg_from] in items({
-                \ 'NeomakeErrorSign': ['Error', 'bg'],
+                \ 'NeomakeErrorSign': ['Error', 'fg'],
                 \ 'NeomakeWarningSign': ['Todo', 'fg'],
                 \ 'NeomakeInfoSign': ['Question', 'fg'],
                 \ 'NeomakeMessageSign': ['ModeMsg', 'fg']


### PR DESCRIPTION
Not sure if this was intentional, but this was causing error signs and markers to be almost invisible in my color scheme.  I suspect this would also be the case for many other color schemes.