### PR TITLE
add and use a cargo rust checker

### DIFF
--- a/autoload/neomake/makers/ft/rust.vim
+++ b/autoload/neomake/makers/ft/rust.vim
@@ -1,7 +1,7 @@
 " vim: ts=4 sw=4 et
 
 function! neomake#makers#ft#rust#EnabledMakers() abort
-    return ['rustc']
+    return ['cargo']
 endfunction
 
 function! neomake#makers#ft#rust#rustc() abort
@@ -20,5 +20,23 @@ function! neomake#makers#ft#rust#rustc() abort
             \ '%I%>help:\ %#%m,'.
             \ '%Z\ %#%m,'.
             \ '%-G%s',
+        \ }
+endfunction
+
+function! neomake#makers#ft#rust#cargo() abort
+    return {
+        \ 'args': ['build'],
+        \ 'append_file': 0,
+        \ 'errorformat':
+            \ ',' .
+            \ '%-G,' .
+            \ '%-Gerror: aborting %.%#,' .
+            \ '%-Gerror: Could not compile %.%#,' .
+            \ '%Eerror: %m,' .
+            \ '%Eerror[E%n]: %m,' .
+            \ '%-Gwarning: the option `Z` is unstable %.%#,' .
+            \ '%Wwarning: %m,' .
+            \ '%Inote: %m,' .
+            \ '%C %#--> %f:%l:%c',
         \ }
 endfunction


### PR DESCRIPTION
I'm getting the `can't find crate for` error described in rust-lang/rust.vim#130 .

This PR adapts on a fork of the rust.vim Syntastic plugin [here](https://github.com/innerand/rust.vim/commit/d6add4dee3b2a1cb796d975b7991aa887aa21a93), and creates (and uses) a new `cargo` checker.

I'm looking for feedback as I'm new to both rust and neomake:
- [ ] is my errorformat string correct for `cargo build`?
- [ ] is my errorformat string correct for neomake?
- [ ] should I go ahead and kill the old `rustc` checker?
