### PR TITLE
Fix argument quoting for Vim on Windows

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -1540,9 +1540,8 @@ function! neomake#DisplayInfo() abort
         unlet! V  " Fix variable type mismatch with Vim 7.3.
     endfor
     echo "\n"
-    echo 'shell:' &shell
-    echo 'shellcmdflag:' &shellcmdflag
     echo 'Windows: '.neomake#utils#IsRunningWindows()
+    echo '[shell, shellcmdflag, shellslash]:' [&shell, &shellcmdflag, &shellslash]
     echo '```'
     if &verbose
         echo "\n"

--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -348,31 +348,35 @@ function! s:maker_base._get_argv(...) abort dict
         endif
     endif
 
-    if neomake#has_async_support()
+    if has('nvim')
         if args_is_list
             let argv = [exe] + args
         else
             let argv = exe . (len(args) ? ' ' . args : '')
         endif
-        if !has('nvim')
-            if !args_is_list
-                " Have to use a shell to handle argv properly (Vim splits it
-                " at spaces).
-                let argv = [&shell, &shellcmdflag, argv]
+    elseif neomake#has_async_support()
+        " Vim jobs, need special treatment on Windows..
+        if neomake#utils#IsRunningWindows()
+            " Windows needs a subshell to handle PATH/%PATHEXT% etc.
+            if args_is_list
+                let argv = join(map(copy([exe] + args), 'neomake#utils#shellescape(v:val)'))
+            else
+                let argv = exe.' '.args
             endif
+            let argv = &shell.' '.&shellcmdflag.' '.argv
+
+        elseif !args_is_list
+            " Use a shell to handle argv properly (Vim splits at spaces).
+            let argv = [&shell, &shellcmdflag, exe.' '.args]
+        else
+            let argv = [exe] + args
         endif
     else
-        let argv = exe
-        if len(args)
-            if args_is_list
-                if neomake#utils#IsRunningWindows()
-                    let argv .= ' '.join(args)
-                else
-                    let argv .= ' '.join(map(args, 'shellescape(v:val)'))
-                endif
-            else
-                let argv .= ' '.args
-            endif
+        " Vim-async, via system().
+        if args_is_list
+            let argv = join(map(copy([exe] + args), 'neomake#utils#shellescape(v:val)'))
+        else
+            let argv = exe.' '.args
         endif
     endif
     return argv

--- a/autoload/neomake/utils.vim
+++ b/autoload/neomake/utils.vim
@@ -468,3 +468,18 @@ endfunction
 function! neomake#utils#JSONdecode(json) abort
     return neomake#compat#json_decode(a:json)
 endfunction
+
+" Smarter shellescape, via vim-fugitive.
+function! s:gsub(str,pat,rep) abort
+  return substitute(a:str,'\v\C'.a:pat,a:rep,'g')
+endfunction
+
+function! neomake#utils#shellescape(arg) abort
+  if a:arg =~# '^[A-Za-z0-9_/.-]\+$'
+    return a:arg
+  elseif &shell =~? 'cmd' || exists('+shellslash') && !&shellslash
+    return '"'.s:gsub(s:gsub(a:arg, '"', '""'), '\%', '"%"').'"'
+  else
+    return shellescape(a:arg)
+  endif
+endfunction

--- a/tests/args.vader
+++ b/tests/args.vader
@@ -1,6 +1,6 @@
 Include: include/setup.vader
 
-Execute (maker.args as string gets not escaped):
+Execute (maker.args as list gets escaped):
   let maker = {
         \ 'exe': '/usr/bin/printf',
         \ 'args': ['%s\n', '1', '2', '3a 3b'],
@@ -17,7 +17,18 @@ Execute (maker.args as string gets not escaped):
   AssertEqual map(copy(getloclist(0)), 'v:val.text'),
     \ ['1', '2', '3a 3b', fname_abs]
 
-  let maker.args = "'%s\\n' 1 2 '3a 3b' 4"
+Execute (maker.args as string gets not escaped):
+  let maker = {
+        \ 'exe': '/usr/bin/printf',
+        \ 'args': "'%s\\n' 1 2 '3a 3b' 4",
+        \ 'errorformat': '%f: %m',
+        \ 'mapexpr': 'expand("%:p") . ": " . v:val',
+        \ }
+
+  let fname = 'tests/fixtures/a filename with spaces'
+  e! tests/fixtures/a\ filename\ with\ spaces
+  let fname_abs = expand('%:p')
+
   call neomake#Make(1, [maker])
   NeomakeTestsWaitForFinishedJobs
   AssertEqual map(copy(getloclist(0)), 'v:val.text'),

--- a/tests/neomake.vader
+++ b/tests/neomake.vader
@@ -300,5 +300,5 @@ Execute (Neomake picks up custom maker correctly):
     AssertNeomakeMessage "Starting async job: ['echo', '".fname."', '--foo', 'bar']"
     NeomakeTestsWaitForFinishedJobs
   else
-    AssertNeomakeMessage "Starting: echo '".fname."' '--foo' 'bar'"
+    AssertNeomakeMessage "Starting: echo ".fname." --foo bar"
   endif

--- a/tests/utils.vader
+++ b/tests/utils.vader
@@ -254,7 +254,7 @@ Execute (neomake#utils#MakerFromCommand splits shell/shellcmdflag):
   if neomake#has_async_support()
     let expected_argv = ['/bin/bash', '-o', 'pipefail', '-c', 'echo 1']
   else
-    let expected_argv = "/bin/bash '-o' 'pipefail' '-c' 'echo 1'"
+    let expected_argv = "/bin/bash -o pipefail -c 'echo 1'"
   endif
   let bound_maker = neomake#GetMaker(maker.fn(jobinfo))
   AssertEqual bound_maker._get_argv(), expected_argv
@@ -265,7 +265,7 @@ Execute (neomake#utils#MakerFromCommand splits shell/shellcmdflag):
   if neomake#has_async_support()
     let expected_argv = ['/bin/bash', '-o', 'pipefail', '-c', 'echo 2']
   else
-    let expected_argv = "/bin/bash '-o' 'pipefail' '-c' 'echo 2'"
+    let expected_argv = "/bin/bash -o pipefail -c 'echo 2'"
   endif
   let bound_maker = neomake#GetMaker(maker.fn(jobinfo))
   AssertEqual bound_maker._get_argv(), expected_argv

--- a/tests/verbosity.vader
+++ b/tests/verbosity.vader
@@ -71,7 +71,7 @@ Execute (neomake#Make uses &verbose):
     \ [[2, "Starting async job: ['echo', '1']", {'make_id': make_id}]]
   else
     AssertEqual g:neomake_test_messages,
-    \ [[2, "Starting: echo '1'", {'make_id': make_id}]]
+    \ [[2, "Starting: echo 1", {'make_id': make_id}]]
   endif
   AssertEqual len(g:neomake_test_messages), 1
 


### PR DESCRIPTION
This reverts db461be and fixes #959 by using `fnameescape` on each argument.

Fixes #959.
Fixes #992.