### PR TITLE
Drop signs queue

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -635,7 +635,7 @@ function! s:AddExprCallback(jobinfo, prev_index) abort
     let index = a:prev_index
     let maker_type = file_mode ? 'file' : 'project'
     let cleaned_signs = 0
-    let ignored_signs = 0
+    let ignored_signs = []
     let s:postprocess = get(maker, 'postprocess', function('neomake#utils#CompressWhitespace'))
     let debug = get(g:, 'neomake_verbose', 0) >= 3
 
@@ -704,7 +704,7 @@ function! s:AddExprCallback(jobinfo, prev_index) abort
 
         if g:neomake_place_signs
             if entry.lnum is 0
-                let ignored_signs += 1
+                let ignored_signs += [entry]
             else
                 call neomake#signs#PlaceSign(entry, maker_type)
             endif
@@ -721,10 +721,10 @@ function! s:AddExprCallback(jobinfo, prev_index) abort
             call setqflist(list, 'r')
         endif
     endif
-    if ignored_signs
+    if len(ignored_signs)
         call neomake#utils#DebugMessage(printf(
-                    \ 'Could not place signs for %d entries without line number.',
-                    \ ignored_signs))
+                    \ 'Could not place signs for %d entries without line number: %s.',
+                    \ len(ignored_signs), string(ignored_signs)))
     endif
     return counts_changed
 endfunction

--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -706,7 +706,7 @@ function! s:AddExprCallback(jobinfo, prev_index) abort
             if entry.lnum is 0
                 let ignored_signs += 1
             else
-                call neomake#signs#RegisterSign(entry, maker_type)
+                call neomake#signs#PlaceSign(entry, maker_type)
             endif
         endif
         if highlight_columns || highlight_lines
@@ -911,9 +911,6 @@ function! neomake#ProcessPendingOutput() abort
     call neomake#ProcessCurrentWindow()
     if len(s:project_job_output)
         call s:ProcessPendingOutput(s:project_job_output)
-        if g:neomake_place_signs
-            call neomake#signs#PlaceVisibleSigns()
-        endif
     endif
     call neomake#highlights#ShowHighlights()
 endfunction
@@ -935,9 +932,6 @@ function! s:RegisterJobOutput(jobinfo, lines, source) abort
     if !a:jobinfo.file_mode
         if s:CanProcessJobOutput()
             call s:ProcessJobOutput(a:jobinfo, a:lines, a:source)
-            if g:neomake_place_signs
-                call neomake#signs#PlaceVisibleSigns()
-            endif
             return 0
         else
             if !exists('s:project_job_output[a:jobinfo.id]')
@@ -954,7 +948,6 @@ function! s:RegisterJobOutput(jobinfo, lines, source) abort
     " Process the window directly if we can.
     if s:CanProcessJobOutput() && index(get(w:, 'neomake_make_ids', []), a:jobinfo.make_id) != -1
         call s:ProcessJobOutput(a:jobinfo, a:lines, a:source)
-        call neomake#signs#PlaceVisibleSigns()
         call neomake#highlights#ShowHighlights()
         return 0
     endif
@@ -1295,15 +1288,7 @@ function! neomake#EchoCurrentError(...) abort
     call neomake#utils#WideMessage(message)
 endfunction
 
-let s:last_cursormoved = [0, 0]
 function! neomake#CursorMoved() abort
-    let l:line = line('.')
-    if s:last_cursormoved[0] != l:line || s:last_cursormoved[1] != bufnr('%')
-        let s:last_cursormoved = [l:line, bufnr('%')]
-        if g:neomake_place_signs
-            call neomake#signs#PlaceVisibleSigns()
-        endif
-    endif
     call neomake#EchoCurrentError()
 endfunction
 

--- a/tests/signs.vader
+++ b/tests/signs.vader
@@ -20,20 +20,13 @@ Execute (neomake#signs#RedefineErrorSign):
 
   new
   file 1
+  let bufnr = bufnr('%')
+
   call neomake#Make(1, [maker])
   NeomakeTestsWaitForFinishedJobs
+  AssertNeomakeMessage 'Placing sign: sign place 5000 line=2 name=neomake_warn buffer='.bufnr('%')
   AssertNeomakeMessage 'Could not place signs for 1 entries without line number.'
 
-  let bufnr = bufnr('%')
-  let g:sign_msg = 'Placing sign: sign place 5000 line=2 name=neomake_warn buffer='.bufnr('%')
-  call neomake#signs#PlaceVisibleSigns()
-  AssertThrows AssertNeomakeMessage g:sign_msg
-  AssertEqual g:vader_exception, "Message '".g:sign_msg."' not found."
-
-  " Add the line referring to the sign.
-  norm o
-  call neomake#signs#PlaceVisibleSigns()
-  AssertNeomakeMessage g:sign_msg
 
   " Test #736.
   call neomake#signs#RedefineErrorSign({'text': '✗', 'texthl': 'ErrorMsg'})
@@ -47,7 +40,7 @@ Execute (neomake#signs#RedefineErrorSign):
   call neomake#signs#CleanAllOldSigns('file')
   AssertNeomakeMessage 'Removing signs {file: {}, project: {}}', 3
 
-Execute (neomake#signs#PlaceVisibleSigns in project mode):
+Execute (Placing signs in project mode):
   let maker = neomake#utils#MakerFromCommand('echo 1:1: W: warning')
   call extend(maker, {
         \ 'name': 'custom_maker',

--- a/tests/signs.vader
+++ b/tests/signs.vader
@@ -25,8 +25,11 @@ Execute (neomake#signs#RedefineErrorSign):
   call neomake#Make(1, [maker])
   NeomakeTestsWaitForFinishedJobs
   AssertNeomakeMessage 'Placing sign: sign place 5000 line=2 name=neomake_warn buffer='.bufnr('%')
-  AssertNeomakeMessage 'Could not place signs for 1 entries without line number.'
 
+  AssertNeomakeMessage printf("Could not place signs for 1 entries without line number: %s.",
+  \ string([{'lnum': 0, 'bufnr': bufnr, 'col': 0, 'valid': 1, 'vcol': 0,
+  \          'nr': -1, 'type': 'E', 'maker_name': 'custom_maker', 'pattern': '',
+  \          'text': 'error'}]))
 
   " Test #736.
   call neomake#signs#RedefineErrorSign({'text': '✗', 'texthl': 'ErrorMsg'})


### PR DESCRIPTION
Drop signs queue: place them immediately

This removes neomake#signs#PlaceVisibleSigns and neomake#signs#RegisterSign.

Fixes: https://github.com/neomake/neomake/issues/834
Closes: https://github.com/neomake/neomake/pull/471
Ref: https://github.com/neomake/neomake/issues/240
Ref: https://github.com/neomake/neomake/pull/893