### PR TITLE
[RFC] autolinting

### DIFF
--- a/autoload/neomake/configure.vim
+++ b/autoload/neomake/configure.vim
@@ -31,6 +31,7 @@ function! neomake#configure#autolint(modes, ...) abort
     au!
     if len(a:modes)
       if !has('timers')
+        call neomake#utils#ErrorMessage('Timer support is required for autolinting.')
       endif
       if a:modes =~# 'n'
         autocmd WinEnter,CursorMoved <buffer> call <SID>neomake_autolint_delayed('n')

--- a/autoload/neomake/configure.vim
+++ b/autoload/neomake/configure.vim
@@ -34,10 +34,10 @@ function! neomake#configure#autolint(modes, ...) abort
         call neomake#utils#ErrorMessage('Timer support is required for autolinting.')
       endif
       if a:modes =~# 'n'
-        autocmd WinEnter,CursorMoved <buffer> call <SID>neomake_autolint_delayed('n')
+        autocmd WinEnter,CursorMoved * call <SID>neomake_autolint_delayed('n')
       endif
       if a:modes =~# 'i'
-        autocmd InsertEnter,CursorMovedI <buffer> call <SID>neomake_autolint_delayed('i')
+        autocmd InsertEnter,CursorMovedI * call <SID>neomake_autolint_delayed('i')
       endif
     endif
   augroup END

--- a/autoload/neomake/configure.vim
+++ b/autoload/neomake/configure.vim
@@ -1,0 +1,43 @@
+function! s:neomake_autolint_delayed(mode) abort
+  if exists('s:autolint_timer')
+    call timer_stop(s:autolint_timer)
+    unlet s:autolint_timer
+  endif
+  let s:autolint_laststate = [getpos('.'), a:mode, bufnr('%')]
+  let s:autolint_timer = timer_start(
+        \ get(g:, 'neomake#config#autolint_delay', 500),
+        \ function('s:autolint_delayed_cb'))
+endfunction
+
+function! s:autolint_delayed_cb(timer) abort
+  if [getpos('.'), mode(), bufnr('%')] == s:autolint_laststate
+    if b:changedtick != get(get(b:, 'neomake_state', {}), 'changedtick', -1)
+      Neomake
+
+      if !exists('b:neomake_state')
+        let b:neomake_state = {}
+      endif
+      let b:neomake_state.changedtick = b:changedtick
+    endif
+  endif
+endfunction
+
+function! neomake#configure#autolint(modes, ...) abort
+  if a:0
+    let g:neomake#config#autolint_delay = a:1
+  endif
+
+  augroup neomake_autolint
+    au!
+    if len(a:modes)
+      if !has('timers')
+      endif
+      if a:modes =~# 'n'
+        autocmd WinEnter,CursorMoved <buffer> call <SID>neomake_autolint_delayed('n')
+      endif
+      if a:modes =~# 'i'
+        autocmd InsertEnter,CursorMovedI <buffer> call <SID>neomake_autolint_delayed('i')
+      endif
+    endif
+  augroup END
+endfunction

--- a/autoload/neomake/configure.vim
+++ b/autoload/neomake/configure.vim
@@ -1,47 +1,114 @@
+let s:timer_info = {}
+let s:timer_by_bufnr = {}
+
+function! s:get_setting(name, default) abort
+  return get(get(b:, 'neomake', {}), a:name,
+        \ get(get(g:, 'neomake', {}), a:name, a:default))
+endfunction
+
 function! s:neomake_autolint_delayed(mode) abort
-  if exists('s:autolint_timer')
-    call timer_stop(s:autolint_timer)
-    unlet s:autolint_timer
+  let bufnr = bufnr('%')
+  if exists('s:timer_by_bufnr[bufnr]')
+    call timer_stop(s:timer_by_bufnr[bufnr])
+    unlet s:timer_by_bufnr[bufnr]
   endif
-  let s:autolint_laststate = [getpos('.'), a:mode, bufnr('%')]
-  let s:autolint_timer = timer_start(
-        \ get(g:, 'neomake#config#autolint_delay', 500),
+
+  " TODO: test
+  let buftype = getbufvar(bufnr, '&buftype')
+  if len(buftype)
+    call neomake#utils#DebugMessage(printf(
+          \ 'autolint: timer: skipping setup for buftype=%s (bufnr=%s)', buftype, bufnr))
+    return
+  endif
+
+  let delay = s:get_setting('autolint_delay', 500)
+  let timer = timer_start(
+        \ delay,
         \ function('s:autolint_delayed_cb'))
+  let s:timer_info[timer] = {
+        \ 'context': [getpos('.'), a:mode, bufnr]}
+  let s:timer_by_bufnr[bufnr] = timer
 endfunction
 
 function! s:autolint_delayed_cb(timer) abort
-  if [getpos('.'), mode(), bufnr('%')] == s:autolint_laststate
-    if b:changedtick != get(get(b:, 'neomake_state', {}), 'changedtick', -1)
+  let bufnr = bufnr('%')
+  let timer_info = s:timer_info[a:timer]
+  if !len(timer_info)
+    " Timed out in a different buffer?!
+    " TODO: restart?
+    "
+    return
+  endif
+
+  if [getpos('.'), mode(), bufnr] == timer_info.context
+    if b:changedtick != get(b:, 'neomake_autolint_tick', -1)
       Neomake
 
-      if !exists('b:neomake_state')
-        let b:neomake_state = {}
-      endif
-      let b:neomake_state.changedtick = b:changedtick
+      let b:neomake_autolint_tick = b:changedtick
     endif
   endif
+
+  unlet s:timer_info[a:timer]
 endfunction
 
-function! neomake#configure#autolint(modes, ...) abort
+function! neomake#configure#autolint_for_buffer(...) abort
+  let bufnr = a:0 > 2 ? a:3 : bufnr('%')
+  let buftype = getbufvar(bufnr, '&buftype')
+  if !empty(&buftype)
+    call neomake#utils#DebugMessage(printf(
+          \ 'autolint: skipping setup for buftype=%s (bufnr=%s)', buftype, bufnr))
+    return
+  endif
+  if a:0 > 0
+    if !exists('b:neomake')
+      let b:neomake = {}
+    endif
+    let b:neomake.autolint_modes = a:1
+    if a:0 > 1
+      let b:neomake.autolint_delay = a:2
+    endif
+  endif
+
+  augroup neomake_autolint_buffer
+    let modes = s:get_setting('autolint_modes', '')
+    if len(modes)
+      if modes =~# 'n'
+        autocmd WinEnter <buffer> call <SID>neomake_autolint_delayed('n')
+        autocmd TextChanged <buffer> call <SID>neomake_autolint_delayed('n')
+      endif
+      if modes =~# 'i'
+        autocmd TextChangedI <buffer> call <SID>neomake_autolint_delayed('i')
+      endif
+      if modes =~# 'w'
+        autocmd BufWritePost <buffer> Neomake
+      endif
+    else
+    endif
+  augroup END
+  " Log neomake#utils#redir('au neomake_autolint_buffer')
+endfunction
+
+function! neomake#configure#autolint(...) abort
   if a:0
-    let g:neomake#config#autolint_delay = a:1
+    if !exists('g:neomake')
+      let g:neomake = {}
+    endif
+    let g:neomake.autolint_modes = a:1
+    if a:0 > 1
+      let g:neomake.autolint_delay = a:2
+    endif
   endif
 
   augroup neomake_autolint
     au!
-    if len(a:modes)
+    if len(g:neomake.autolint_modes)
       if !has('timers')
         call neomake#utils#ErrorMessage('Timer support is required for autolinting.')
+      else
+        autocmd FileType,BufWinEnter,BufNew * call neomake#configure#autolint_for_buffer()
       endif
-      if a:modes =~# 'n'
-        autocmd WinEnter,CursorMoved * call <SID>neomake_autolint_delayed('n')
-      endif
-      if a:modes =~# 'i'
-        autocmd InsertEnter,CursorMovedI * call <SID>neomake_autolint_delayed('i')
-      endif
-      if a:modes =~# 'w'
-        autocmd BufWritePost * Neomake
-      endif
+      " Setup current buffer now.
+      call neomake#configure#autolint_for_buffer()
     endif
   augroup END
 endfunction

--- a/autoload/neomake/configure.vim
+++ b/autoload/neomake/configure.vim
@@ -39,6 +39,9 @@ function! neomake#configure#autolint(modes, ...) abort
       if a:modes =~# 'i'
         autocmd InsertEnter,CursorMovedI * call <SID>neomake_autolint_delayed('i')
       endif
+      if a:modes =~# 'w'
+        autocmd BufWritePost * Neomake
+      endif
     endif
   augroup END
 endfunction

--- a/autoload/neomake/configure.vim
+++ b/autoload/neomake/configure.vim
@@ -72,17 +72,22 @@ function! neomake#configure#autolint_for_buffer(...) abort
   augroup neomake_autolint_buffer
     let modes = s:get_setting('autolint_modes', '')
     if len(modes)
-      if modes =~# 'n'
-        autocmd WinEnter <buffer> call <SID>neomake_autolint_delayed('n')
-        autocmd TextChanged <buffer> call <SID>neomake_autolint_delayed('n')
+      if modes =~# 'n' || modes =~# 'i'
+        if !has('timers')
+          call neomake#utils#ErrorMessage('Timer support is required for autolinting.')
+        else
+          if modes =~# 'n'
+            autocmd WinEnter <buffer> call <SID>neomake_autolint_delayed('n')
+            autocmd TextChanged <buffer> call <SID>neomake_autolint_delayed('n')
+          endif
+          if modes =~# 'i'
+            autocmd TextChangedI <buffer> call <SID>neomake_autolint_delayed('i')
+          endif
+        endif
       endif
-      if modes =~# 'i'
-        autocmd TextChangedI <buffer> call <SID>neomake_autolint_delayed('i')
-      endif
-      if modes =~# 'w'
-        autocmd BufWritePost <buffer> Neomake
-      endif
-    else
+    endif
+    if modes =~# 'w'
+      autocmd BufWritePost <buffer> Neomake
     endif
   augroup END
   " Log neomake#utils#redir('au neomake_autolint_buffer')

--- a/tests/autolint.vader
+++ b/tests/autolint.vader
@@ -7,6 +7,7 @@ Execute (Autolinting):
   else
     new
     setfiletype neomake_tests
+    Save g:neomake_test_enabledmakers
     let g:neomake_test_enabledmakers = ['true']
     norm iline1
     norm oline2

--- a/tests/autolint.vader
+++ b/tests/autolint.vader
@@ -33,6 +33,10 @@ Execute (Autolinting):
     sleep 20m
     AssertNeomakeMessage 'Nothing to make: no enabled makers.'
 
+    call neomake#configure#autolint('nw', 10)
+    exe 'write' tempname()
+    AssertNeomakeMessage 'Nothing to make: no enabled makers.'
+
     bwipe!
     bwipe!
   endif

--- a/tests/autolint.vader
+++ b/tests/autolint.vader
@@ -102,8 +102,9 @@ Execute (neomake#configure#autolint_for_buffer handles current buffer only):
   AssertNotEqual autocmds, "\n--- Auto-Commands ---"
 
   " First buffer should be still configured.
-  b#
+  wincmd p
   AssertEqual NeomakeTestsGetAutocommands(), autocmds
 
   bwipe
+  wincmd p
   bwipe

--- a/tests/autolint.vader
+++ b/tests/autolint.vader
@@ -91,7 +91,12 @@ Execute (neomake#configure#autolint_for_buffer handles current buffer only):
   new
   call neomake#configure#autolint_for_buffer('n', 10)
   let autocmds = NeomakeTestsGetAutocommands()
-  AssertNotEqual autocmds, "\n--- Auto-Commands ---"
+  if has('timers')
+    AssertNotEqual autocmds, "\n--- Auto-Commands ---"
+  else
+    AssertEqual NeomakeTestsGetAutocommands(), "\n--- Auto-Commands ---"
+    AssertNeomakeMessage 'Timer support is required for autolinting.'
+  endif
 
   " New buffer should not be configured.
   new
@@ -99,7 +104,9 @@ Execute (neomake#configure#autolint_for_buffer handles current buffer only):
 
   " Now configure 2nd buffer.
   call neomake#configure#autolint_for_buffer('n', 2000)
-  AssertNotEqual autocmds, "\n--- Auto-Commands ---"
+  if has('timers')
+    AssertNotEqual autocmds, "\n--- Auto-Commands ---"
+  endif
 
   " First buffer should be still configured.
   wincmd p

--- a/tests/autolint.vader
+++ b/tests/autolint.vader
@@ -2,9 +2,12 @@ Include: include/setup.vader
 
 Execute (Autolinting):
   call neomake#configure#autolint('n', 10)
+
   if !has('timers')
     AssertNeomakeMessage 'Timer support is required for autolinting.', 0
   else
+    AssertEqual &buftype, 'nofile'
+    AssertNeomakeMessage 'autolint: skipping setup for buftype=nofile (bufnr='.bufnr('%').')'
     new
     setfiletype neomake_tests
     Save g:neomake_test_enabledmakers
@@ -14,23 +17,32 @@ Execute (Autolinting):
 
     call g:NeomakeSetupAutocmdWrappers()
 
-    doautocmd CursorMoved
+    doautocmd TextChanged
     sleep 50m
     AssertEqual len(g:neomake_test_jobfinished), 1
 
     " Should not run without changes to the buffer.
-    doautocmd CursorMoved
+    doautocmd TextChanged
     sleep 50m
     AssertEqual len(g:neomake_test_jobfinished), 1
 
     " Should run with changes to the buffer.
     norm oline3
-    doautocmd CursorMoved
+    doautocmd TextChanged
     sleep 50m
     AssertEqual len(g:neomake_test_jobfinished), 2
 
+    norm oline4
+    AssertEqual len(g:neomake_test_jobfinished), 2
+    doautocmd TextChanged
+    AssertEqual len(g:neomake_test_jobfinished), 2
+    doautocmd TextChanged
+    AssertEqual len(g:neomake_test_jobfinished), 2
+    sleep 50m
+    AssertEqual len(g:neomake_test_jobfinished), 3
+
     new
-    doautocmd CursorMoved
+    doautocmd TextChanged
     sleep 50m
     AssertNeomakeMessage 'Nothing to make: no enabled makers.'
 
@@ -41,3 +53,57 @@ Execute (Autolinting):
     bwipe!
     bwipe!
   endif
+
+Execute (Autolinting: skips non-default buftypes):
+  call neomake#configure#autolint('n', 10)
+  if !has('timers')
+    AssertNeomakeMessage 'Timer support is required for autolinting.', 0
+  else
+    new
+    setfiletype neomake_tests
+    Save g:neomake_test_enabledmakers
+    let g:neomake_test_enabledmakers = ['true']
+    set buftype=nofile
+
+    call g:NeomakeSetupAutocmdWrappers()
+
+    doautocmd TextChanged
+    sleep 50m
+    AssertEqual len(g:neomake_test_jobfinished), 0
+    bwipe!
+  endif
+
+Execute (neomake#configure#autolint_for_buffer skips non-default buftypes):
+  new
+  set buftype=nofile
+  call neomake#configure#autolint_for_buffer('n', 10)
+  AssertNeomakeMessage 'autolint: skipping setup for buftype=nofile (bufnr='.bufnr('%').')'
+  bwipe
+
+Execute (neomake#configure#autolint_for_buffer handles current buffer only):
+  call neomake#configure#autolint('')
+
+  function! NeomakeTestsGetAutocommands()
+    return neomake#utils#redir('au neomake_autolint_buffer * <buffer='.bufnr('%').'>')
+  endfunction
+
+  " Configure first buffer only.
+  new
+  call neomake#configure#autolint_for_buffer('n', 10)
+  let autocmds = NeomakeTestsGetAutocommands()
+  AssertNotEqual autocmds, "\n--- Auto-Commands ---"
+
+  " New buffer should not be configured.
+  new
+  AssertEqual NeomakeTestsGetAutocommands(), "\n--- Auto-Commands ---"
+
+  " Now configure 2nd buffer.
+  call neomake#configure#autolint_for_buffer('n', 2000)
+  AssertNotEqual autocmds, "\n--- Auto-Commands ---"
+
+  " First buffer should be still configured.
+  b#
+  AssertEqual NeomakeTestsGetAutocommands(), autocmds
+
+  bwipe
+  bwipe

--- a/tests/autolint.vader
+++ b/tests/autolint.vader
@@ -22,7 +22,7 @@ Execute (Autolinting):
     sleep 20m
     AssertEqual len(g:neomake_test_jobfinished), 1
 
-    " Should not run without changes to the buffer.
+    " Should run with changes to the buffer.
     norm oline3
     doautocmd CursorMoved
     sleep 20m

--- a/tests/autolint.vader
+++ b/tests/autolint.vader
@@ -28,5 +28,11 @@ Execute (Autolinting):
     sleep 20m
     AssertEqual len(g:neomake_test_jobfinished), 2
 
+    new
+    doautocmd CursorMoved
+    sleep 20m
+    AssertNeomakeMessage 'Nothing to make: no enabled makers.'
+
+    bwipe!
     bwipe!
   endif

--- a/tests/autolint.vader
+++ b/tests/autolint.vader
@@ -15,23 +15,23 @@ Execute (Autolinting):
     call g:NeomakeSetupAutocmdWrappers()
 
     doautocmd CursorMoved
-    sleep 20m
+    sleep 50m
     AssertEqual len(g:neomake_test_jobfinished), 1
 
     " Should not run without changes to the buffer.
     doautocmd CursorMoved
-    sleep 20m
+    sleep 50m
     AssertEqual len(g:neomake_test_jobfinished), 1
 
     " Should run with changes to the buffer.
     norm oline3
     doautocmd CursorMoved
-    sleep 20m
+    sleep 50m
     AssertEqual len(g:neomake_test_jobfinished), 2
 
     new
     doautocmd CursorMoved
-    sleep 20m
+    sleep 50m
     AssertNeomakeMessage 'Nothing to make: no enabled makers.'
 
     call neomake#configure#autolint('nw', 10)

--- a/tests/autolint.vader
+++ b/tests/autolint.vader
@@ -1,0 +1,32 @@
+Include: include/setup.vader
+
+Execute (Autolinting):
+  call neomake#configure#autolint('n', 10)
+  if !has('timers')
+    AssertNeomakeMessage 'Timer support is required for autolinting.', 0
+  else
+    new
+    setfiletype neomake_tests
+    let g:neomake_test_enabledmakers = ['true']
+    norm iline1
+    norm oline2
+
+    call g:NeomakeSetupAutocmdWrappers()
+
+    doautocmd CursorMoved
+    sleep 20m
+    AssertEqual len(g:neomake_test_jobfinished), 1
+
+    " Should not run without changes to the buffer.
+    doautocmd CursorMoved
+    sleep 20m
+    AssertEqual len(g:neomake_test_jobfinished), 1
+
+    " Should not run without changes to the buffer.
+    norm oline3
+    doautocmd CursorMoved
+    sleep 20m
+    AssertEqual len(g:neomake_test_jobfinished), 2
+
+    bwipe!
+  endif

--- a/tests/neomake.vader
+++ b/tests/neomake.vader
@@ -3,6 +3,7 @@
 " include/setup.vader).
 
 ~ Features
+Include (Autolinting): autolint.vader
 Include (Completion): completion.vader
 Include (Error handling): errors.vader
 Include (Filetype handling): filetypes.vader


### PR DESCRIPTION
This is a step into the direction of better linting on-the-fly etc.

Use `call neomake#configure#autolint('niw', 100)` to configure it in
normal and insert mode with a delay of 100ms, and to setup a `BufWritePost` autocommand.

Use `i` to configure it for insert mode only.

The default delay is 500ms.

TODO:
 - [ ] better config (see https://github.com/dojoteef/neomake-autolint/commit/c0e1d874aac953bd351cf140a9b4be39f5902174 / https://github.com/dojoteef/neomake-autolint/issues/8).
 - [x] split out handling of temp files: https://github.com/neomake/neomake/pull/1057
 - [ ] allow config overrides based on autolint mode (by refactoring settings in general (dict based))
 - [ ] short-circuit maker init/setup e.g. while in the same mode / settings were not changed (performance); basically try to just run job_start again.
 - [ ] explicitly cancel jobs when restarting, instead of letting Neomake handle it?!

Ref: https://github.com/neomake/neomake/issues/190

/cc @dojoteef 