### PR TITLE
Vim: split output on \r\n optionally

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -1063,7 +1063,7 @@ function! s:vim_output_handler(channel, output, event_type) abort
     let job_id = ch_info(a:channel)['id']
     let jobinfo = s:jobs[job_id]
 
-    let data = split(a:output, "\n", 1)
+    let data = split(a:output, '\v\r?\n', 1)
 
     if exists('jobinfo._vim_in_handler')
         call neomake#utils#DebugMessage(printf('Queueing: %s: %s: %s',

--- a/tests/processing.vader
+++ b/tests/processing.vader
@@ -225,3 +225,28 @@ Execute (Pending output with restarted job when not in normal/insert mode (quick
     " TODO: should have output from 2nd job, should work on serialize branch.
     AssertEqual map(copy(getqflist()), 'v:val.text'), []
   endif
+
+Execute (100 lines of output should not get processed one by one):
+  " This would be the case when using Vim's 'nl' mode.
+  call g:NeomakeSetupAutocmdWrappers()
+  let maker = NeomakeTestsCommandMaker('echo_100', 'i=100; while ((i--)); do echo $i; done')
+  let maker.buffer_output = 0
+  call neomake#Make(0, [maker])
+  NeomakeTestsWaitForFinishedJobs
+  let c = g:neomake_test_countschanged
+  Assert len(c) < 50, 'There were 50+ count changes: '.len(c)
+
+Execute (Mixed newlines get handled correctly):
+  if has('nvim')
+    NeomakeTestsSkip 'only for Vim/Windows'
+  else
+    let maker = {
+    \ 'exe': 'printf',
+    \ 'args': 'line1\\nline2\\r\\nline3',
+    \ 'errorformat': '%m',
+    \ }
+    call neomake#Make(0, [maker])
+    NeomakeTestsWaitForFinishedJobs
+    AssertEqual map(copy(getqflist()), 'v:val.text'),
+    \ ['line1', 'line2', 'line3']
+  endif


### PR DESCRIPTION
Fixes https://github.com/neomake/neomake/issues/1078.