### PR TITLE
tests: call NeomakeCancelJobs! (and use keys therein)

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -109,8 +109,8 @@ function! neomake#CancelJob(job_id, ...) abort
 endfunction
 
 function! neomake#CancelJobs(bang) abort
-    for job in neomake#GetJobs()
-        call neomake#CancelJob(job.id, a:bang)
+    for job_id in keys(s:jobs)
+        call neomake#CancelJob(job_id, a:bang)
     endfor
 endfunction
 

--- a/tests/include/setup.vader
+++ b/tests/include/setup.vader
@@ -27,6 +27,7 @@ Before:
         for j in jobs
           Log "Remaining job: ".string(j)
         endfor
+        NeomakeCancelJobs!
         throw len(jobs).' jobs did not finish after 3s.'
       endif
       exe 'sleep' (max < 25 ? 100 : max < 35 ? 50 : 10).'m'


### PR DESCRIPTION
When accidentally modifying a s:jobs entry, and the key does not match
the entry's id property anymore, you should still be able to kill all
jobs.  This is mostly relevant for tests only.