### PR TITLE
tests: move Include in neomake.vader

### DIFF
--- a/tests/neomake.vader
+++ b/tests/neomake.vader
@@ -283,8 +283,7 @@ Execute (neomake#Make handles invalid cwd):
       \ }
   call neomake#Make(1, [maker])
   NeomakeTestsWaitForFinishedJobs
-  let cd = exists(':tcd') ? 'tcd' : 'cd'
-  AssertNeomakeMessage "custom_maker: could not change to maker's cwd (/doesnotexist): Vim(".cd."):E344: Can't find directory \"/doesnotexist\" in cdpath", 0
+  AssertNeomakeMessage "custom_maker: could not change to maker's cwd (/doesnotexist): Vim(cd):E344: Can't find directory \"/doesnotexist\" in cdpath", 0
 
 Execute (Neomake picks up custom maker correctly):
   let g:neomake_c_lint_maker = {

--- a/tests/neomake.vader
+++ b/tests/neomake.vader
@@ -1,7 +1,6 @@
 " Main entry point to run all Vader tests.
 " You can run the included files by itself (since they also include
 " include/setup.vader).
-Include: include/setup.vader
 
 ~ Features
 Include (Completion): completion.vader
@@ -36,7 +35,10 @@ Include (Vim): ft_vim.vader
 ~ Regression tests
 Include (cwd: tcd): cwd-tcd.vader
 
+
 * Old/unorganized tests
+Include: include/setup.vader
+
 Execute (neomake#GetMakers):
   AssertEqual neomake#GetMakers('non-existent'), []
   AssertEqual neomake#GetMakers('pug'), ['puglint']


### PR DESCRIPTION
This is necessary to reset After/Before after cwd-tcd.vader.