### PR TITLE
New g:neomake_always_show_list option suggestion

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -498,9 +498,17 @@ function! s:HandleLoclistQflistDisplay(file_mode) abort
         let height = get(g:, 'neomake_list_height', 10)
         let win_val = winnr()
         if a:file_mode
-            exe 'lwindow' height
+            if open_val == 3
+                exe 'lopen' height
+            else
+                exe 'lwindow' height
+            endif
         else
-            exe 'cwindow' height
+            if open_val == 3
+                exe 'copen' height
+            else
+                exe 'cwindow' height
+            endif
         endif
         if open_val == 2 && win_val != winnr()
             wincmd p

--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -496,15 +496,16 @@ function! s:HandleLoclistQflistDisplay(file_mode) abort
     let open_val = get(g:, 'neomake_open_list')
     if open_val
         let height = get(g:, 'neomake_list_height', 10)
+        let always_show = get(g:, 'neomake_always_show_list', 0)
         let win_val = winnr()
         if a:file_mode
-            if open_val == 3
+            if always_show
                 exe 'lopen' height
             else
                 exe 'lwindow' height
             endif
         else
-            if open_val == 3
+            if always_show
                 exe 'copen' height
             else
                 exe 'cwindow' height

--- a/doc/neomake.txt
+++ b/doc/neomake.txt
@@ -304,8 +304,11 @@ the current buffer. This effectively defaults to: >
 This setting will open the |location-list| or |quickfix| list (depending on
 whether it is operating on a file) when adding entries. A value of 2 will
 preserve the cursor position when the |location-list| or |quickfix| window is
-opened. A value of 3 always opens the |location-list| or |quickfix| regardless 
-of the result. Defaults to 0.
+opened. Defaults to 0.
+
+*g:neomake_always_show_list*
+Setting this variable to 1 will always open the |location-list| or |quickfix| 
+regardless of the result. Defaults to 0.
 
 *g:neomake_list_height*
 The height of the |location-list| or |quickfix| list opened by Neomake.

--- a/doc/neomake.txt
+++ b/doc/neomake.txt
@@ -304,7 +304,8 @@ the current buffer. This effectively defaults to: >
 This setting will open the |location-list| or |quickfix| list (depending on
 whether it is operating on a file) when adding entries. A value of 2 will
 preserve the cursor position when the |location-list| or |quickfix| window is
-opened. Defaults to 0.
+opened. A value of 3 always opens the |location-list| or |quickfix| regardless 
+of the result. Defaults to 0.
 
 *g:neomake_list_height*
 The height of the |location-list| or |quickfix| list opened by Neomake.


### PR DESCRIPTION
In my case I always want neomake to show what happen. Sometimes my makers will have errors that are not recognized by the 'errorformat' and I am just left hanging and having to open the location list manually.
Thanks for a great plugin