### PR TITLE
Add support for maker.{process_output,get_list_entries}

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -1695,6 +1695,19 @@ function! s:display_maker_info(...) abort
             endif
             unlet V  " vim73
         endfor
+
+        let issues = neomake#debug#validate_maker(maker)
+        if !empty(issues)
+            for type in sort(copy(keys(issues)))
+                let items = issues[type]
+                if len(items)
+                    echo '   '.toupper(type) . ':'
+                    for issue in items
+                        echo '    - ' . issue
+                    endfor
+                endif
+            endfor
+        endif
     endfor
 endfunction
 

--- a/autoload/neomake/debug.vim
+++ b/autoload/neomake/debug.vim
@@ -1,0 +1,18 @@
+function! neomake#debug#validate_maker(maker) abort
+  let issues = {'errors': [], 'warnings': []}
+
+  if has_key(a:maker, 'process_output')
+    if has_key(a:maker, 'mapexpr')
+      let issues.warnings += ['maker has mapexpr, but only process_output will be used.']
+    endif
+    if has_key(a:maker, 'postprocess')
+      let issues.warnings += ['maker has postprocess, but only process_output will be used.']
+    endif
+  endif
+
+  if !executable(a:maker.exe)
+      let issues.errors += [printf("maker's exe (%s) is not executable.", a:maker.exe)]
+  endif
+
+  return issues
+endfunction

--- a/autoload/neomake/utils.vim
+++ b/autoload/neomake/utils.vim
@@ -237,7 +237,7 @@ function! s:command_maker.fn(jobinfo) dict abort
     let argv = split(&shell) + split(&shellcmdflag)
 
     if a:jobinfo.file_mode && get(self, 'append_file', 1)
-        let fname = self._get_fname_for_buffer(a:jobinfo.bufnr)
+        let fname = self._get_fname_for_buffer(a:jobinfo)
         let command .= ' '.fnamemodify(fname, ':p')
         let self.append_file = 0
     endif

--- a/autoload/neomake/utils.vim
+++ b/autoload/neomake/utils.vim
@@ -342,7 +342,7 @@ function! neomake#utils#GetSetting(key, maker, default, ft, bufnr) abort
   if bufvar isnot s:unset
       return bufvar
   endif
-  if has_key(g:, 'neomake_'.a:key)
+  if a:key !=# 'enabled_makers' && has_key(g:, 'neomake_'.a:key)
       return get(g:, 'neomake_'.a:key)
   endif
   return a:default

--- a/autoload/neomake/utils.vim
+++ b/autoload/neomake/utils.vim
@@ -324,10 +324,10 @@ function! neomake#utils#GetSetting(key, maker, default, ft, bufnr) abort
         break
     endif
     let config_var = 'neomake_'.part.'_'.a:key
-    unlet! bufcfgvar  " vim73
-    let bufcfgvar = neomake#compat#getbufvar(a:bufnr, config_var, s:unset)
-    if bufcfgvar isnot s:unset
-        return copy(bufcfgvar)
+    unlet! Bufcfgvar  " vim73
+    let Bufcfgvar = neomake#compat#getbufvar(a:bufnr, config_var, s:unset)
+    if Bufcfgvar isnot s:unset
+        return copy(Bufcfgvar)
     endif
     if has_key(g:, config_var)
         return copy(get(g:, config_var))

--- a/doc/neomake.txt
+++ b/doc/neomake.txt
@@ -80,9 +80,31 @@ Just set your |'makeprg'| and |'errorformat'| as usual, and run |:Neomake!|.
 If you want more, read on.
 
 Makers                                                        *neomake-makers*
-A maker is an object that tells Neomake how to run a job for you. A maker may
-be run with a file as input (great for linting), or with no file as input
-(great for building, project-level tasks).
+A maker is an object that tells Neomake how to run a job for you.
+
+                                             *neomake-makers-get_list_entries*
+If a maker has a `get_list_entries` function, this gets used to retrieve
+entries for the location or quickfix list directly.
+The function gets passed a jobinfo (|neomake-object-jobinfo|) object, and
+should return a list of entries that will be used to fill the
+location/quickfix list: >
+    let maker = {'name': 'My maker'}
+    function! maker.get_list_entries(jobinfo) abort
+      return [
+        \ {'text': 'Some error', 'lnum': 1},
+        \ {'text': 'Some warning', 'type': 'W', 'lnum': 2, 'col': 1,
+        \  'length': 5},
+        \ ]
+    endfunction
+<
+The required keys for entries are `text` and `lnum`.
+The `length` entry in the example is internal to Neomake, and sets the length
+for an highlight (see |neomake-highlight|).
+
+                                                          *neomake-job-makers*
+Otherwise a maker gets run as a job with a file as input ("file mode", good
+for linting), or with no file as input ("project mode", good for building and
+project-level tasks).
 
 Here is a sample maker definition: >
     let g:neomake_make_maker = {
@@ -148,6 +170,25 @@ This can be useful for makers that are filetype dependent but are typically
 run on an whole project rather than a specific file.
 
                                                    *neomake-makers-processing*
+A job maker's output gets processed in two ways:
+1. through a maker's `process_output` function, or
+2. via its `errorformat` (together with `mapexpr` and `postprocess`).
+
+                                               *neomake-makers-process_output*
+If a maker has a `process_output` function, this gets used to retrieve
+entries for the location or quickfix list for the job's output directly.
+
+The function gets called with a `context` dictionary, with the following
+entries:
+ - `output`: a list of lines
+ - `source`: the source of the output (`stderr`, `stdout`)
+ - `jobinfo`: the jobinfo object, see |neomake-object-jobinfo|
+It should return a list of entries (dictionaries), where `text` and `lnum`
+are required.
+
+Using this method skips the processing based on `errorformat` (including
+`mapexpr` and `postprocess`).
+
                                                       *neomake-makers-mapexpr*
 You can define two optional properties on a maker object to process its
 output: `mapexpr` is applied to the maker's output before any processing, and
@@ -566,6 +607,26 @@ The NeomakeJobFinished autocommand is triggered after a single job has
 finished.
 For this event `g:neomake_hook_context.jobinfo` will be set, where `exit_code`
 is available.
+
+==============================================================================
+5. Objects                                                   *neomake-objects*
+
+                                                      *neomake-object-jobinfo*
+The `jobinfo` dictionary contains information about a job.
+(this is experimental, so not everything is documented)
+ - `maker`: a dictionary containing information about the maker that ran
+   this job.  See |neomake-object-maker|.
+ - `file_mode`: 1 for file mode, 0 for project/directory mode.
+ - `make_id`: the ID of the make run
+
+ - Relevant for file mode:
+   - `bufnr`: the number of the buffer.
+   - `ft`: the filetype.
+                                                        *neomake-object-maker*
+The `maker` dictionary contains the following keys:
+(this is experimental, so not everything is documented)
+ - `name`: name of the maker.
+ - `exe`: executable of the maker.
 
 ==============================================================================
 6. Frequently Asked Questions (FAQ)                              *neomake-faq*

--- a/tests/include/setup.vader
+++ b/tests/include/setup.vader
@@ -279,6 +279,7 @@ Before:
 
   function! s:After()
     Restore
+    unlet! g:expected  " for old Vim with Vader, that does not wrap tests in a function.
 
     " Stop any (non-canceled) jobs.  Canceled jobs might take a while to call the
     " exit handler, but that is OK.

--- a/tests/integration.vader
+++ b/tests/integration.vader
@@ -232,6 +232,7 @@ Execute (NeomakeInfo with FuncRef):
   let info = split(neomake#utils#redir('NeomakeInfo'), '\n')
   let idx = 0
   for line in [
+      \ 'Current filetype: c',
       \ 'For the current filetype (with :Neomake):',
       \ ' - doesnotexist',
       \ '   - args: function(''getcwd'')',

--- a/tests/integration.vader
+++ b/tests/integration.vader
@@ -239,7 +239,7 @@ Execute (NeomakeInfo with FuncRef):
       \ '   - errorformat: ''custom_efm: %m''',
       \ '   - exe: ''doesnotexist''']
     let i = index(info, line)
-    Assert i > idx, 'line not found: '.line
+    Assert i > idx, 'line not found: "'.line.'" (idx: '.idx.')'
     let idx = i
   endfor
   bwipe
@@ -251,6 +251,37 @@ Execute (NeomakeInfo with unusual filetype):
   let info = split(neomake#utils#redir('NeomakeInfo'), '\n')
   Assert index(info, 'NOTE: you can define g:neomake_ft1_gentoo_package_keywords_enabled_makers to configure it (or b:neomake_ft1_gentoo_package_keywords_enabled_makers).') != -1, 'Line was found'
   bwipe
+
+Execute (NeomakeInfo: displays issues):
+  Save g:neomake_enabled_makers, g:neomake_mymaker_maker
+
+  let g:neomake_enabled_makers = ['mymaker']
+  let g:neomake_mymaker_maker = {
+  \ 'exe': 'doesnotexist',
+  \ 'args': function('getcwd'),
+  \ 'errorformat': 'custom_efm: %m',
+  \ 'mapexpr': '',
+  \ 'postprocess': function('tr'),
+  \ 'process_output': function('tr'),
+  \ }
+
+  let info = split(neomake#utils#redir('NeomakeInfo'), '\n')
+  let idx = 0
+  for line in [
+      \ 'For the project (with :Neomake!):',
+      \ ' - mymaker',
+      \ '   - args: function(''getcwd'')',
+      \ '   - errorformat: ''custom_efm: %m''',
+      \ '   - exe: ''doesnotexist''',
+      \ '   ERRORS:',
+      \ "    - maker's exe (doesnotexist) is not executable.",
+      \ '   WARNINGS:',
+      \ '    - maker has mapexpr, but only process_output will be used.',
+      \ ]
+    let i = index(info, line)
+    Assert i > idx, 'line not found: "'.line.'" (idx: '.idx.')'
+    let idx = i
+  endfor
 
 Execute (Having an invalid &errorformat is OK):
   Save &errorformat

--- a/tests/makers.vader
+++ b/tests/makers.vader
@@ -182,6 +182,9 @@ Execute (Correct function binding from base maker):
   Assert string(maker) =~# '\v''_get_argv'': function\(''\d+''\),', 'Simple _get_argv'
 
 Execute (Makers: process_output):
+  call neomake#statusline#ResetCounts()
+  call g:NeomakeSetupAutocmdWrappers()
+
   Save g:neomake_test_entries
   let g:neomake_test_entries = [{
     \ 'bufnr': bufnr('%'),
@@ -195,24 +198,141 @@ Execute (Makers: process_output):
     \ 'type': 'E',
     \ }]
 
-  Save Neomake_test_maker_get_entries
-  function! Neomake_test_maker_get_entries(context) abort
-    return g:neomake_test_entries
+  function! Neomake_test_maker_process_output(context) abort
+    AssertEqual ['maker_output'], a:context.output
+    AssertEqual 'stdout', a:context.source
+    return deepcopy(g:neomake_test_entries)
   endfunction
 
   let maker = {
+  \ 'name': 'mymaker',
   \ 'exe': 'printf',
-  \ 'args': ['foo'],
+  \ 'args': ['maker_output'],
   \ 'append_file': 0,
-  \ 'process_output': function('Neomake_test_maker_get_entries')}
+  \ 'process_output': function('Neomake_test_maker_process_output')}
 
+  call neomake#Make(1, [maker])
+  NeomakeTestsWaitForFinishedJobs
+
+  let expected = copy(g:neomake_test_entries)[0]
+  " valid=1 gets added
+  let expected.valid = 1
+  " filename is removed
+  unlet expected.filename
+  AssertEqual getloclist(0), [expected]
+
+  AssertEqual len(g:neomake_test_countschanged), 1
+  AssertEqual len(g:neomake_test_jobfinished), 1
+  AssertEqual len(g:neomake_test_finished), 1
+
+Execute (Makers: get_list_entries):
+  call neomake#statusline#ResetCounts()
+  call g:NeomakeSetupAutocmdWrappers()
+
+  Save g:neomake_test_entries
+  let g:neomake_test_entries = [{
+    \ 'bufnr': bufnr('%'),
+    \ 'filename': 'not_used_with_valid_bufnr',
+    \ 'lnum': 23,
+    \ 'pattern': '',
+    \ 'col': 42,
+    \ 'vcol': 0,
+    \ 'nr': 4711,
+    \ 'text': 'error message',
+    \ 'type': 'E',
+    \ }]
+
+  let maker = {}
+  function! maker.get_list_entries(...) abort dict
+    let jobinfo = a:1
+    AssertEqual keys(jobinfo.maker), ['name', 'get_list_entries']
+    Assert !has_key(self, 'errorformat'), 'errorformat is not required'
+    return deepcopy(g:neomake_test_entries)
+  endfunction
+
+  let maker = neomake#GetMaker(maker)
   call neomake#Make(1, [maker])
   NeomakeTestsWaitForFinishedJobs
 
   " valid=1 gets added
   let expected = map(copy(g:neomake_test_entries), "extend(v:val, {'valid': 1})")
-  " filename is removed
+  " filename and maker_name is removed
   let expected = map(expected, "filter(v:val, 'v:key != \"filename\"')")
   AssertEqual getloclist(0), g:neomake_test_entries
 
-  AssertNeomakeMessage 'Skipping User autocmd NeomakeCountsChanged: no hooks.'
+  AssertEqual len(g:neomake_test_countschanged), 1
+  AssertEqual len(g:neomake_test_jobfinished), 1
+  AssertEqual len(g:neomake_test_finished), 1
+
+Execute (Makers: get_list_entries via config):
+  let maker = {'name': 'mymaker', 'exe': 'doesnotexist'}
+
+  Save g:neomake_test_entries
+  let g:neomake_test_entries = [{
+    \ 'filename': 'not_used_with_valid_bufnr',
+    \ 'lnum': 23,
+    \ 'pattern': '',
+    \ 'col': 42,
+    \ 'vcol': 0,
+    \ 'nr': 4711,
+    \ 'text': 'error message',
+    \ 'type': 'E',
+    \ }]
+
+  function! NeomakeTestGetEntries(...) abort dict
+    let a = a:000
+    Assert !has_key(self, 'errorformat'), 'errorformat is not required'
+    return deepcopy(g:neomake_test_entries)
+  endfunction
+
+  new
+  let bufnr = bufnr('%')
+  set filetype=neomake_tests
+  let b:neomake_neomake_tests_enabled_makers = [maker]
+  let b:neomake_neomake_tests_mymaker_get_list_entries = function('NeomakeTestGetEntries')
+  RunNeomake
+
+  " valid=1 gets added
+  let expected = map(copy(g:neomake_test_entries), "extend(v:val, {'valid': 1})")
+  " filename is removed
+  let expected = map(expected, "filter(v:val, 'v:key != \"filename\"')")
+  " bufnr gets added from jobinfo
+  let expected = map(expected, "extend(v:val, {'bufnr': bufnr})")
+  AssertEqual getloclist(0), g:neomake_test_entries
+
+  AssertEqual len(g:neomake_test_countschanged), 1
+  AssertEqual len(g:neomake_test_jobfinished), 1
+  AssertEqual len(g:neomake_test_finished), 1
+  bwipe
+
+Execute (get_list_entries: minimal example (from doc)):
+  new
+  call g:NeomakeSetupAutocmdWrappers()
+  let bufnr = bufnr('%')
+
+  let maker = {'name': 'My maker'}
+  function! maker.get_list_entries(jobinfo) abort
+    " Change bufnr.
+    new
+    return [
+      \ {'text': 'Some error', 'lnum': 1},
+      \ {'text': 'Some warning', 'type': 'W', 'lnum': 2, 'col': 1, 'length': 5},
+      \ ]
+  endfunction
+  call neomake#Make(1, [maker])
+  " .length was transformed into a highlight.
+  if !has('nvim')
+    AssertEqual neomake#highlights#_get()['file'][bufnr]['NeomakeWarning'], [[2, 1, 5]]
+  endif
+
+  AssertEqual getloclist(0), [
+  \ {'lnum': 1, 'bufnr': bufnr, 'col': 0, 'valid': 1, 'vcol': 0, 'nr': -1,
+  \  'type': 'E', 'pattern': '', 'text': 'Some error'},
+  \ {'lnum': 2, 'bufnr': bufnr, 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1,
+  \  'type': 'W', 'pattern': '', 'text': 'Some warning'}]
+  bwipe
+  bwipe
+
+  AssertEqual len(g:neomake_test_countschanged), 1
+  AssertEqual len(g:neomake_test_finished), 1
+  AssertEqual len(g:neomake_test_jobfinished), 1

--- a/tests/makers.vader
+++ b/tests/makers.vader
@@ -180,3 +180,39 @@ Execute (Correct function binding from base maker):
   " representation of the object's function, when dumping the object.  This was
   " different before, when assigning the function from the base maker dict.
   Assert string(maker) =~# '\v''_get_argv'': function\(''\d+''\),', 'Simple _get_argv'
+
+Execute (Makers: process_output):
+  Save g:neomake_test_entries
+  let g:neomake_test_entries = [{
+    \ 'bufnr': bufnr('%'),
+    \ 'filename': 'not_used_with_valid_bufnr',
+    \ 'lnum': 23,
+    \ 'pattern': '',
+    \ 'col': 42,
+    \ 'vcol': 0,
+    \ 'nr': 4711,
+    \ 'text': 'error message',
+    \ 'type': 'E',
+    \ }]
+
+  Save Neomake_test_maker_get_entries
+  function! Neomake_test_maker_get_entries(context) abort
+    return g:neomake_test_entries
+  endfunction
+
+  let maker = {
+  \ 'exe': 'printf',
+  \ 'args': ['foo'],
+  \ 'append_file': 0,
+  \ 'process_output': function('Neomake_test_maker_get_entries')}
+
+  call neomake#Make(1, [maker])
+  NeomakeTestsWaitForFinishedJobs
+
+  " valid=1 gets added
+  let expected = map(copy(g:neomake_test_entries), "extend(v:val, {'valid': 1})")
+  " filename is removed
+  let expected = map(expected, "filter(v:val, 'v:key != \"filename\"')")
+  AssertEqual getloclist(0), g:neomake_test_entries
+
+  AssertNeomakeMessage 'Skipping User autocmd NeomakeCountsChanged: no hooks.'

--- a/tests/serialize.vader
+++ b/tests/serialize.vader
@@ -289,7 +289,7 @@ Execute (Uses correct maker filetypes when started in another buffer):
     NeomakeTestsWaitForFinishedJobs
 
     AssertEqual g:neomake_test_exit_cb[1], {'status': 0, 'name': 'maker2', 'has_next': 0}
-    AssertEqual g:neomake_test_exit_cb[0].maker.ft, 'orig_ft'
+    AssertEqual g:neomake_test_exit_cb[0].ft, 'orig_ft'
 
     bwipe
   endif

--- a/tests/tempfiles.vader
+++ b/tests/tempfiles.vader
@@ -114,7 +114,7 @@ Execute (Maker can specify temporary file to use via fn):
   file unreadable
   let maker = neomake#GetMaker(maker)
   AssertEqual maker.args, []
-  let jobinfo = {'file_mode': 1, 'bufnr': bufnr}
+  let jobinfo = {'file_mode': 1, 'bufnr': bufnr, 'ft': ''}
   call maker.fn(jobinfo)
   AssertEqual maker.args, []
   call maker._get_argv(jobinfo)
@@ -138,7 +138,7 @@ Execute (maker._get_argv uses jobinfo for bufnr):
   new
   let b:neomake_tempfile_enabled = 1
   let bufnr = bufnr('%')
-  let jobinfo = {'file_mode': 1, 'bufnr': bufnr}
+  let jobinfo = {'file_mode': 1, 'bufnr': bufnr, 'ft': ''}
   call maker._get_argv(jobinfo)
   Assert !empty(maker.tempfile_name)
 
@@ -148,7 +148,7 @@ Execute (maker._get_argv uses jobinfo for bufnr):
   Assert !has_key(maker, 'tempfile_name')
 
   wincmd p
-  let jobinfo = {'file_mode': 1, 'bufnr': bufnr}
+  let jobinfo = {'file_mode': 1, 'bufnr': bufnr, 'ft': ''}
   let expected = ['my_maker', fnameescape(fnamemodify(bufname(bufnr), ':p'))]
   if neomake#has_async_support()
     AssertEqual expected, maker._get_argv(jobinfo)
@@ -165,6 +165,7 @@ Execute (_get_fname_for_buffer handles modified buffer with disabled tempfiles):
   file file1
   set modified
   let maker = neomake#GetMaker({})
-  let fname = maker._get_fname_for_buffer(bufnr('%'))
+  let jobinfo = {'bufnr': bufnr('%'), 'ft': ''}
+  let fname = maker._get_fname_for_buffer(jobinfo)
   AssertEqual fname, 'file1'
   bwipe!

--- a/tests/utils.vader
+++ b/tests/utils.vader
@@ -171,6 +171,7 @@ Execute (neomake#utils#ExpandArgs):
   Save $HOME
   let $HOME='/home/sweet'
 
+  new
   file file1.ext
   let isk = &iskeyword
   let args = [
@@ -219,6 +220,7 @@ Execute (neomake#utils#ExpandArgs):
   call neomake#utils#ExpandArgs(args)
   AssertEqual expected_args, args
   AssertEqual isk, &iskeyword
+  bwipe
 
 Execute (neomake#utils#diff_dict):
   AssertEqual neomake#utils#diff_dict({}, {}), [{}, {}, {}]
@@ -265,7 +267,7 @@ Execute (neomake#utils#sort_by_col):
 Execute (neomake#utils#MakerFromCommand splits shell/shellcmdflag):
   Save &shell, &shellcmdflag
 
-  let jobinfo = {'file_mode': 0, 'bufnr': 0}
+  let jobinfo = {'file_mode': 0, 'bufnr': 0, 'ft': ''}
 
   let &shell = '/bin/bash -o pipefail'
   let &shellcmdflag = '-c'
@@ -369,7 +371,7 @@ Execute (neomake#utils#MakerFromCommand uses tempfile):
 
   new
   let b:neomake_tempfile_enabled = 1
-  let jobinfo = {'file_mode': 1, 'bufnr': bufnr('%')}
+  let jobinfo = {'file_mode': 1, 'bufnr': bufnr('%'), 'ft': ''}
   file dir/\ with\ spaces
 
   set buftype=nofile
@@ -380,7 +382,6 @@ Execute (neomake#utils#MakerFromCommand uses tempfile):
   AssertEqual bound_maker.exe, &shell
   AssertEqual bound_maker.remove_invalid_entries, 0
   AssertNotEqual temp_file, fnameescape(temp_file)
-
   bwipe
 
 Execute (neomake#utils#get_config_fts):


### PR DESCRIPTION
This is meant to return quickfix/location list entries directly,
avoiding to use both `mapexpr` and `postprocess` with JSON output.

TODO:
 - [x] doc
 - [x] skip `_bind_args` etc after #1057 is merged for `get_list_entries`: use another base dict, and use `if has_key(maker, '_bind_args') | … | endif` then?!
 - [ ] review the diff according to all the rebases/changes

/cc @JelteF 