### PR TITLE
python: python: move script into compile.py file

### DIFF
--- a/autoload/neomake/makers/ft/python.vim
+++ b/autoload/neomake/makers/ft/python.vim
@@ -1,5 +1,10 @@
 " vim: ts=4 sw=4 et
 
+if !exists('s:compile_script')
+    let s:slash = neomake#utils#Slash()
+    let s:compile_script = expand('<sfile>:p:h', 1).s:slash.'python'.s:slash.'compile.py'
+endif
+
 function! neomake#makers#ft#python#EnabledMakers() abort
     if exists('s:python_makers')
         return s:python_makers
@@ -227,17 +232,7 @@ endfunction
 
 function! neomake#makers#ft#python#python() abort
     return {
-        \ 'args': [ '-c',
-            \ "from __future__ import print_function\r" .
-            \ "from sys import argv, exit\r" .
-            \ "if len(argv) != 2:\r" .
-            \ "    exit(64)\r" .
-            \ "try:\r" .
-            \ "    compile(open(argv[1]).read(), argv[1], 'exec', 0, 1)\r" .
-            \ "except SyntaxError as err:\r" .
-            \ "    print('%s:%s:%s: %s' %% (err.filename, err.lineno, err.offset, err.msg))\r" .
-            \ '    exit(1)'
-        \ ],
+        \ 'args': [s:compile_script],
         \ 'errorformat': '%E%f:%l:%c: %m',
         \ 'serialize': 1,
         \ 'serialize_abort_on_error': 1,

--- a/autoload/neomake/makers/ft/python/compile.py
+++ b/autoload/neomake/makers/ft/python/compile.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+from sys import argv, exit
+
+
+if len(argv) != 2:
+    exit(64)
+
+try:
+    compile(open(argv[1]).read(), argv[1], 'exec', 0, 1)
+except SyntaxError as err:
+    print('%s:%s:%s: %s' % (err.filename, err.lineno, err.offset, err.msg))
+    exit(1)

--- a/autoload/neomake/utils.vim
+++ b/autoload/neomake/utils.vim
@@ -193,6 +193,11 @@ function! neomake#utils#DevNull() abort
     return '/dev/null'
 endfunction
 
+" Get directory separator
+function! neomake#utils#Slash() abort " {{{2
+    return (!exists('+shellslash') || &shellslash) ? '/' : '\'
+endfunction " }}}2
+
 function! neomake#utils#Exists(exe) abort
     " DEPRECATED: just use executable() directly.
     return executable(a:exe)


### PR DESCRIPTION
This makes it less verbose in the logs, and less fragile with regard to
having "newlines" in the args.