### PR TITLE
Improve logging format

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ install:
         SKIP_BUILD_REASON="docker_vimhelplint: No changed doc files."
       fi
     elif [ "$ENV" = "testnvim" ]; then
-      eval "$(curl -Ss https://raw.githubusercontent.com/neovim/bot-ci/master/scripts/travis-setup.sh) nightly-x64"
+      eval "$(curl -Ss https://raw.githubusercontent.com/blueyed/bot-ci/fix-travis-setup.sh/scripts/travis-setup.sh) nightly-x64"
     fi
 
     if [ "${ENV#vint}" != "$ENV" ]; then

--- a/Makefile
+++ b/Makefile
@@ -49,10 +49,7 @@ testvim: _run_vim
 # 2. test case header in bold "(2/2)"
 # 3. Neomake's debug log messages in less intense grey
 # 4. non-Neomake log lines (e.g. from :Log) in bold/bright yellow.
-_SED_HIGHLIGHT_ERRORS:=| sed -e 's/^ \+([ [:digit:]]\+\/[[:digit:]]\+) \[[ [:alpha:]]\+\] (X).*/[31m[1m\0[0m/' \
-	-e 's/^ \+([ [:digit:]]\+\/[[:digit:]]\+)/[1m\0[0m/' \
-	-e 's/^ \+> \[\(debug\)\] \[[.[:digit:]]\+\]: .*/[38;5;8m\0[0m/' \
-	-e '/\[\(verb \|quiet\|error\)\]/! s/^ \+> .*/[33;1m\0[0m/'
+_SED_HIGHLIGHT_ERRORS:=| contrib/highlight-log vader
 # Need to close stdin to fix spurious 'sed: couldn't write X items to stdout: Resource temporarily unavailable'.
 # Redirect to stderr again for Docker (where only stderr is used from).
 _REDIR_STDOUT:=2>&1 </dev/null >/dev/null $(_SED_HIGHLIGHT_ERRORS) >&2

--- a/contrib/highlight-log
+++ b/contrib/highlight-log
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+# This script adds color highlighting to the output from Neomake's Vader tests
+# (when called with "vader"), or to the file that gets written into according
+# to `neomake_logfile`.
+#
+# You can use the following to watch colored logs in a terminal window, after
+# having used `let g:neomake_logfile = '/tmp/neomake.log'` in Neovim/Vim:
+#
+#     tail -f /tmp/neomake.log | /path/to/neomake/contrib/highlight-log
+
+# Use 256-color mode for dark grey.
+debug_color='[38;5;8m'
+
+if [ "$1" = vader ]; then
+  if [ -n "$CI" ]; then
+    # Travis does not seem to understand 256 color mode; use bright black.
+    debug_color='[30;1m'
+  fi
+
+  # Add coloring to Vader's output:
+  # 1. failures (includes pending) in red "(X)"
+  # 2. test case header in bold "(2/2)"
+  # 3. Neomake's debug log messages in less intense grey
+  # 4. non-Neomake log lines (e.g. from :Log) in bold/bright yellow.
+  sed -e 's/^ \+([ [:digit:]]\+\/[[:digit:]]\+) \[[ [:alpha:]]\+\] (X).*/[31m[1m\0[0m/' \
+      -e 's/^ \+([ [:digit:]]\+\/[[:digit:]]\+)/[1m\0[0m/' \
+      -e 's/^ \+> \[\(debug  \|D +[.[:digit:]]\+\)\]: .*/'"$debug_color"'\0[0m/' \
+      -e '/\[\(verbose\|warning\|error  \|\(\(V\|W\|\E\) +[.[:digit:]]\+\)\)\]/! s/^ \+> .*/[33;1m\0[0m/'
+else
+  # Output from neomake_logfile.
+  error='^[:[:digit:]]\+ \[E .*'
+  warn='^[:[:digit:]]\+ \[W .*'
+  debug='^[:[:digit:]]\+ \[D .*'
+  sed -e "s/$error/[31m[1m\0[0m/" \
+      -e "s/$warn/w:[33m\0[0m/" \
+      -e "s/$debug/$debug_color\\0[0m/"
+fi

--- a/tests/utils.vader
+++ b/tests/utils.vader
@@ -6,7 +6,12 @@ Execute (neomake#utils#LogMessage writes to logfile always):
   let g:neomake_logfile = tempname()
   call neomake#utils#LogMessage(1, 'msg1')
   let logfile_msg = readfile(g:neomake_logfile)[0]
-  Assert logfile_msg =~# '\v\[\d+-\d\d-\d\dT\d\d:\d\d:\d\d\+\d+ \@\d+\.\d\d\d, quiet\] msg1$'
+  Assert logfile_msg =~# '\v\d\d:\d\d:\d\d \[W      \] msg1$'
+
+  sleep 10m
+  call neomake#utils#LogMessage(1, 'msg2')
+  let logfile_msg = readfile(g:neomake_logfile)[-1]
+  Assert logfile_msg =~# '\v\d\d:\d\d:\d\d \[W \+0.0\d\] msg2$', 'Message does not match: '.logfile_msg
 
 Execute (NeomakeTestsEnsureExe creates exe):
   Assert !executable('boobar'), 'boobar is not executable'


### PR DESCRIPTION
It includes the relative time to the previous message now, but only if
greater than 0.01 seconds.

For `neomake_logfile`:

```
21:34:18 [V +42.9] Calling User autocmd NeomakeCountsChanged …
21:34:18 [D      ] [120] Running makers: vint
21:34:18 [V      ] [120] Starting async job: …
21:34:19 [D +1.19] [120.119] stdout: vint: …
21:34:19 [D +0.02] [120.119] exit: vint: 1
21:34:19 [D      ] [120.119] vint: processing 1 lines of output.
```

For tests:

```
    (2/9) [EXECUTE] Output is only processed in normal/insert mode (qflist)
      > [debug  ]: Skipping User autocmd NeomakeCountsChanged: no hooks.
      > [debug  ]: [2] Running makers: sleep_efm_maker
      > [verbose]: [2] Starting async job: …
      > [D +0.11]: [2.2] stdout: sleep_efm_maker: …
      > [debug  ]: [2.2] exit: sleep_efm_maker: 0
      > [debug  ]: Not processing output for mode V
      > [debug  ]: [2.2] sleep_efm_maker: completed with exit code 0.
      > [debug  ]: [2.2] Output left to be processed, not cleaning job yet.
```

Messages:

```
Neomake [     ]: [1] Running makers: vint
Neomake [     ]: [1] Starting async job: …
Neomake [+1.29]: [1.1] exit: vint: 0
Neomake [     ]: [1.1] vint: completed with exit code 0.
Neomake [     ]: [1.1] Cleaning jobinfo
Neomake [     ]: Skipping User autocmd NeomakeJobFinished: no hooks.
Neomake [     ]: File-level errors cleaned in buffer 1
Neomake [     ]: [1.1] Calling User autocmd NeomakeFinished …
Neomake [+11.0]: [2] Running makers: vint
```

I thought about resetting it for new runs (by storing it with
`make_info`, but that can be added later).

The coloring has been moved into a separate script
(contrib/highlight-log), and enhanced to work with the (new)
neomake_logfile format.

Also "quiet" has been renamed to "warning" in the public output.