### PR TITLE
Handle unreadable/modified buffers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,5 +64,6 @@ script:
       if [[ "$ENV" = "testvim" ]]; then
         vim --version
       fi
+      umask 022
       make $ENV $MAKE_ARGS
     fi

--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -147,18 +147,6 @@ function! s:MakeJob(make_id, options) abort
         \ 'next': get(a:options, 'next', {}),
         \ }
 
-    " Call .fn function in maker object, if any.
-    if has_key(maker, 'fn')
-        " TODO: Allow to throw and/or return 0 to abort/skip?!
-        let returned_maker = call(maker.fn, [jobinfo], maker)
-        if returned_maker isnot# 0
-            " This conditional assignment allows to both return a copy
-            " (factory), while also can be used as a init method.  The maker
-            " is deepcopied usually here already though anyway (via
-            " s:map_makers).
-            let maker = returned_maker
-        endif
-    endif
     let jobinfo.maker = maker
 
     " Check for already running job for the same maker (from other runs).
@@ -223,7 +211,7 @@ function! s:MakeJob(make_id, options) abort
 
     try
         let error = ''
-        let argv = maker._get_argv(jobinfo.file_mode ? jobinfo.bufnr : 0)
+        let argv = maker._get_argv(jobinfo)
         " Lock maker to make sure it does not get changed accidentally, but
         " only with depth=1, so that a postprocess object can change itself.
         lockvar 1 maker
@@ -309,17 +297,78 @@ function! s:MakeJob(make_id, options) abort
 endfunction
 
 let s:maker_base = {}
-function! s:maker_base._get_argv(...) abort dict
-    let bufnr = a:0 ? a:1 : 0
-
-    " Resolve exe/args, which might be a function or dictionary.
-    if type(self.exe) == type(function('tr'))
-        let exe = call(self.exe, [])
-    elseif type(self.exe) == type({})
-        let exe = call(self.exe.fn, [], self.exe)
-    else
-        let exe = self.exe
+function! s:maker_base._get_tempfilename() abort dict
+    if has_key(self, 'tempfile_name')
+        return self.tempfile_name
     endif
+
+    let bufnr = bufnr('%')
+    let fts = has_key(self, 'ft') ? [self.ft] : []
+    let tempfile_enabled = neomake#utils#GetSetting('tempfile_enabled', self, 1, fts, bufnr)
+    if !tempfile_enabled
+        return ''
+    endif
+
+    let bufname = bufname(bufnr)
+    if len(bufname)
+        let bufname = fnamemodify(bufname, ':t')
+    else
+        let bufname = 'neomake_tmp.' . join(fts, '.')
+    endif
+
+    return tempname() . (has('win32') ? '\' : '/') . bufname
+endfunction
+
+" Check if a temporary file is used, and set self.tempfile_name in case it is.
+function! s:maker_base._get_fname_for_buffer() abort
+    let bufnr = bufnr('%')
+    let bufname = bufname(bufnr)
+    if !len(bufname)
+        let temp_file = self._get_tempfilename()
+        if !empty(temp_file)
+            call neomake#utils#DebugMessage(printf(
+                        \ 'Using tempfile for unnamed buffer %s: %s', bufnr, temp_file))
+        else
+            throw 'Neomake: no file name'
+        endif
+
+    elseif &modified
+        let temp_file = self._get_tempfilename()
+        if !empty(temp_file)
+            call neomake#utils#DebugMessage(printf(
+                        \ 'Using tempfile for modified buffer %s: %s', bufnr, temp_file))
+        else
+            call neomake#utils#DebugMessage(printf(
+                        \ 'warning: buffer is modified: %s', bufnr))
+        endif
+
+    elseif !filereadable(bufname)
+        let temp_file = self._get_tempfilename()
+        if !empty(temp_file)
+            call neomake#utils#DebugMessage(printf(
+                        \ 'Using tempfile for unreadable buffer %s: %s', bufnr, temp_file))
+        else
+            throw 'Neomake: file is not readable ('.fnamemodify(bufname, ':p').')'
+        endif
+    else
+        let bufname = fnamemodify(bufname, ':p')
+    endif
+
+    if exists('temp_file')
+        let temp_dir = fnamemodify(temp_file, ':h')
+        if !isdirectory(temp_dir)
+            call mkdir(temp_dir, 'p', 0750)
+        endif
+        call writefile(getbufline(bufnr, 1, '$'), temp_file)
+
+        let bufname = temp_file
+        let self.tempfile_name = temp_file
+    endif
+    return bufname
+endfunction
+
+function! s:maker_base._bind_args() abort dict
+    " Resolve args, which might be a function or dictionary.
     if type(self.args) == type(function('tr'))
         let args = call(self.args, [])
     elseif type(self.args) == type({})
@@ -328,23 +377,32 @@ function! s:maker_base._get_argv(...) abort dict
         let args = copy(self.args)
     endif
     let args_is_list = type(args) == type([])
-
     if args_is_list
         call neomake#utils#ExpandArgs(args)
     endif
-    if bufnr && neomake#utils#GetSetting('append_file', self, 1, [self.ft], bufnr)
-        let bufname = bufname(bufnr)
-        if !len(bufname)
-            throw 'Neomake: no file name'
-        endif
-        let bufname = fnamemodify(bufname, ':p')
-        if !filereadable(bufname)
-            throw 'Neomake: file is not readable ('.bufname.')'
-        endif
+    let self.args = args
+endfunction
+
+function! s:maker_base._get_argv(jobinfo) abort dict
+    " Resolve exe, which might be a function or dictionary.
+    if type(self.exe) == type(function('tr'))
+        let exe = call(self.exe, [])
+    elseif type(self.exe) == type({})
+        let exe = call(self.exe.fn, [], self.exe)
+    else
+        let exe = self.exe
+    endif
+
+    let args = copy(self.args)
+    let args_is_list = type(args) == type([])
+
+    let fts = has_key(self, 'ft') ? [self.ft] : []
+    if a:jobinfo.file_mode && neomake#utils#GetSetting('append_file', self, 1, fts, a:jobinfo.bufnr)
+        let filename = self._get_fname_for_buffer()
         if args_is_list
-            call add(args, bufname)
+            call add(args, filename)
         else
-            let args .= ' '.fnameescape(bufname)
+            let args .= ' '.fnameescape(filename)
         endif
     endif
 
@@ -659,16 +717,20 @@ function! s:Make(options) abort
         endif
 
         call s:AddMakeInfoForCurrentWin(s:make_id)
-    endif
 
-    let args = [options.enabled_makers]
-    if file_mode
-        let args += [&filetype]
-    endif
-    let enabled_makers = call('s:map_makers', args)
-    if !len(enabled_makers)
-        call neomake#utils#DebugMessage('Nothing to make: no valid makers.')
-        return []
+        " Instantiate all makers in the beginning (so expand() gets used in
+        " the current buffer's context).
+        let args = [options]
+        if file_mode
+            let args += [&filetype]
+        endif
+        let enabled_makers = call('s:map_makers', args)
+        if !len(enabled_makers)
+            call neomake#utils#DebugMessage('Nothing to make: no valid makers.')
+            return []
+        endif
+    else
+        let enabled_makers = get(options, 'enabled_makers', [])
     endif
 
     let maker_info = join(map(copy(enabled_makers),
@@ -683,6 +745,8 @@ function! s:Make(options) abort
             continue
         endif
         if has_key(a:options, 'exit_callback')
+            " FIXME: remove/refactor exit_callback with NeomakeFinished.
+            "        (https://github.com/neomake/neomake/issues/1074)
             let maker.exit_callback = a:options.exit_callback
         endif
         " call neomake#utils#DebugMessage('Maker: '.string(enabled_makers), {'make_id': s:make_id})
@@ -760,6 +824,9 @@ function! s:AddExprCallback(jobinfo, prev_index) abort
         let index += 1
 
         let before = copy(entry)
+        if file_mode && has_key(a:jobinfo.maker, 'tempfile_name')
+            let entry.bufnr = a:jobinfo.bufnr
+        endif
         if !empty(s:postprocessors)
             let g:neomake_hook_context = {'jobinfo': a:jobinfo}
             for s:f in s:postprocessors
@@ -868,6 +935,18 @@ function! s:CleanJobinfo(jobinfo) abort
         endif
         if has_key(s:project_job_output, a:jobinfo.id)
             unlet s:project_job_output[a:jobinfo.id]
+        endif
+    endif
+
+    let temp_file = get(a:jobinfo.maker, 'tempfile_name', '')
+    if !empty(temp_file)
+        call neomake#utils#DebugMessage(printf('Removing temporary file: %s',
+                    \ temp_file))
+        call delete(temp_file)
+        " XXX: old Vim has no support for flags.. the patch version is not
+        " exact here!
+        if v:version >= 705 || (v:version == 704 && has('patch1689'))
+            call delete(fnamemodify(temp_file, ':h'), 'd')
         endif
     endif
 
@@ -1452,17 +1531,32 @@ function! neomake#CompleteJobs(...) abort
     return join(map(neomake#GetJobs(), "v:val.id.': '.v:val.maker.name"), "\n")
 endfunction
 
-function! s:map_makers(makers, ...) abort
+function! s:map_makers(jobinfo, ...) abort
     let r = []
-    for maker in a:makers
+    for maker_or_name in a:jobinfo.enabled_makers
         try
-            let m = call('neomake#GetMaker', [maker] + a:000)
+            let maker = call('neomake#GetMaker', [maker_or_name] + a:000)
+            call maker._bind_args()
+
+            " Call .fn function in maker object, if any.
+            if has_key(maker, 'fn')
+                " TODO: Allow to throw and/or return 0 to abort/skip?!
+                let returned_maker = call(maker.fn, [a:jobinfo], maker)
+                if returned_maker isnot# 0
+                    " This conditional assignment allows to both return a copy
+                    " (factory), while also can be used as a init method.  The maker
+                    " is deepcopied usually here already though anyway (via
+                    " s:map_makers).
+                    let maker = returned_maker
+                endif
+            endif
+
         catch /^Neomake: /
             let error = substitute(v:exception, '^Neomake: ', '', '')
-            call neomake#utils#ErrorMessage(error)
+            call neomake#utils#ErrorMessage(error, {'make_id': s:make_id})
             continue
         endtry
-        let r += [m]
+        let r += [maker]
     endfor
     return r
 endfunction

--- a/autoload/neomake/makers/ft/neomake_tests.vim
+++ b/autoload/neomake/makers/ft/neomake_tests.vim
@@ -20,3 +20,7 @@ function! neomake#makers#ft#neomake_tests#echo_maker() abort
         \ 'append_file': 0,
         \ }
 endfunction
+
+function! neomake#makers#ft#neomake_tests#true() abort
+  return {}
+endfunction

--- a/autoload/neomake/utils.vim
+++ b/autoload/neomake/utils.vim
@@ -237,14 +237,17 @@ function! s:command_maker.fn(jobinfo) dict abort
     let argv = split(&shell) + split(&shellcmdflag)
 
     if a:jobinfo.file_mode && get(self, 'append_file', 1)
-        let command .= ' '.fnameescape(fnamemodify(bufname(a:jobinfo.bufnr), ':p'))
+        let fname = self._get_fname_for_buffer()
+        let command .= ' '.fnamemodify(fname, ':p')
         let self.append_file = 0
     endif
     call extend(self, {
                 \ 'exe': argv[0],
                 \ 'args': argv[1:] + [command],
                 \ })
-    return filter(copy(self), "v:key !~# '^__' && v:key !~# 'fn'")
+
+    " Return a cleaned up copy of self.
+    return filter(copy(self), "v:key !~# '^__' && v:key !=# 'fn'")
 endfunction
 
 function! neomake#utils#MakerFromCommand(command) abort

--- a/autoload/neomake/utils.vim
+++ b/autoload/neomake/utils.vim
@@ -237,7 +237,7 @@ function! s:command_maker.fn(jobinfo) dict abort
     let argv = split(&shell) + split(&shellcmdflag)
 
     if a:jobinfo.file_mode && get(self, 'append_file', 1)
-        let fname = self._get_fname_for_buffer()
+        let fname = self._get_fname_for_buffer(a:jobinfo.bufnr)
         let command .= ' '.fnamemodify(fname, ':p')
         let self.append_file = 0
     endif

--- a/doc/neomake.txt
+++ b/doc/neomake.txt
@@ -239,6 +239,18 @@ property: >
         \ 'cwd': '%:p:h'
         \ }
 <
+                                             *neomake-makers-tempfile_enabled*
+Default: 1
+In case the buffer is not readable or modified, the maker will get passed a
+temporary file with the buffer's contents.
+The temporary filename is based on |tempname()| by default, and will be set as
+`tempfile_name` in the maker dict.  You can set it dynamically through the
+experimental `maker.fn` callback (which is not documented on purpose yet).
+
+If some maker has problems with temporary files outside the source tree, you
+can disable this behaviour using: >
+        let g:neomake_<ft>_<name>_tempfile_enabled = 0
+<
 
 Global Options                                               *neomake-options*
 

--- a/tests/errors.vader
+++ b/tests/errors.vader
@@ -2,7 +2,9 @@ Include: include/setup.vader
 
 Execute (Error with no filename):
   new
-  set ft=python
+  set ft=neomake_tests
+  let b:neomake_neomake_tests_enabled_makers = ['true']
+  let b:neomake_neomake_tests_true_tempfile_enabled = 0
 
   Neomake
   let make_id = neomake#GetStatus().last_make_id
@@ -11,7 +13,9 @@ Execute (Error with no filename):
 
 Execute (Error with non-existing filename):
   new
-  set ft=python
+  set ft=neomake_tests
+  let b:neomake_neomake_tests_enabled_makers = ['true']
+  let b:neomake_neomake_tests_true_tempfile_enabled = 0
   file doesnotexist
 
   let fname = fnamemodify(bufname('%'), ':p')
@@ -24,7 +28,9 @@ Execute (Error with non-existing filename for 2nd maker):
   call g:NeomakeSetupAutocmdWrappers()
 
   new
-  set ft=python
+  set ft=neomake_tests
+  let b:neomake_neomake_tests_enabled_makers = ['true']
+  let b:neomake_neomake_tests_true_tempfile_enabled = 0
   file doesnotexist
 
   let maker1 = {
@@ -35,6 +41,7 @@ Execute (Error with non-existing filename for 2nd maker):
       \ }
   let maker2 = copy(maker1)
   let maker2.append_file = 1
+  let maker2.tempfile_enabled = 0
   let maker3 = copy(maker1)
 
   let fname = fnamemodify(bufname('%'), ':p')

--- a/tests/integration.vader
+++ b/tests/integration.vader
@@ -349,7 +349,7 @@ Execute (Neomake! for project maker via g:neomake_enabled_makers):
   let g:neomake_enabled_makers = ['mycargo']
   let g:neomake_mycargo_maker = {
   \ 'exe': 'echo',
-  \ 'args': ['mycargo']
+  \ 'args': ['mycargo'],
   \ }
   Neomake!
   NeomakeTestsWaitForFinishedJobs

--- a/tests/neomake.vader
+++ b/tests/neomake.vader
@@ -18,6 +18,7 @@ Include (Processing): processing.vader
 Include (Serialize): serialize.vader
 Include (Signs): signs.vader
 Include (Statusline): statusline.vader
+Include (Temporary files): tempfiles.vader
 Include (Utils): utils.vader
 Include (Verbosity): verbosity.vader
 
@@ -65,8 +66,9 @@ Execute (Neomake with unknown maker):
   runtime autoload/neomake/statusline.vim
 
   Neomake doesnotexist
+  let make_id = neomake#GetStatus().last_make_id
   AssertEqual g:neomake_test_messages, [
-  \ [0, 'Maker not found (for filetypes []): doesnotexist', {}],
+  \ [0, 'Maker not found (for filetypes []): doesnotexist', {'make_id': make_id}],
   \ [3, 'Nothing to make: no valid makers.', {}],
   \ ]
 

--- a/tests/processing.vader
+++ b/tests/processing.vader
@@ -188,6 +188,8 @@ Execute (Sleep in postprocess gets handled correctly):
 
 Execute (Pending output with restarted job when not in normal/insert mode (loclist)):
   if NeomakeAsyncTestsSetup()
+    let g:neomake_test_inc_maker_counter = 0
+
     file b1
     let first_jobs = neomake#Make(1, [g:neomake_test_inc_maker])
     let make_id = neomake#GetStatus().last_make_id
@@ -196,18 +198,24 @@ Execute (Pending output with restarted job when not in normal/insert mode (locli
     AssertNeomakeMessage 'Not processing output for mode V', 3
     exe "norm! \<Esc>"
     call neomake#Make(1, [g:neomake_test_inc_maker])
-    AssertNeomakeMessage 'Restarting already running job ('
+    AssertNeomakeMessageAbsent 'Restarting already running job ('
       \ .make_id.'.'.first_jobs[0].') for the same maker.', 2, {'make_id': make_id+1}
     NeomakeTestsWaitForFinishedJobs
-    AssertEqual map(copy(getloclist(0)), 'v:val.text'), []
+    AssertEqual map(copy(getloclist(0)), 'v:val.text'),
+    \ ['2:0: buf: b1', '2:1: buf: b1']
     doautocmd CursorHold
 
-    " TODO: should have output from 2nd job, should work on serialize branch.
-    AssertEqual map(copy(getloclist(0)), 'v:val.text'), []
+    " TODO: should not overwrite later job!
+    AssertEqual map(copy(getloclist(0)), 'v:val.text'),
+    \ ['1:0: buf: b1']
+
+    AssertEqual len(g:neomake_test_finished), 2
   endif
 
 Execute (Pending output with restarted job when not in normal/insert mode (quickfix)):
   if NeomakeAsyncTestsSetup()
+    let g:neomake_test_inc_maker_counter = 0
+
     file b1
     let first_jobs = neomake#Make(0, [g:neomake_test_inc_maker])
     let make_id = neomake#GetStatus().last_make_id
@@ -216,14 +224,18 @@ Execute (Pending output with restarted job when not in normal/insert mode (quick
     AssertNeomakeMessage 'Not processing output for mode V', 3
     exe "norm! \<Esc>"
     call neomake#Make(0, [g:neomake_test_inc_maker])
-    AssertNeomakeMessage 'Restarting already running job ('
+    AssertNeomakeMessageAbsent 'Restarting already running job ('
       \ .make_id.'.'.first_jobs[0].') for the same maker.', 2, {'make_id': make_id+1}
     NeomakeTestsWaitForFinishedJobs
-    AssertEqual map(copy(getqflist()), 'v:val.text'), []
+    AssertEqual map(copy(getqflist()), 'v:val.text'),
+    \ ['2:0: buf: b1', '2:1: buf: b1']
     doautocmd CursorHold
 
-    " TODO: should have output from 2nd job, should work on serialize branch.
-    AssertEqual map(copy(getqflist()), 'v:val.text'), []
+    " TODO: should not overwrite later job!
+    AssertEqual map(copy(getqflist()), 'v:val.text'),
+    \ ['1:0: buf: b1']
+
+    AssertEqual len(g:neomake_test_finished), 2
   endif
 
 Execute (100 lines of output should not get processed one by one):

--- a/tests/serialize.vader
+++ b/tests/serialize.vader
@@ -148,7 +148,6 @@ Execute (Neomake#Make handles cwd properly):
 
       " Create a new window/buffer, with a different working dir.
       new
-      let unreadable_bufnr = bufnr('%')
       file file2
       if !isdirectory('dir1')
         call mkdir('dir1', '', 0770)
@@ -187,11 +186,9 @@ Execute (Neomake#Make handles cwd properly):
       exe 'cd '.orig_cwd
     endtry
 
-    let temp_file = g:neomake_test_jobfinished[2].jobinfo.maker.tempfile_name
-    AssertNeomakeMessage printf('Using tempfile for unreadable buffer %d: %s',
-    \ unreadable_bufnr,  temp_file)
+    Assert !has_key(g:neomake_test_jobfinished[2].jobinfo.maker, 'tempfile_name'), 'No tempfile is used'
 
     AssertEqual g:neomake_test_exit_cb, [jobinfo1, {'status': 0, 'name': 'maker1', 'has_next': 0}]
     AssertEqual map(copy(getloclist(0)), 'v:val.text'),
-    \ ['maker_1 build: '.file1, 'maker_2 build: '.file1, 'maker_3 '.temp_file]
+    \ ['maker_1 build: '.file1, 'maker_2 build: '.file1, 'maker_3 '.file1]
   endif

--- a/tests/serialize.vader
+++ b/tests/serialize.vader
@@ -148,6 +148,7 @@ Execute (Neomake#Make handles cwd properly):
 
       " Create a new window/buffer, with a different working dir.
       new
+      let unreadable_bufnr = bufnr('%')
       file file2
       if !isdirectory('dir1')
         call mkdir('dir1', '', 0770)
@@ -178,6 +179,7 @@ Execute (Neomake#Make handles cwd properly):
       NeomakeTestsWaitForFinishedJobs
       " Trigger processing.
       wincmd p
+
       " Cleanup.
       wincmd p
       bd
@@ -185,7 +187,11 @@ Execute (Neomake#Make handles cwd properly):
       exe 'cd '.orig_cwd
     endtry
 
+    let temp_file = g:neomake_test_jobfinished[2].jobinfo.maker.tempfile_name
+    AssertNeomakeMessage printf('Using tempfile for unreadable buffer %d: %s',
+    \ unreadable_bufnr,  temp_file)
+
     AssertEqual g:neomake_test_exit_cb, [jobinfo1, {'status': 0, 'name': 'maker1', 'has_next': 0}]
     AssertEqual map(copy(getloclist(0)), 'v:val.text'),
-    \ ['maker_1 build: '.file1, 'maker_2 build: '.file1, 'maker_3 '.file1]
+    \ ['maker_1 build: '.file1, 'maker_2 build: '.file1, 'maker_3 '.temp_file]
   endif

--- a/tests/tempfiles.vader
+++ b/tests/tempfiles.vader
@@ -128,7 +128,7 @@ Execute (Maker can specify temporary file to use via fn):
   if neomake#has_async_support()
     AssertNeomakeMessage "Starting async job: ['true', '".g:neomake_test_tempfile."']"
   else
-    AssertNeomakeMessage "Starting: true '".g:neomake_test_tempfile."'"
+    AssertNeomakeMessage "Starting: true ".fnameescape(g:neomake_test_tempfile)
   endif
   bwipe
 
@@ -148,7 +148,12 @@ Execute (maker._get_argv uses jobinfo for bufnr):
 
   wincmd p
   let jobinfo = {'file_mode': 1, 'bufnr': bufnr}
-  AssertEqual maker._get_argv(jobinfo), ['my_maker', fnamemodify(bufname(bufnr), ':p')]
+  let expected = ['my_maker', fnameescape(fnamemodify(bufname(bufnr), ':p'))]
+  if neomake#has_async_support()
+    AssertEqual expected, maker._get_argv(jobinfo)
+  else
+    AssertEqual join(expected), maker._get_argv(jobinfo)
+  endif
 
   wincmd p
   bwipe

--- a/tests/tempfiles.vader
+++ b/tests/tempfiles.vader
@@ -131,3 +131,24 @@ Execute (Maker can specify temporary file to use via fn):
     AssertNeomakeMessage "Starting: true '".g:neomake_test_tempfile."'"
   endif
   bwipe
+
+Execute (maker._get_argv uses jobinfo for bufnr):
+  let maker = neomake#GetMaker({'name': 'my_maker', 'append_file': 1})
+
+  new
+  let bufnr = bufnr('%')
+  let jobinfo = {'file_mode': 1, 'bufnr': bufnr}
+  call maker._get_argv(jobinfo)
+  Assert !empty(maker.tempfile_name)
+
+  let maker = neomake#GetMaker({'name': 'my_maker', 'append_file': 1})
+  e! tests/fixtures/errors.py
+  call maker._get_argv(jobinfo)
+  Assert !has_key(maker, 'tempfile_name')
+
+  wincmd p
+  let jobinfo = {'file_mode': 1, 'bufnr': bufnr}
+  AssertEqual maker._get_argv(jobinfo), ['my_maker', fnamemodify(bufname(bufnr), ':p')]
+
+  wincmd p
+  bwipe

--- a/tests/tempfiles.vader
+++ b/tests/tempfiles.vader
@@ -1,0 +1,133 @@
+Include: include/setup.vader
+
+Execute (Neomake uses temporary file for unsaved buffer):
+  new
+  norm iline1
+  norm oline2
+
+  let maker = {
+  \ 'exe': 'cat',
+  \ 'append_file': 1,
+  \ 'errorformat': '%m',
+  \ 'tempfile_enabled': 1,
+  \ }
+  call neomake#Make(1, [maker])
+  if neomake#has_async_support()
+    let jobinfo = neomake#GetJobs()[0]
+
+    let temp_file = jobinfo.maker.tempfile_name
+    AssertEqual fnamemodify(temp_file, ':h:h'), fnamemodify(tempname(), ':h')
+    AssertEqual getfperm(temp_file), 'rw-r--r--'
+    NeomakeTestsWaitForFinishedJobs
+  endif
+
+  AssertEqual getloclist(0), [{
+  \ 'lnum': 0,
+  \ 'bufnr': bufnr('%'),
+  \ 'col': 0,
+  \ 'valid': 1,
+  \ 'vcol': 0,
+  \ 'nr': -1,
+  \ 'type': '',
+  \ 'pattern': '',
+  \ 'text': 'line1'},
+  \ {
+  \ 'lnum': 0,
+  \ 'bufnr': bufnr('%'),
+  \ 'col': 0,
+  \ 'valid': 1,
+  \ 'vcol': 0,
+  \ 'nr': -1,
+  \ 'type': '',
+  \ 'pattern': '',
+  \ 'text': 'line2'}]
+
+  if neomake#has_async_support()
+    AssertEqual filereadable(temp_file), 0, 'temp_file was removed'
+    AssertNeomakeMessage 'Removing temporary file: '.temp_file
+  else
+    AssertEqual len(filter(copy(g:neomake_test_messages), "v:val[1] =~# '^Removing temporary file:'")), 1, 'msg found'
+  endif
+
+  bwipe!
+
+Execute (Uses temporary file for unreadable buffer):
+  new
+  set ft=neomake_tests
+  let b:neomake_neomake_tests_enabled_makers = ['true']
+  let b:neomake_neomake_tests_true_tempfile_enabled = 1
+  file doesnotexist
+
+  let fname = fnamemodify(bufname('%'), ':p')
+  RunNeomake
+
+  let bufnr = bufnr('%')
+  AssertEqual len(filter(copy(g:neomake_test_messages),
+  \ "v:val[1] =~ '^Using tempfile for unreadable buffer '.bufnr")), 1, 'message found'
+
+  bd!
+
+Execute (2nd maker uses temporary file):
+  call g:NeomakeSetupAutocmdWrappers()
+
+  new
+  set ft=python
+  file doesnotexist
+
+  let maker1 = {
+      \ 'exe': 'true',
+      \ 'name': 'true_maker',
+      \ 'errorformat': '%m',
+      \ 'append_file': 0,
+      \ 'tempfile_enabled': 1,
+      \ }
+  let maker2 = copy(maker1)
+  let maker2.append_file = 1
+  let maker3 = copy(maker1)
+
+  let fname = fnamemodify(bufname('%'), ':p')
+  call neomake#Make(1, [maker1, maker2, maker3])
+  let make_id = neomake#GetStatus().last_make_id
+
+  let bufnr = bufnr('%')
+  AssertEqual len(filter(copy(g:neomake_test_messages),
+  \ "v:val[1] =~ '^Using tempfile for unreadable buffer '.bufnr")), 1, 'message not found'
+  NeomakeTestsWaitForFinishedJobs
+  AssertEqual len(g:neomake_test_finished), 1
+  AssertEqual len(g:neomake_test_jobfinished), 3
+  bd!
+
+Execute (Maker can specify temporary file to use via fn):
+  Save g:neomake_test_tempfile
+  let g:neomake_test_tempfile = tempname() . 'injected/with/subdir'
+
+  function! NeomakeTestsF(jobinfo) abort dict
+    let self.tempfile_name = g:neomake_test_tempfile
+  endfunction
+  let maker = {
+  \ 'exe': 'true',
+  \ 'fn': function('NeomakeTestsF'),
+  \ }
+
+  new
+  let bufnr = bufnr('%')
+  file unreadable
+  let maker = neomake#GetMaker(maker)
+  AssertEqual maker.args, []
+  let jobinfo = {'file_mode': 1, 'bufnr': bufnr}
+  call maker.fn(jobinfo)
+  AssertEqual maker.args, []
+  call maker._get_argv(jobinfo)
+  AssertEqual maker.args, []
+  AssertEqual maker.tempfile_name, g:neomake_test_tempfile
+  AssertNeomakeMessage 'Using tempfile for unreadable buffer '.bufnr.': '.g:neomake_test_tempfile
+
+  call neomake#Make(1, [maker])
+  AssertNeomakeMessage 'Using tempfile for unreadable buffer '.bufnr.': '.g:neomake_test_tempfile
+  NeomakeTestsWaitForFinishedJobs
+  if neomake#has_async_support()
+    AssertNeomakeMessage "Starting async job: ['true', '".g:neomake_test_tempfile."']"
+  else
+    AssertNeomakeMessage "Starting: true '".g:neomake_test_tempfile."'"
+  endif
+  bwipe

--- a/tests/utils.vader
+++ b/tests/utils.vader
@@ -253,7 +253,7 @@ Execute (neomake#utils#sort_by_col):
 Execute (neomake#utils#MakerFromCommand splits shell/shellcmdflag):
   Save &shell, &shellcmdflag
 
-  let jobinfo = {'file_mode': 0}
+  let jobinfo = {'file_mode': 0, 'bufnr': 0}
 
   let &shell = '/bin/bash -o pipefail'
   let &shellcmdflag = '-c'
@@ -264,7 +264,7 @@ Execute (neomake#utils#MakerFromCommand splits shell/shellcmdflag):
     let expected_argv = "/bin/bash -o pipefail -c 'echo 1'"
   endif
   let bound_maker = neomake#GetMaker(maker.fn(jobinfo))
-  AssertEqual bound_maker._get_argv(), expected_argv
+  AssertEqual bound_maker._get_argv(jobinfo), expected_argv
 
   let &shell = '/bin/bash'
   let &shellcmdflag = '-o pipefail -c'
@@ -275,21 +275,23 @@ Execute (neomake#utils#MakerFromCommand splits shell/shellcmdflag):
     let expected_argv = "/bin/bash -o pipefail -c 'echo 2'"
   endif
   let bound_maker = neomake#GetMaker(maker.fn(jobinfo))
-  AssertEqual bound_maker._get_argv(), expected_argv
+  AssertEqual bound_maker._get_argv(jobinfo), expected_argv
 
 Execute (neomake#utils#MakerFromCommand appends args for file_mode):
-  let maker = neomake#utils#MakerFromCommand('foo')
-  let jobinfo = {'file_mode': 0}
+  let maker = neomake#utils#MakerFromCommand('echo')
+  let jobinfo = {'file_mode': 0, 'bufnr': 0}
 
   AssertEqual maker.fn(jobinfo), {
-  \ 'args': [&shellcmdflag, 'foo'], 'exe': &shell, 'remove_invalid_entries': 0}
+  \ 'args': [&shellcmdflag, 'echo'], 'exe': &shell, 'remove_invalid_entries': 0}
 
-  file file\ with\ space
+  e! tests/fixtures/a\ filename\ with\ spaces
   let fname = expand('%:p')
   let jobinfo = {'maker': maker, 'file_mode': 1, 'bufnr': bufnr('%')}
-  AssertEqual maker.fn(jobinfo), {
-  \ 'args': [&shellcmdflag, 'foo '.fnameescape(fname)], 'append_file': 0,
-  \ 'exe': &shell, 'remove_invalid_entries': 0}
+  let bound_maker = neomake#GetMaker(maker).fn(jobinfo)
+  AssertEqual bound_maker.args, [&shellcmdflag, 'echo '.fname]
+  AssertEqual bound_maker.append_file, 0
+  AssertEqual bound_maker.exe, &shell
+  AssertEqual bound_maker.remove_invalid_entries, 0
 
 Execute (neomake#utils#Stringify):
   AssertEqual neomake#utils#Stringify(1), 1
@@ -349,3 +351,21 @@ Execute (neomake#utils#Stringify):
     AssertEqual neomake#utils#Stringify(obj.f2), "function('".(fnr_base + 1)."')"
   endif
   AssertEqual neomake#utils#Stringify(obj), "{f2: function('".(fnr_base + 1)."'), base: 1}"
+
+Execute (neomake#utils#MakerFromCommand uses tempfile):
+  let maker = neomake#utils#MakerFromCommand('echo')
+
+  new
+  let jobinfo = {'file_mode': 1, 'bufnr': bufnr('%')}
+  file dir/\ with\ spaces
+
+  set buftype=nofile
+  let bound_maker = neomake#GetMaker(maker).fn(jobinfo)
+  let temp_file = bound_maker.tempfile_name
+  AssertEqual bound_maker.args, [&shellcmdflag, 'echo '.temp_file]
+  AssertEqual bound_maker.append_file, 0
+  AssertEqual bound_maker.exe, &shell
+  AssertEqual bound_maker.remove_invalid_entries, 0
+  AssertNotEqual temp_file, fnameescape(temp_file)
+
+  bwipe


### PR DESCRIPTION
This includes unnamed and modified buffers, and helps with doing linting
on-the-fly (autolint).

It also enables support for linting of unreadable files (e.g. fugitive).

Ref: https://github.com/neomake/neomake/issues/190

Fixes https://github.com/neomake/neomake/issues/552.

Extracted out of https://github.com/neomake/neomake/pull/1055, to get this in first.

There was `neomake_make_modified` already (removed in #73 again (143725dc)).

I think we need a way to whitelist makers and/or configure how the temporary file gets created.
Some linters support an option like `--stdin`, which could be used in case of modified files.

There is a new setting `tempfile_enabled`, which defaults to 1 currently.
Makers that cannot handle temporary files should disable it.
`tempfile_name` can be used to specify a filename, which would allow to e.g. copy stuff somewhere to make the linter use it properly.

TODO:
 - [ ] change default to disabled, to get this merged, without causing too much trouble (#1092 is based on this).  (done in https://github.com/neomake/neomake/pull/1110).