### PR TITLE
Fix cargo

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -390,7 +390,8 @@ function! neomake#GetMaker(name_or_maker, ...) abort
                     catch /^Vim\%((\a\+)\)\=:E117/
                     endtry
                 endfor
-            else
+            endif
+            if !exists('maker')
                 try
                     let maker = eval('neomake#makers#'.a:name_or_maker.'#'.a:name_or_maker.'()')
                 catch /^Vim\%((\a\+)\)\=:E117/


### PR DESCRIPTION
Some change recently broke the cargo maker for me. I fully understand if this PR is not the proper solution. This works for me.

I got the following when running `:NeomakeInfo`:

```
#### Neomake debug information
Async support: 1
Current filetype: rust
##### Enabled makers
For the current filetype (with :Neomake): None.
NOTE: you can define g:neomake_rust_enabled_makers to configure it (or b:neomake_rust_enabled_makers).
For the project (with :Neomake!):
Error detected while processing function neomake#DisplayInfo[17]..<SNR>39_display_maker_info[1]..neomake#GetEnabledMakers[6]..n
eomake#GetMaker:
line   45:
E605: Exception not caught: Neomake: Maker not found: cargo
Error detected while processing function neomake#DisplayInfo[17]..<SNR>39_display_maker_info[1]..neomake#GetEnabledMakers:
line    6:
E171: Missing :endif
Press ENTER or type command to continue
```