### PR TITLE
Move restart check into s:MakeJob

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -97,7 +97,9 @@ function! neomake#CancelJob(job_id, ...) abort
             endtry
         else
             let vim_job = jobinfo.vim_job
-            if job_status(vim_job) !=# 'run'
+            " Use ch_status here, since job_status might be 'dead' already,
+            " without the exit handler being called yet.
+            if ch_status(vim_job) !=# 'open'
                 call neomake#utils#LoudMessage(
                             \ 'job_stop: job was not running anymore', jobinfo)
                 return 0

--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -141,7 +141,6 @@ function! s:MakeJob(make_id, options) abort
         \ 'name': 'neomake_'.job_id,
         \ 'bufnr': a:options.bufnr,
         \ 'file_mode': a:options.file_mode,
-        \ 'maker': maker,
         \ 'make_id': a:make_id,
         \ 'next': get(a:options, 'next', {}),
         \ }
@@ -149,9 +148,6 @@ function! s:MakeJob(make_id, options) abort
     " Call .fn function in maker object, if any.
     if has_key(maker, 'fn')
         " TODO: Allow to throw and/or return 0 to abort/skip?!
-        " Currently this needs to be copied here for the restart check (which
-        " compares the makers directly).
-        let maker = copy(maker)
         let returned_maker = call(maker.fn, [jobinfo], maker)
         if returned_maker isnot# 0
             " This conditional assignment allows to both return a copy
@@ -159,6 +155,33 @@ function! s:MakeJob(make_id, options) abort
             " is deepcopied usually here already though anyway (via
             " s:map_makers).
             let maker = returned_maker
+        endif
+    endif
+    lockvar maker
+    let jobinfo.maker = maker
+
+    " Check for already running job for the same maker (from other runs).
+    " This used to use this key: maker.name.',ft='.maker.ft.',buf='.maker.bufnr
+    if len(s:jobs)
+        let running_already = values(filter(copy(s:jobs),
+                    \ 'v:val.make_id != s:make_id && v:val.maker == maker'
+                    \ .' && v:val.bufnr == jobinfo.bufnr'
+                    \ ." && !get(v:val, 'restarting')"))
+        if len(running_already)
+            let jobinfo = running_already[0]
+            " let jobinfo.next = copy(options)
+            " TODO: required?! (
+            " let jobinfo.next.enabled_makers = [maker]
+            call neomake#utils#LoudMessage(printf(
+                        \ 'Restarting already running job (%d.%d) for the same maker.',
+                        \ jobinfo.make_id, jobinfo.id), {'make_id': s:make_id})
+            let jobinfo.restarting = s:make_id
+            if neomake#CancelJob(jobinfo.id)
+                return -2
+            endif
+            " Previous job was not running anymore, and we are not being
+            " restarted through its exit handler.
+            return s:MakeJob(a:make_id, a:options)
         endif
     endif
 
@@ -622,26 +645,6 @@ function! s:Make(options) abort
         endif
         " call neomake#utils#DebugMessage('Maker: '.string(enabled_makers), {'make_id': s:make_id})
 
-        " Check for already running job for the same maker (from other runs).
-        " This used to use this key: maker.name.',ft='.maker.ft.',buf='.maker.bufnr
-        if len(s:jobs)
-            let running_already = values(filter(copy(s:jobs),
-                        \ 'v:val.make_id != s:make_id && v:val.maker == maker'
-                        \ ." && v:val.bufnr == bufnr && !get(v:val, 'restarting')"))
-            if len(running_already)
-                let jobinfo = running_already[0]
-                " let jobinfo.next = copy(options)
-                " TODO: required?! (
-                " let jobinfo.next.enabled_makers = [maker]
-                call neomake#utils#LoudMessage(printf(
-                            \ 'Restarting already running job (%d.%d) for the same maker.',
-                            \ jobinfo.make_id, jobinfo.id), {'make_id': s:make_id})
-                let jobinfo.restarting = s:make_id
-                call neomake#CancelJob(jobinfo.id)
-                continue
-            endif
-        endif
-
         if neomake#has_async_support()
             let serialize = neomake#utils#GetSetting('serialize', maker, 0, [ft], bufnr)
         else
@@ -662,6 +665,8 @@ function! s:Make(options) abort
         let options.maker = maker
         try
             let job_id = s:MakeJob(s:make_id, options)
+        catch /^Neomake: restarting job/
+            continue
         catch /^Neomake: /
             let error = substitute(v:exception, '^Neomake: ', '', '')
             call neomake#utils#ErrorMessage(error, {'make_id': s:make_id})
@@ -673,7 +678,7 @@ function! s:Make(options) abort
             endif
             continue
         endtry
-        if job_id != -1
+        if job_id >= 0
             call add(job_ids, job_id)
         endif
         " If we are serializing makers, stop after the first one. The

--- a/tests/neomake.vader
+++ b/tests/neomake.vader
@@ -151,19 +151,13 @@ Execute (neomake#CancelJob):
 
 Execute (neomake#CancelJob with invalid job):
   if NeomakeAsyncTestsSetup()
-    let job_id = neomake#Sh("sh -c 'sleep 1'")
+    let job_id = neomake#Sh("sh -c 'sleep .1'")
     let jobinfo = neomake#GetJob(job_id)
     if has('nvim')
       call jobstop(job_id)
     else
       let vim_job = jobinfo.vim_job
-      call job_stop(vim_job)
-      " Wait for the job to be stopped really, but without sleep to not trigger
-      " the exit handler yet (which would remove the job).
-      let c = 1000
-      while c > 0 && job_status(vim_job) ==# 'run'
-        let c -= 1
-      endwhile
+      call ch_close(vim_job)
     endif
     let ret = neomake#CancelJob(job_id)
     Assert len(neomake#GetJobs()), 'There are jobs (1)'
@@ -177,16 +171,7 @@ Execute (neomake#CancelJob with invalid job):
     if has('nvim')
       AssertNeomakeMessage 'jobstop failed: Vim(call):E900: Invalid job id', 2, jobinfo
     else
-      try
-        AssertNeomakeMessage 'job_stop: job was not running anymore', 2, jobinfo
-      catch
-        " Happens at least on Vim 8.0.69.
-        if !has('patch-8.0.70')
-          throw v:exception.' (might be a flaky test)'
-        else
-          Log v:exception.' (ignoring potentially flaky test)'
-        endif
-      endtry
+      AssertNeomakeMessage 'job_stop: job was not running anymore', 2, jobinfo
     endif
     Assert len(neomake#GetJobs()), 'There are jobs'
 
@@ -198,8 +183,13 @@ Execute (neomake#CancelJob with invalid job):
     AssertNeomakeMessage 'Stopping job', 3, jobinfo
 
     AssertNeomakeMessageAbsent 'exit: job was canceled.', 3
-    NeomakeTestsWaitForNextMessage
-    AssertNeomakeMessage 'exit: job was canceled.', 3
+    if has('nvim')
+      " With Vim the exit callback is not invoked (since ch_close was used).
+      NeomakeTestsWaitForNextMessage
+      AssertNeomakeMessage 'exit: job was canceled.', 3
+    else
+      NeomakeCancelJobs!
+    endif
     let ret = neomake#CancelJob(job_id)
     AssertEqual ret, 0, "CancelJob (3) returned ".ret
     AssertNeomakeMessage 'CancelJob: job not found: '.job_id, 0


### PR DESCRIPTION
This also stores the maker from after the `maker.fn` on `jobinfo`.

Not sure about using an exception here (instead of a special return
value).

/cc @tweekmonster ^^