### PR TITLE
Improve managing active jobs, and restart them directly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,5 +64,6 @@ script:
       if [[ "$ENV" = "testvim" ]]; then
         vim --version
       fi
+      umask 022
       make $ENV $MAKE_ARGS
     fi

--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -147,18 +147,6 @@ function! s:MakeJob(make_id, options) abort
         \ 'next': get(a:options, 'next', {}),
         \ }
 
-    " Call .fn function in maker object, if any.
-    if has_key(maker, 'fn')
-        " TODO: Allow to throw and/or return 0 to abort/skip?!
-        let returned_maker = call(maker.fn, [jobinfo], maker)
-        if returned_maker isnot# 0
-            " This conditional assignment allows to both return a copy
-            " (factory), while also can be used as a init method.  The maker
-            " is deepcopied usually here already though anyway (via
-            " s:map_makers).
-            let maker = returned_maker
-        endif
-    endif
     let jobinfo.maker = maker
 
     " Check for already running job for the same maker (from other runs).
@@ -223,7 +211,7 @@ function! s:MakeJob(make_id, options) abort
 
     try
         let error = ''
-        let argv = maker._get_argv(jobinfo.file_mode ? jobinfo.bufnr : 0)
+        let argv = maker._get_argv(jobinfo)
         " Lock maker to make sure it does not get changed accidentally, but
         " only with depth=1, so that a postprocess object can change itself.
         lockvar 1 maker
@@ -309,17 +297,76 @@ function! s:MakeJob(make_id, options) abort
 endfunction
 
 let s:maker_base = {}
-function! s:maker_base._get_argv(...) abort dict
-    let bufnr = a:0 ? a:1 : 0
-
-    " Resolve exe/args, which might be a function or dictionary.
-    if type(self.exe) == type(function('tr'))
-        let exe = call(self.exe, [])
-    elseif type(self.exe) == type({})
-        let exe = call(self.exe.fn, [], self.exe)
-    else
-        let exe = self.exe
+function! s:maker_base._get_tempfilename(bufnr) abort dict
+    if has_key(self, 'tempfile_name')
+        return self.tempfile_name
     endif
+
+    let fts = has_key(self, 'ft') ? [self.ft] : []
+    let tempfile_enabled = neomake#utils#GetSetting('tempfile_enabled', self, 1, fts, a:bufnr)
+    if !tempfile_enabled
+        return ''
+    endif
+
+    let bufname = bufname(a:bufnr)
+    if len(bufname)
+        let bufname = fnamemodify(bufname, ':t')
+    else
+        let bufname = 'neomake_tmp.' . join(fts, '.')
+    endif
+
+    return tempname() . (has('win32') ? '\' : '/') . bufname
+endfunction
+
+" Check if a temporary file is used, and set self.tempfile_name in case it is.
+function! s:maker_base._get_fname_for_buffer(bufnr) abort
+    let bufname = bufname(a:bufnr)
+    if !len(bufname)
+        let temp_file = self._get_tempfilename(a:bufnr)
+        if !empty(temp_file)
+            call neomake#utils#DebugMessage(printf(
+                        \ 'Using tempfile for unnamed buffer %s: %s', a:bufnr, temp_file))
+        else
+            throw 'Neomake: no file name'
+        endif
+
+    elseif getbufvar(a:bufnr, '&modified')
+        let temp_file = self._get_tempfilename(a:bufnr)
+        if !empty(temp_file)
+            call neomake#utils#DebugMessage(printf(
+                        \ 'Using tempfile for modified buffer %s: %s', a:bufnr, temp_file))
+        else
+            call neomake#utils#DebugMessage(printf(
+                        \ 'warning: buffer is modified: %s', a:bufnr))
+        endif
+
+    elseif !filereadable(bufname)
+        let temp_file = self._get_tempfilename(a:bufnr)
+        if !empty(temp_file)
+            call neomake#utils#DebugMessage(printf(
+                        \ 'Using tempfile for unreadable buffer %s: %s', a:bufnr, temp_file))
+        else
+            throw 'Neomake: file is not readable ('.fnamemodify(bufname, ':p').')'
+        endif
+    else
+        let bufname = fnamemodify(bufname, ':p')
+    endif
+
+    if exists('temp_file')
+        let temp_dir = fnamemodify(temp_file, ':h')
+        if !isdirectory(temp_dir)
+            call mkdir(temp_dir, 'p', 0750)
+        endif
+        call writefile(getbufline(a:bufnr, 1, '$'), temp_file)
+
+        let bufname = temp_file
+        let self.tempfile_name = temp_file
+    endif
+    return bufname
+endfunction
+
+function! s:maker_base._bind_args() abort dict
+    " Resolve args, which might be a function or dictionary.
     if type(self.args) == type(function('tr'))
         let args = call(self.args, [])
     elseif type(self.args) == type({})
@@ -328,23 +375,32 @@ function! s:maker_base._get_argv(...) abort dict
         let args = copy(self.args)
     endif
     let args_is_list = type(args) == type([])
-
     if args_is_list
         call neomake#utils#ExpandArgs(args)
     endif
-    if bufnr && neomake#utils#GetSetting('append_file', self, 1, [self.ft], bufnr)
-        let bufname = bufname(bufnr)
-        if !len(bufname)
-            throw 'Neomake: no file name'
-        endif
-        let bufname = fnamemodify(bufname, ':p')
-        if !filereadable(bufname)
-            throw 'Neomake: file is not readable ('.bufname.')'
-        endif
+    let self.args = args
+endfunction
+
+function! s:maker_base._get_argv(jobinfo) abort dict
+    " Resolve exe, which might be a function or dictionary.
+    if type(self.exe) == type(function('tr'))
+        let exe = call(self.exe, [])
+    elseif type(self.exe) == type({})
+        let exe = call(self.exe.fn, [], self.exe)
+    else
+        let exe = self.exe
+    endif
+
+    let args = copy(self.args)
+    let args_is_list = type(args) == type([])
+
+    let fts = has_key(self, 'ft') ? [self.ft] : []
+    if a:jobinfo.file_mode && neomake#utils#GetSetting('append_file', self, 1, fts, a:jobinfo.bufnr)
+        let filename = self._get_fname_for_buffer(a:jobinfo.bufnr)
         if args_is_list
-            call add(args, bufname)
+            call add(args, filename)
         else
-            let args .= ' '.fnameescape(bufname)
+            let args .= ' '.fnameescape(filename)
         endif
     endif
 
@@ -659,16 +715,20 @@ function! s:Make(options) abort
         endif
 
         call s:AddMakeInfoForCurrentWin(s:make_id)
-    endif
 
-    let args = [options.enabled_makers]
-    if file_mode
-        let args += [&filetype]
-    endif
-    let enabled_makers = call('s:map_makers', args)
-    if !len(enabled_makers)
-        call neomake#utils#DebugMessage('Nothing to make: no valid makers.')
-        return []
+        " Instantiate all makers in the beginning (so expand() gets used in
+        " the current buffer's context).
+        let args = [options]
+        if file_mode
+            let args += [&filetype]
+        endif
+        let enabled_makers = call('s:map_makers', args)
+        if !len(enabled_makers)
+            call neomake#utils#DebugMessage('Nothing to make: no valid makers.')
+            return []
+        endif
+    else
+        let enabled_makers = get(options, 'enabled_makers', [])
     endif
 
     let maker_info = join(map(copy(enabled_makers),
@@ -683,6 +743,8 @@ function! s:Make(options) abort
             continue
         endif
         if has_key(a:options, 'exit_callback')
+            " FIXME: remove/refactor exit_callback with NeomakeFinished.
+            "        (https://github.com/neomake/neomake/issues/1074)
             let maker.exit_callback = a:options.exit_callback
         endif
         " call neomake#utils#DebugMessage('Maker: '.string(enabled_makers), {'make_id': s:make_id})
@@ -760,6 +822,9 @@ function! s:AddExprCallback(jobinfo, prev_index) abort
         let index += 1
 
         let before = copy(entry)
+        if file_mode && has_key(a:jobinfo.maker, 'tempfile_name')
+            let entry.bufnr = a:jobinfo.bufnr
+        endif
         if !empty(s:postprocessors)
             let g:neomake_hook_context = {'jobinfo': a:jobinfo}
             for s:f in s:postprocessors
@@ -868,6 +933,18 @@ function! s:CleanJobinfo(jobinfo) abort
         endif
         if has_key(s:project_job_output, a:jobinfo.id)
             unlet s:project_job_output[a:jobinfo.id]
+        endif
+    endif
+
+    let temp_file = get(a:jobinfo.maker, 'tempfile_name', '')
+    if !empty(temp_file)
+        call neomake#utils#DebugMessage(printf('Removing temporary file: %s',
+                    \ temp_file))
+        call delete(temp_file)
+        " XXX: old Vim has no support for flags.. the patch version is not
+        " exact here!
+        if v:version >= 705 || (v:version == 704 && has('patch1689'))
+            call delete(fnamemodify(temp_file, ':h'), 'd')
         endif
     endif
 
@@ -1452,17 +1529,32 @@ function! neomake#CompleteJobs(...) abort
     return join(map(neomake#GetJobs(), "v:val.id.': '.v:val.maker.name"), "\n")
 endfunction
 
-function! s:map_makers(makers, ...) abort
+function! s:map_makers(jobinfo, ...) abort
     let r = []
-    for maker in a:makers
+    for maker_or_name in a:jobinfo.enabled_makers
         try
-            let m = call('neomake#GetMaker', [maker] + a:000)
+            let maker = call('neomake#GetMaker', [maker_or_name] + a:000)
+            call maker._bind_args()
+
+            " Call .fn function in maker object, if any.
+            if has_key(maker, 'fn')
+                " TODO: Allow to throw and/or return 0 to abort/skip?!
+                let returned_maker = call(maker.fn, [a:jobinfo], maker)
+                if returned_maker isnot# 0
+                    " This conditional assignment allows to both return a copy
+                    " (factory), while also can be used as a init method.  The maker
+                    " is deepcopied usually here already though anyway (via
+                    " s:map_makers).
+                    let maker = returned_maker
+                endif
+            endif
+
         catch /^Neomake: /
             let error = substitute(v:exception, '^Neomake: ', '', '')
-            call neomake#utils#ErrorMessage(error)
+            call neomake#utils#ErrorMessage(error, {'make_id': s:make_id})
             continue
         endtry
-        let r += [m]
+        let r += [maker]
     endfor
     return r
 endfunction

--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -53,6 +53,7 @@ endfunction
 function! neomake#GetStatus() abort
     return {
                 \ 'last_make_id': s:make_id,
+                \ 'make_info': s:make_info,
                 \ }
 endfunction
 
@@ -76,24 +77,21 @@ function! neomake#CancelJob(job_id, ...) abort
         call neomake#utils#ErrorMessage('CancelJob: job not found: '.job_id)
         return 0
     endif
+    let ret = 0
     let jobinfo = s:jobs[job_id]
     if get(jobinfo, 'finished')
-        call neomake#utils#DebugMessage('Removing already finished job: '.job_id)
-        call s:CleanJobinfo(jobinfo)
+        call neomake#utils#DebugMessage('Removing already finished job', jobinfo)
     else
-        if remove_always
-            unlet s:jobs[job_id]
-        endif
         " Mark it as canceled for the exit handler.
         let jobinfo.canceled = 1
         call neomake#utils#DebugMessage('Stopping job', jobinfo)
         if has('nvim')
             try
                 call jobstop(job_id)
+                let ret = 1
             catch /^Vim\%((\a\+)\)\=:\(E474\|E900\):/
                 call neomake#utils#LoudMessage(printf(
                             \ 'jobstop failed: %s', v:exception), jobinfo)
-                return 0
             endtry
         else
             let vim_job = jobinfo.vim_job
@@ -102,12 +100,16 @@ function! neomake#CancelJob(job_id, ...) abort
             if ch_status(vim_job) !=# 'open'
                 call neomake#utils#LoudMessage(
                             \ 'job_stop: job was not running anymore', jobinfo)
-                return 0
+            else
+                call job_stop(vim_job)
+                let ret = 1
             endif
-            call job_stop(vim_job)
         endif
     endif
-    return 1
+    if ret == 0 || remove_always
+        call s:CleanJobinfo(jobinfo)
+    endif
+    return ret
 endfunction
 
 function! neomake#CancelJobs(bang) abort
@@ -138,16 +140,21 @@ endfunction
 function! s:MakeJob(make_id, options) abort
     let job_id = s:job_id
     let s:job_id += 1
-    let maker = a:options.maker
-    let jobinfo = {
+
+    " Optional:
+    "  - serialize (default: 0)
+    "  - serialize_abort_on_error (default: 0)
+    "  - exit_callback (string/function, default: 0)
+    let jobinfo = extend({
         \ 'name': 'neomake_'.job_id,
+        \ 'maker': a:options.maker,
         \ 'bufnr': a:options.bufnr,
         \ 'file_mode': a:options.file_mode,
+        \ 'fts': a:options.fts,
         \ 'make_id': a:make_id,
-        \ 'next': get(a:options, 'next', {}),
-        \ }
+        \ }, a:options)
 
-    let jobinfo.maker = maker
+    let maker = jobinfo.maker
 
     " Check for already running job for the same maker (from other runs).
     " This used to use this key: maker.name.',ft='.maker.ft.',buf='.maker.bufnr
@@ -165,12 +172,9 @@ function! s:MakeJob(make_id, options) abort
                         \ 'Restarting already running job (%d.%d) for the same maker.',
                         \ jobinfo.make_id, jobinfo.id), {'make_id': s:make_id})
             let jobinfo.restarting = s:make_id
-            if neomake#CancelJob(jobinfo.id)
-                return -2
-            endif
-            " Previous job was not running anymore, and we are not being
-            " restarted through its exit handler.
-            return s:MakeJob(a:make_id, a:options)
+
+            call neomake#CancelJob(jobinfo.id)
+            return s:MakeJob(s:make_id, a:options)
         endif
     endif
 
@@ -189,7 +193,7 @@ function! s:MakeJob(make_id, options) abort
         " XXX: mark it as to be skipped earlier?!
         call neomake#utils#DebugMessage(printf(
                     \ 'Exe (%s) of auto-configured maker %s is not executable, skipping.', maker.exe, maker.name))
-        return -1
+        return {}
     endif
 
     let cwd = get(maker, 'cwd', s:make_info[a:make_id].cwd)
@@ -205,7 +209,7 @@ function! s:MakeJob(make_id, options) abort
             call neomake#utils#ErrorMessage(
                         \ maker.name.": could not change to maker's cwd (".cwd.'): '
                         \ .v:exception, jobinfo)
-            return -1
+            return {}
         endtry
     endif
 
@@ -272,28 +276,28 @@ function! s:MakeJob(make_id, options) abort
 
             " Bail out on errors.
             if len(error)
+                let jobinfo.failed_to_start = 1
                 call neomake#utils#ErrorMessage(error, jobinfo)
-                call s:handle_next_makers(jobinfo, 122)
-                return -1
+                return s:handle_next_maker(jobinfo)
             endif
-
-            let r = jobinfo.id
         else
             call neomake#utils#DebugMessage('Running synchronously')
             call neomake#utils#LoudMessage('Starting: '.argv, jobinfo)
 
             let jobinfo.id = job_id
             let s:jobs[job_id] = jobinfo
+            let s:make_info[s:make_id].active_jobs[jobinfo.id] = jobinfo
             call s:output_handler(job_id, split(system(argv), '\r\?\n', 1), 'stdout')
             call s:exit_handler(job_id, v:shell_error, 'exit')
-            let r = -1
+            return {}
         endif
     finally
         if exists('cd') && exists('old_wd')
             exe cd fnameescape(old_wd)
         endif
     endtry
-    return r
+    let s:make_info[s:make_id].active_jobs[jobinfo.id] = jobinfo
+    return jobinfo
 endfunction
 
 let s:maker_base = {}
@@ -302,8 +306,7 @@ function! s:maker_base._get_tempfilename(bufnr) abort dict
         return self.tempfile_name
     endif
 
-    let fts = has_key(self, 'ft') ? [self.ft] : []
-    let tempfile_enabled = neomake#utils#GetSetting('tempfile_enabled', self, 1, fts, a:bufnr)
+    let tempfile_enabled = neomake#utils#GetSetting('tempfile_enabled', self, 1, self.fts, a:bufnr)
     if !tempfile_enabled
         return ''
     endif
@@ -312,7 +315,7 @@ function! s:maker_base._get_tempfilename(bufnr) abort dict
     if len(bufname)
         let bufname = fnamemodify(bufname, ':t')
     else
-        let bufname = 'neomake_tmp.' . join(fts, '.')
+        let bufname = 'neomake_tmp.' . join(self.fts, '.')
     endif
 
     return tempname() . (has('win32') ? '\' : '/') . bufname
@@ -394,8 +397,7 @@ function! s:maker_base._get_argv(jobinfo) abort dict
     let args = copy(self.args)
     let args_is_list = type(args) == type([])
 
-    let fts = has_key(self, 'ft') ? [self.ft] : []
-    if a:jobinfo.file_mode && neomake#utils#GetSetting('append_file', self, 1, fts, a:jobinfo.bufnr)
+    if a:jobinfo.file_mode && neomake#utils#GetSetting('append_file', self, 1, self.fts, a:jobinfo.bufnr)
         let filename = self._get_fname_for_buffer(a:jobinfo.bufnr)
         if args_is_list
             call add(args, filename)
@@ -441,8 +443,7 @@ endfunction
 function! neomake#GetMaker(name_or_maker, ...) abort
     if a:0
         let file_mode = 1
-        let real_ft = a:1
-        let fts = neomake#utils#GetSortedFiletypes(real_ft)
+        let fts = neomake#utils#GetSortedFiletypes(a:1)
     else
         let file_mode = 0
         let fts = []
@@ -508,16 +509,13 @@ function! neomake#GetMaker(name_or_maker, ...) abort
         \ 'exe': maker.name,
         \ 'args': [],
         \ 'errorformat': &errorformat,
+        \ 'fts': fts,
         \ })
     let bufnr = bufnr('%')
     for [key, default] in items(defaults)
         let maker[key] = neomake#utils#GetSetting(key, maker, default, fts, bufnr)
         unlet! default  " workaround for old Vim (7.3.429)
     endfor
-
-    if exists('real_ft')
-        let maker.ft = real_ft
-    endif
     return maker
 endfunction
 
@@ -671,126 +669,94 @@ function! s:Make(options) abort
     call extend(options, {
                 \ 'file_mode': 0,
                 \ 'bufnr': bufnr('%'),
-                \ 'ft': '',
+                \ 'fts': [],
                 \ }, 'keep')
     let bufnr = options.bufnr
     let file_mode = options.file_mode
-    let ft = options.ft
 
-    " Reset/clear on first run, but not when using 'serialize'.
-    if !get(options, 'continuation', 0)
-        let s:make_id += 1
-        let s:make_info[s:make_id] = {
-                    \ 'cwd': getcwd(),
-                    \ 'verbosity': get(g:, 'neomake_verbose', 1),
-                    \ }
-        if &verbose
-            let s:make_info[s:make_id].verbosity += &verbose
-            call neomake#utils#DebugMessage(printf(
-                        \ 'Adding &verbose (%d) to verbosity level: %d',
-                        \ &verbose, s:make_info[s:make_id].verbosity),
-                        \ {'make_id': s:make_id})
-        endif
-
-        if !has_key(options, 'enabled_makers')
-            let makers = call('neomake#GetEnabledMakers', file_mode ? [ft] : [])
-            if !len(makers)
-                if file_mode
-                    call neomake#utils#DebugMessage('Nothing to make: no enabled file mode makers.', {'make_id': s:make_id})
-                    return []
-                else
-                    let makers = ['makeprg']
-                endif
-            endif
-            let options.enabled_makers = makers
-        endif
-
-        if file_mode
-            " XXX: this clears counts for job's buffer only, but we
-            "      add counts for the entry's buffers, which might be
-            "      different!
-            call neomake#statusline#ResetCountsForBuf(bufnr)
-        else
-            call neomake#statusline#ResetCountsForProject()
-        endif
-
-        call s:AddMakeInfoForCurrentWin(s:make_id)
-
-        " Instantiate all makers in the beginning (so expand() gets used in
-        " the current buffer's context).
-        let args = [options]
-        if file_mode
-            let args += [&filetype]
-        endif
-        let enabled_makers = call('s:map_makers', args)
-        if !len(enabled_makers)
-            call neomake#utils#DebugMessage('Nothing to make: no valid makers.')
-            return []
-        endif
-    else
-        let enabled_makers = get(options, 'enabled_makers', [])
+    let s:make_id += 1
+    let make_id = s:make_id
+    let s:make_info[make_id] = {
+                \ 'cwd': getcwd(),
+                \ 'verbosity': get(g:, 'neomake_verbose', 1),
+                \ 'active_jobs': {},
+                \ 'finished_jobs': [],
+                \ 'options': options,
+                \ }
+    if &verbose
+        let s:make_info[s:make_id].verbosity += &verbose
+        call neomake#utils#DebugMessage(printf(
+                    \ 'Adding &verbose (%d) to verbosity level: %d',
+                    \ &verbose, s:make_info[s:make_id].verbosity),
+                    \ {'make_id': s:make_id})
     endif
 
-    let maker_info = join(map(copy(enabled_makers),
+    if has_key(options, 'enabled_makers')
+        let makers = options.enabled_makers
+        unlet options.enabled_makers
+    else
+        let makers = call('neomake#GetEnabledMakers', file_mode ? options.fts : [])
+        if !len(makers)
+            if file_mode
+                call neomake#utils#DebugMessage('Nothing to make: no enabled file mode makers.', {'make_id': make_id})
+                unlet s:make_info[make_id]
+                return []
+            else
+                let makers = ['makeprg']
+            endif
+        endif
+    endif
+
+    " Instantiate all makers in the beginning (so expand() gets used in
+    " the current buffer's context).
+    let args = [options, makers]
+    if file_mode
+        let args += [options.fts]
+    endif
+    let makers = call('s:map_makers', args)
+    if !len(makers)
+        call neomake#utils#DebugMessage('Nothing to make: no valid makers.')
+        unlet s:make_info[make_id]
+        return []
+    endif
+
+    let maker_info = join(map(copy(makers),
                 \ "v:val.name . (get(v:val, 'auto_enabled', 0) ? ' (auto)' : '')"), ', ')
     call neomake#utils#DebugMessage(printf('Running makers: %s', maker_info),
-                \ {'make_id': s:make_id})
+                \ {'make_id': make_id})
 
+    let s:make_info[make_id].makers_queue = makers
+
+    if file_mode
+        " XXX: this clears counts for job's buffer only, but we add counts for
+        " the entry's buffers, which might be different!
+        call neomake#statusline#ResetCountsForBuf(bufnr)
+    else
+        call neomake#statusline#ResetCountsForProject()
+    endif
+
+    call s:AddMakeInfoForCurrentWin(make_id)
+
+    " TODO: return jobinfos?!
     let job_ids = []
-    while len(enabled_makers)
-        let maker = remove(enabled_makers, 0)
-        if empty(maker)
-            continue
+    while 1
+        let jobinfo = s:handle_next_maker({})
+        if empty(jobinfo)
+            break
         endif
-        if has_key(a:options, 'exit_callback')
-            " FIXME: remove/refactor exit_callback with NeomakeFinished.
-            "        (https://github.com/neomake/neomake/issues/1074)
-            let maker.exit_callback = a:options.exit_callback
-        endif
-        " call neomake#utils#DebugMessage('Maker: '.string(enabled_makers), {'make_id': s:make_id})
-
-        if neomake#has_async_support()
-            let serialize = neomake#utils#GetSetting('serialize', maker, 0, [ft], bufnr)
-        else
-            let serialize = 1
-        endif
-        if serialize && len(enabled_makers) > 0
-            let next_opts = copy(options)
-            let next_opts.enabled_makers = enabled_makers
-            let next_opts.continuation = 1
-            call extend(next_opts, {
-                    \ 'file_mode': file_mode,
-                    \ 'bufnr': bufnr,
-                    \ 'serialize_abort_on_error':
-                    \    neomake#utils#GetSetting('serialize_abort_on_error', maker, 0, [ft], bufnr),
-                    \ })
-            let options.next = next_opts
-        endif
-        let options.maker = maker
-        try
-            let job_id = s:MakeJob(s:make_id, options)
-        catch /^Neomake: restarting job/
-            continue
-        catch /^Neomake: /
-            let error = substitute(v:exception, '^Neomake: ', '', '')
-            call neomake#utils#ErrorMessage(error, {'make_id': s:make_id})
-            if serialize && len(enabled_makers) && options.next.serialize_abort_on_error
-                " TODO: refactor with s:handle_next_makers.
-                let next_makers = '['.join(map(copy(enabled_makers), 'v:val.name'), ', ').']'
-                call neomake#utils#LoudMessage('Aborting next makers '.next_makers.' (status 127)')
-                break
-            endif
-            continue
-        endtry
+        let job_id = jobinfo.id
         if job_id >= 0
             call add(job_ids, job_id)
         endif
-        " If we are serializing makers, stop after the first one. The
-        " remaining makers will be processed in turn when this one is done.
-        if serialize
+        if get(jobinfo, 'serialize', 0)
             break
         endif
     endwhile
+
+    if has_key(s:make_info, make_id) && !len(s:make_info[make_id].active_jobs)
+        " Might have been removed through s:CleanJobinfo already.
+        unlet s:make_info[make_id]
+    endif
     return job_ids
 endfunction
 
@@ -921,10 +887,19 @@ function! s:AddExprCallback(jobinfo, prev_index) abort
 endfunction
 
 function! s:CleanJobinfo(jobinfo) abort
+    if get(a:jobinfo, 'pending_output', 0) && !get(a:jobinfo, 'restarting', 0)
+        call neomake#utils#DebugMessage(
+                    \ 'Output left to be processed, not cleaning job yet.', a:jobinfo)
+        return
+    endif
     call neomake#utils#DebugMessage('Cleaning jobinfo', a:jobinfo)
 
-    if has_key(a:jobinfo, 'id')
+    let make_info = s:make_info[a:jobinfo.make_id]
+    let active_jobs = make_info.active_jobs
+
+    if has_key(s:jobs, get(a:jobinfo, 'id', -1))
         call remove(s:jobs, a:jobinfo.id)
+        call remove(active_jobs, a:jobinfo.id)
 
         let [t, w] = s:GetTabWinForMakeId(a:jobinfo.make_id)
         let jobs_output = s:gettabwinvar(t, w, 'neomake_jobs_output', {})
@@ -948,11 +923,23 @@ function! s:CleanJobinfo(jobinfo) abort
         endif
     endif
 
-    call neomake#utils#hook('NeomakeJobFinished', {'jobinfo': a:jobinfo})
+    if !get(a:jobinfo, 'restarting', 0)
+                \ && !get(a:jobinfo, 'failed_to_start', 0)
+        call neomake#utils#hook('NeomakeJobFinished', {'jobinfo': a:jobinfo})
+        call add(make_info.finished_jobs, a:jobinfo.id)
+    endif
 
     " Trigger autocmd if all jobs for a s:Make instance have finished.
-    if !len(filter(copy(s:jobs), 'v:val.make_id == a:jobinfo.make_id'
-                \ . "|| get(v:val, 'restarting', 0) == a:jobinfo.make_id"))
+    if len(active_jobs)
+        return
+    endif
+
+    let makers_queue = s:make_info[a:jobinfo.make_id].makers_queue
+    if len(makers_queue)
+        return
+    endif
+
+    if len(make_info.finished_jobs)
         call s:init_job_output(a:jobinfo)
 
         " If signs were not cleared before this point, then the maker did not return
@@ -979,6 +966,7 @@ function! s:CleanJobinfo(jobinfo) abort
                     \ 'file_mode': a:jobinfo.file_mode,
                     \ 'make_id': a:jobinfo.make_id}, a:jobinfo)
     endif
+    unlet s:make_info[a:jobinfo.make_id]
 endfunction
 
 function! s:CanProcessJobOutput() abort
@@ -1102,6 +1090,7 @@ function! s:ProcessPendingOutput(outputs) abort
         if has_key(jobinfo, 'pending_output')
             if !s:has_pending_output(jobinfo)
                 call neomake#utils#DebugMessage('Processed pending output', jobinfo)
+                let jobinfo.pending_output = 0
                 call s:CleanJobinfo(jobinfo)
             endif
         endif
@@ -1236,9 +1225,10 @@ function! s:vim_exit_handler(channel) abort
         let error = 'Vim job failed to run: '.substitute(join(jobinfo.stderr), '\v\s+$', '', '')
         let jobinfo.stderr = []
         call neomake#utils#ErrorMessage(error)
+        call s:CleanJobinfo(jobinfo)
+    else
+        call s:exit_handler(job_id, status, 'exit')
     endif
-
-    call s:exit_handler(job_id, status, 'exit')
 endfunction
 
 function! s:has_pending_output(jobinfo) abort
@@ -1306,9 +1296,8 @@ function! s:exit_handler(job_id, data, event_type) abort
     endif
     let jobinfo = s:jobs[a:job_id]
     if get(jobinfo, 'restarting')
-        call neomake#utils#DebugMessage('exit: job is restarting.', jobinfo)
-        call s:MakeJob(jobinfo.restarting, jobinfo)
-        call remove(s:jobs, jobinfo.id)
+        call neomake#utils#DebugMessage('exit: job was restarted.', jobinfo)
+        call s:CleanJobinfo(jobinfo)
         return
     endif
     if get(jobinfo, 'canceled')
@@ -1348,35 +1337,35 @@ function! s:exit_handler(job_id, data, event_type) abort
 
     let status = a:data
     let jobinfo.exit_code = a:data
-    if has_key(maker, 'exit_callback') && !get(jobinfo, 'failed_to_start')
-        let callback_dict = { 'status': status,
-                            \ 'name': maker.name,
-                            \ 'has_next': has_key(maker, 'next') }
-        if type(maker.exit_callback) == type('')
-            let l:ExitCallback = function(maker.exit_callback)
-        else
-            let l:ExitCallback = maker.exit_callback
+    if !get(jobinfo, 'failed_to_start')
+        let l:ExitCallback = neomake#utils#GetSetting('exit_callback',
+                    \ extend(copy(jobinfo), maker), 0, jobinfo.fts, jobinfo.bufnr)
+        if l:ExitCallback isnot# 0
+            let callback_dict = { 'status': status,
+                                \ 'name': maker.name,
+                                \ 'has_next': len(s:make_info[jobinfo.make_id].makers_queue) > 0 }
+            if type(l:ExitCallback) == type('')
+                let l:ExitCallback = function(l:ExitCallback)
+            endif
+            try
+                call call(l:ExitCallback, [callback_dict], jobinfo)
+            catch /^Vim\%((\a\+)\)\=:E117/
+            endtry
         endif
-        try
-            call call(l:ExitCallback, [callback_dict], jobinfo)
-        catch /^Vim\%((\a\+)\)\=:E117/
-        endtry
     endif
 
-    if neomake#has_async_support() && (has('nvim') || status != 122)
-        call neomake#utils#DebugMessage(printf(
-                    \ '%s: completed with exit code %d.',
-                    \ maker.name, status), jobinfo)
+    if neomake#has_async_support()
+        if has('nvim') || status != 122
+            call neomake#utils#DebugMessage(printf(
+                        \ '%s: completed with exit code %d.',
+                        \ maker.name, status), jobinfo)
+        endif
+        if has_pending_output || s:has_pending_output(jobinfo)
+            let jobinfo.pending_output = 1
+            let jobinfo.finished = 1
+        endif
     endif
-
-    if has_pending_output || s:has_pending_output(jobinfo)
-        call neomake#utils#DebugMessage(
-                    \ 'Output left to be processed, not cleaning job yet.', jobinfo)
-        let jobinfo.pending_output = 1
-        let jobinfo.finished = 1
-    endif
-
-    call s:handle_next_makers(jobinfo, status)
+    call s:handle_next_maker(jobinfo)
 endfunction
 
 function! s:output_handler(job_id, data, event_type) abort
@@ -1408,23 +1397,67 @@ function! s:output_handler(job_id, data, event_type) abort
     endif
 endfunction
 
-function! s:handle_next_makers(jobinfo, status) abort
-    if len(a:jobinfo.next)
-        let next = a:jobinfo.next
-        let next_makers = '['.join(map(copy(next.enabled_makers), 'v:val.name'), ', ').']'
-        if (a:status != 0 && index([122, 127], a:status) == -1 && next.serialize_abort_on_error)
-            call neomake#utils#LoudMessage('Aborting next makers '.next_makers.' (status '.a:status.')')
-        else
-            call neomake#utils#DebugMessage(printf('next makers: %s',
-                        \ next_makers), a:jobinfo)
-            if len(next.enabled_makers)
-                call s:Make(next)
+function! s:abort_next_makers(make_id) abort
+    let makers_queue = s:make_info[a:make_id].makers_queue
+    if len(makers_queue)
+        let next_makers = '['.join(map(copy(makers_queue), 'v:val.name'), ', ').']'
+        call neomake#utils#LoudMessage('Aborting next makers '.next_makers)
+        let s:make_info[a:make_id].makers_queue = []
+    endif
+endfunction
+
+function! s:handle_next_maker(prev_jobinfo) abort
+    let make_id = get(a:prev_jobinfo, 'make_id', s:make_id)
+    if !has_key(s:make_info, make_id)
+        return {}
+    endif
+    let make_info = s:make_info[make_id]
+
+    if !empty(a:prev_jobinfo)
+        let status = get(a:prev_jobinfo, 'exit_code', 0)
+        if status != 0 && index([122, 127], status) == -1
+            if neomake#utils#GetSetting('serialize_abort_on_error', a:prev_jobinfo.maker, 0, a:prev_jobinfo.fts, a:prev_jobinfo.bufnr)
+                call s:abort_next_makers(make_id)
+                call s:CleanJobinfo(a:prev_jobinfo)
+                return {}
             endif
         endif
+        call s:CleanJobinfo(a:prev_jobinfo)
+        if !has_key(s:make_info, make_id)
+            " Last job was cleaned.
+            return {}
+        endif
     endif
-    if !get(a:jobinfo, 'pending_output', 0)
-        call s:CleanJobinfo(a:jobinfo)
-    endif
+
+    while len(make_info.makers_queue)
+        let maker = remove(make_info.makers_queue, 0)
+        if empty(maker)
+            continue
+        endif
+
+        let options = extend(deepcopy(make_info.options), {'maker': maker})
+
+        " Serialization of jobs, always for non-async Vim.
+        if !neomake#has_async_support()
+                    \ || neomake#utils#GetSetting('serialize', maker, 0, options.fts, options.bufnr)
+            let options.serialize = 1
+        endif
+
+        try
+            return s:MakeJob(make_id, options)
+        catch /^Neomake: /
+            let error = substitute(v:exception, '^Neomake: ', '', '')
+            call neomake#utils#ErrorMessage(error, {'make_id': s:make_id})
+
+            if get(options, 'serialize', 0)
+                        \ && neomake#utils#GetSetting('serialize_abort_on_error', maker, 0, options.fts, options.bufnr)
+                call s:abort_next_makers(make_id)
+                break
+            endif
+            continue
+        endtry
+    endwhile
+    return {}
 endfunction
 
 function! neomake#CleanOldProjectSignsAndErrors() abort
@@ -1529,9 +1562,9 @@ function! neomake#CompleteJobs(...) abort
     return join(map(neomake#GetJobs(), "v:val.id.': '.v:val.maker.name"), "\n")
 endfunction
 
-function! s:map_makers(jobinfo, ...) abort
+function! s:map_makers(jobinfo, makers, ...) abort
     let r = []
-    for maker_or_name in a:jobinfo.enabled_makers
+    for maker_or_name in a:makers
         try
             let maker = call('neomake#GetMaker', [maker_or_name] + a:000)
             call maker._bind_args()
@@ -1565,7 +1598,7 @@ function! neomake#Make(file_mode, enabled_makers, ...) abort
         let options.exit_callback = a:1
     endif
     if a:file_mode
-        let options.ft = &filetype
+        let options.fts = neomake#utils#GetSortedFiletypes(&filetype)
     endif
     if len(a:enabled_makers)
         let options.enabled_makers = a:enabled_makers

--- a/autoload/neomake/makers/ft/neomake_tests.vim
+++ b/autoload/neomake/makers/ft/neomake_tests.vim
@@ -20,3 +20,7 @@ function! neomake#makers#ft#neomake_tests#echo_maker() abort
         \ 'append_file': 0,
         \ }
 endfunction
+
+function! neomake#makers#ft#neomake_tests#true() abort
+  return {}
+endfunction

--- a/autoload/neomake/utils.vim
+++ b/autoload/neomake/utils.vim
@@ -261,13 +261,13 @@ endfunction
 function! neomake#utils#GetSupersetOf(ft) abort
     try
         return eval('neomake#makers#ft#' . a:ft . '#SupersetOf()')
-    catch /^Vim\%((\a\+)\)\=:E117/
+    catch /^Vim\%((\a\+)\)\=:\(E117\|E121\)/
         return ''
     endtry
 endfunction
 
 " Attempt to get list of filetypes in order of most specific to least specific.
-function! neomake#utils#GetSortedFiletypes(ft) abort
+function! neomake#utils#GetSortedFiletypes(fts) abort
     function! CompareFiletypes(ft1, ft2) abort
         if neomake#utils#GetSupersetOf(a:ft1) ==# a:ft2
             return -1
@@ -278,7 +278,8 @@ function! neomake#utils#GetSortedFiletypes(ft) abort
         endif
     endfunction
 
-    return sort(split(a:ft, '\.'), function('CompareFiletypes'))
+    let fts = type(a:fts) == type('') ? split(a:fts, '\.') : a:fts
+    return sort(copy(fts), function('CompareFiletypes'))
 endfunction
 
 let s:unset = {}  " Sentinel.

--- a/autoload/neomake/utils.vim
+++ b/autoload/neomake/utils.vim
@@ -237,14 +237,17 @@ function! s:command_maker.fn(jobinfo) dict abort
     let argv = split(&shell) + split(&shellcmdflag)
 
     if a:jobinfo.file_mode && get(self, 'append_file', 1)
-        let command .= ' '.fnameescape(fnamemodify(bufname(a:jobinfo.bufnr), ':p'))
+        let fname = self._get_fname_for_buffer(a:jobinfo.bufnr)
+        let command .= ' '.fnamemodify(fname, ':p')
         let self.append_file = 0
     endif
     call extend(self, {
                 \ 'exe': argv[0],
                 \ 'args': argv[1:] + [command],
                 \ })
-    return filter(copy(self), "v:key !~# '^__' && v:key !~# 'fn'")
+
+    " Return a cleaned up copy of self.
+    return filter(copy(self), "v:key !~# '^__' && v:key !=# 'fn'")
 endfunction
 
 function! neomake#utils#MakerFromCommand(command) abort

--- a/doc/neomake.txt
+++ b/doc/neomake.txt
@@ -459,7 +459,7 @@ is called when the command exits.  The callback is given the following
 dictionary as its sole argument: >
     { 'status': <exit status of maker>,
     \ 'name': <maker name>,
-    \ 'has_next': <true if another maker follows, false otherwise> }
+    \ 'has_next': <1 if another maker follows, 0 otherwise> }
 
 *neomake#Sh* (command[, callback])
 This function is called by the |:NeomakeSh| command. It runs the specified
@@ -472,7 +472,10 @@ the command exits. The callback is given the following dictionary as its
 sole argument: >
     { 'status': <exit status of command>,
     \ 'name': 'sh: <command>',
-    \ 'has_next': false }
+    \ 'has_next': 0 }
+<
+The callback will receive a `jobinfo` object dict as `self`
+(|dict-functions|).
 
 *neomake#ListJobs*
 Invoked via |:NeomakeListJobs|. Echoes a list of running jobs in the format

--- a/doc/neomake.txt
+++ b/doc/neomake.txt
@@ -239,6 +239,18 @@ property: >
         \ 'cwd': '%:p:h'
         \ }
 <
+                                             *neomake-makers-tempfile_enabled*
+Default: 1
+In case the buffer is not readable or modified, the maker will get passed a
+temporary file with the buffer's contents.
+The temporary filename is based on |tempname()| by default, and will be set as
+`tempfile_name` in the maker dict.  You can set it dynamically through the
+experimental `maker.fn` callback (which is not documented on purpose yet).
+
+If some maker has problems with temporary files outside the source tree, you
+can disable this behaviour using: >
+        let g:neomake_<ft>_<name>_tempfile_enabled = 0
+<
 
 Global Options                                               *neomake-options*
 

--- a/tests/errors.vader
+++ b/tests/errors.vader
@@ -2,7 +2,9 @@ Include: include/setup.vader
 
 Execute (Error with no filename):
   new
-  set ft=python
+  set ft=neomake_tests
+  let b:neomake_neomake_tests_enabled_makers = ['true']
+  let b:neomake_neomake_tests_true_tempfile_enabled = 0
 
   Neomake
   let make_id = neomake#GetStatus().last_make_id
@@ -11,7 +13,9 @@ Execute (Error with no filename):
 
 Execute (Error with non-existing filename):
   new
-  set ft=python
+  set ft=neomake_tests
+  let b:neomake_neomake_tests_enabled_makers = ['true']
+  let b:neomake_neomake_tests_true_tempfile_enabled = 0
   file doesnotexist
 
   let fname = fnamemodify(bufname('%'), ':p')
@@ -24,7 +28,9 @@ Execute (Error with non-existing filename for 2nd maker):
   call g:NeomakeSetupAutocmdWrappers()
 
   new
-  set ft=python
+  set ft=neomake_tests
+  let b:neomake_neomake_tests_enabled_makers = ['true']
+  let b:neomake_neomake_tests_true_tempfile_enabled = 0
   file doesnotexist
 
   let maker1 = {
@@ -35,6 +41,7 @@ Execute (Error with non-existing filename for 2nd maker):
       \ }
   let maker2 = copy(maker1)
   let maker2.append_file = 1
+  let maker2.tempfile_enabled = 0
   let maker3 = copy(maker1)
 
   let fname = fnamemodify(bufname('%'), ':p')

--- a/tests/errors.vader
+++ b/tests/errors.vader
@@ -47,8 +47,8 @@ Execute (Error with non-existing filename for 2nd maker):
   let fname = fnamemodify(bufname('%'), ':p')
   call neomake#Make(1, [maker1, maker2, maker3])
   let make_id = neomake#GetStatus().last_make_id
-  AssertNeomakeMessage 'file is not readable ('.fname.')', 0, {'make_id': make_id}
   NeomakeTestsWaitForFinishedJobs
+  AssertNeomakeMessage 'file is not readable ('.fname.')', 0, {'make_id': make_id}
   AssertEqual len(g:neomake_test_finished), 1
   AssertEqual len(g:neomake_test_jobfinished), 2
   bd!

--- a/tests/ft_python.vader
+++ b/tests/ft_python.vader
@@ -1,7 +1,8 @@
 Include: include/setup.vader
 
 Execute (python: errorformat):
-  e! tests/fixtures/errors.py
+  new
+  e tests/fixtures/errors.py
   Neomake python
   NeomakeTestsWaitForFinishedJobs
 
@@ -15,10 +16,12 @@ Execute (python: errorformat):
   \ 'type': 'E',
   \ 'pattern': '',
   \ 'text': 'invalid syntax'}]
+  bwipe
 
 Execute (python: pylama: errorformat):
   Save &errorformat
   let &errorformat = neomake#makers#ft#python#pylama().errorformat
+  new
   file file1.py
   lgetexpr "file1.py:16:1: [C] C901 'load_library' is too complex (13) [mccabe]"
   AssertEqual getloclist(0), [
@@ -38,11 +41,13 @@ Execute (python: pylama: errorformat):
   \ 'type': 'I',
   \ 'pattern': '',
   \ 'text': "C901 'load_library' is too complex (13) [mccabe]"}
+  bwipe
 
 Execute (python: flake8: errorformat/postprocess: F811):
   Save &errorformat
   let &errorformat = neomake#makers#ft#python#flake8().errorformat
 
+  new
   file file1.py
   norm Iimport os
   norm oimport os . path as os
@@ -88,3 +93,4 @@ Execute (python: flake8: errorformat/postprocess: F811):
   \ 'length': 2,
   \ 'type': 'E',
   \ 'text': "F811 redefinition of unused 'os' from line 2"}, e
+  bwipe!

--- a/tests/include/setup.vader
+++ b/tests/include/setup.vader
@@ -53,15 +53,18 @@ Before:
   command! NeomakeTestsWaitForNextMessage call s:wait_for_next_message()
 
   function! s:wait_for_finished_job()
+    if !exists('#neomake_tests')
+      call g:NeomakeSetupAutocmdWrappers()
+    endif
     let max = 45
-    let n = len(neomake#GetJobs())
+    let n = len(g:neomake_test_jobfinished)
     while 1
       let max -= 1
       if max == 0
         throw 'No job finished after 3s.'
       endif
       exe 'sleep' (max < 25 ? 100 : max < 35 ? 50 : 10).'m'
-      if len(neomake#GetJobs()) != n
+      if len(g:neomake_test_jobfinished) != n
         break
       endif
     endwhile
@@ -287,6 +290,14 @@ Before:
       throw 'There were '.len(jobs).' jobs left: '.string(map(jobs, 'v:val.make_id.".".v:val.id'))
     endif
 
+    let make_info = neomake#GetStatus().make_info
+    if !empty(make_info)
+      let error = 'make_info is not empty: '.string(make_info)
+      for k in keys(make_info)
+        unlet make_info[k]
+      endfor
+      throw error
+    endif
     NeomakeTestsWaitForRemovedJobs
 
     if exists('#neomake_tests')

--- a/tests/integration.vader
+++ b/tests/integration.vader
@@ -349,7 +349,7 @@ Execute (Neomake! for project maker via g:neomake_enabled_makers):
   let g:neomake_enabled_makers = ['mycargo']
   let g:neomake_mycargo_maker = {
   \ 'exe': 'echo',
-  \ 'args': ['mycargo']
+  \ 'args': ['mycargo'],
   \ }
   Neomake!
   NeomakeTestsWaitForFinishedJobs

--- a/tests/integration.vader
+++ b/tests/integration.vader
@@ -344,6 +344,80 @@ Execute (Neomake!: non-existing and proper job):
       \ 'counts have changed'
   endif
 
+Execute (Neomake#Make: error with failing job via jobstart/argv):
+  call g:NeomakeSetupAutocmdWrappers()
+
+  let maker = {'exe': 'true'}
+  function! maker._get_argv(...) dict
+    return neomake#has_async_support() ? ['doesnotexist'] : 'doesnotexist'
+  endfunction
+
+  call neomake#Make(0, [maker])
+  NeomakeTestsWaitForFinishedJobs
+
+  if neomake#has_async_support()
+    AssertNeomakeMessage "Starting async job: ['doesnotexist']"
+  else
+    AssertNeomakeMessage "Starting: doesnotexist"
+  endif
+
+  if has('nvim-0.1.8')
+    AssertNeomakeMessage "Failed to start Neovim job: Executable not found: ['doesnotexist']", 0
+  elseif has('nvim')
+    AssertNeomakeMessage 'Failed to start Neovim job: [''doesnotexist'']: '
+      \ .'Vim(let):E902: "doesnotexist" is not an executable'
+  elseif neomake#has_async_support()
+    AssertNeomakeMessage 'Vim job failed to run: executing job failed: No such file or directory'
+  else
+    AssertNeomakeMessage 'exit: unnamed_maker: 127', 3
+  endif
+
+  if neomake#has_async_support()
+    AssertEqual len(g:neomake_test_jobfinished), 0
+    AssertEqual len(g:neomake_test_finished), 0
+  else
+    AssertEqual len(g:neomake_test_jobfinished), 1
+    AssertEqual len(g:neomake_test_finished), 1
+  endif
+
+
+Execute (Neomake#Make: error with failing job via jobstart/argv + true):
+  call g:NeomakeSetupAutocmdWrappers()
+
+  let maker = {'exe': 'true'}
+  function! maker._get_argv(...) dict
+    return neomake#has_async_support() ? ['doesnotexist'] : 'doesnotexist'
+  endfunction
+
+  call neomake#Make(0, [maker, {'exe': 'true'}])
+  NeomakeTestsWaitForFinishedJobs
+
+  if neomake#has_async_support()
+    AssertNeomakeMessage "Starting async job: ['doesnotexist']"
+  else
+    AssertNeomakeMessage "Starting: doesnotexist"
+  endif
+
+  if has('nvim-0.1.8')
+    AssertNeomakeMessage "Failed to start Neovim job: Executable not found: ['doesnotexist']", 0
+  elseif has('nvim')
+    AssertNeomakeMessage 'Failed to start Neovim job: [''doesnotexist'']: '
+      \ .'Vim(let):E902: "doesnotexist" is not an executable'
+  elseif neomake#has_async_support()
+    AssertNeomakeMessage 'Vim job failed to run: executing job failed: No such file or directory'
+  else
+    AssertNeomakeMessage 'exit: unnamed_maker: 127', 3
+  endif
+
+  if neomake#has_async_support()
+    AssertEqual len(g:neomake_test_jobfinished), 1
+    AssertEqual len(g:neomake_test_finished), 1
+  else
+    AssertEqual len(g:neomake_test_jobfinished), 2
+    AssertEqual len(g:neomake_test_finished), 1
+  endif
+
+
 Execute (Neomake! for project maker via g:neomake_enabled_makers):
   Save g:neomake_enabled_makers, g:neomake_mycargo_maker
   let g:neomake_enabled_makers = ['mycargo']
@@ -445,34 +519,40 @@ Execute (Quickfix list should be cleared only after maker finished):
   endif
 
 Execute (neomake#Sh: exit_callback):
-  let g:neomake_test_cb = 0
-  function! g:NeomakeTestsAfterExit(job_status)
-    let g:neomake_test_cb = 1
+  Save g:neomake_test_cb
+  let g:neomake_test_cb = []
+  function! g:NeomakeTestsAfterExit(job_status) dict
+    call add(g:neomake_test_cb, [self, a:job_status])
   endfunction
   call neomake#Sh('true', function('g:NeomakeTestsAfterExit'))
   NeomakeTestsWaitForFinishedJobs
-  AssertEqual g:neomake_test_cb, 1
+  AssertEqual len(g:neomake_test_cb), 1
+  AssertEqual g:neomake_test_cb[0][1], {'status': 0, 'name': 'sh: true', 'has_next': 0}
 
 Execute (neomake#Make: exit_callback):
-  let g:neomake_test_cb = 0
-  function! g:NeomakeTestsAfterExit(job_status)
-    let g:neomake_test_cb = 1
+  Save g:neomake_test_cb
+  let g:neomake_test_cb = []
+  function! g:NeomakeTestsAfterExit(job_status) dict
+    call add(g:neomake_test_cb, [self, a:job_status])
   endfunction
-  let maker = {'exe': 'true'}
-  call neomake#Make(0, [maker], function('g:NeomakeTestsAfterExit'))
+  let maker = {'exe': 'true', 'serialize': 1}
+  call neomake#Make(0, [maker, maker], function('g:NeomakeTestsAfterExit'))
   NeomakeTestsWaitForFinishedJobs
-  AssertEqual g:neomake_test_cb, 1
+  AssertEqual len(g:neomake_test_cb), 2
+  AssertEqual g:neomake_test_cb[0][1], {'status': 0, 'name': 'unnamed_maker', 'has_next': 1}
+  AssertEqual g:neomake_test_cb[1][1], {'status': 0, 'name': 'unnamed_maker', 'has_next': 0}
 
 Execute (neomake#Make: exit_callback with maker names):
-  let g:neomake_test_cb = 0
-  function! g:NeomakeTestsAfterExit(job_status)
-    let g:neomake_test_cb = 1
+  Save g:neomake_test_cb
+  let g:neomake_test_cb = []
+  function! g:NeomakeTestsAfterExit(job_status) dict
+    call add(g:neomake_test_cb, [self, a:job_status])
   endfunction
   Save g:neomake_mymaker_maker
   let g:neomake_mymaker_maker = {'exe': 'true'}
   call neomake#Make(0, ['mymaker'], function('g:NeomakeTestsAfterExit'))
   NeomakeTestsWaitForFinishedJobs
-  AssertEqual g:neomake_test_cb, 1
+  AssertEqual g:neomake_test_cb[0][1], {'status': 0, 'name': 'mymaker', 'has_next': 0}
 
 Execute (Location list should be cleared only after first output):
   call g:NeomakeSetupAutocmdWrappers()

--- a/tests/lists.vader
+++ b/tests/lists.vader
@@ -50,6 +50,7 @@ Execute (AddExprCallback with changed windows inbetween):
       let maxwait -= 1
     endwhile
     Assert maxwait > 0, 'Postprocessing was not triggered.'
+    AssertEqual g:neomake_tests_postprocess_count, 2, 'postprocess count is != 2: '.g:neomake_tests_postprocess_count
     let loclist_texts = map(copy(getloclist(0)), 'v:val.text')
     AssertEqual sort(copy(loclist_texts)), ['1a SUFFIX:0', '2 SUFFIX:0']
 
@@ -59,6 +60,7 @@ Execute (AddExprCallback with changed windows inbetween):
     " Go to previous window, let previous job finish.
     wincmd j
     NeomakeTestsWaitForFinishedJobs
+    AssertNeomakeMessage 'Output left to be processed, not cleaning job yet.'
     AssertEqual map(copy(getloclist(0)), 'v:val.text'),
       \ loclist_texts + ['1b SUFFIX:1']
     wincmd k

--- a/tests/neomake.vader
+++ b/tests/neomake.vader
@@ -18,6 +18,7 @@ Include (Processing): processing.vader
 Include (Serialize): serialize.vader
 Include (Signs): signs.vader
 Include (Statusline): statusline.vader
+Include (Temporary files): tempfiles.vader
 Include (Utils): utils.vader
 Include (Verbosity): verbosity.vader
 
@@ -65,8 +66,9 @@ Execute (Neomake with unknown maker):
   runtime autoload/neomake/statusline.vim
 
   Neomake doesnotexist
+  let make_id = neomake#GetStatus().last_make_id
   AssertEqual g:neomake_test_messages, [
-  \ [0, 'Maker not found (for filetypes []): doesnotexist', {}],
+  \ [0, 'Maker not found (for filetypes []): doesnotexist', {'make_id': make_id}],
   \ [3, 'Nothing to make: no valid makers.', {}],
   \ ]
 

--- a/tests/neomake.vader
+++ b/tests/neomake.vader
@@ -163,14 +163,18 @@ Execute (neomake#CancelJob with invalid job):
   if NeomakeAsyncTestsSetup()
     let job_id = neomake#Sh("sh -c 'sleep .1'")
     let jobinfo = neomake#GetJob(job_id)
+
+    " Stop the job manually.
     if has('nvim')
       call jobstop(job_id)
     else
       let vim_job = jobinfo.vim_job
       call ch_close(vim_job)
     endif
+
+    AssertEqual len(neomake#GetJobs()), 1, 'There are jobs (1)'
     let ret = neomake#CancelJob(job_id)
-    Assert len(neomake#GetJobs()), 'There are jobs (1)'
+    AssertEqual len(neomake#GetJobs()), 0, 'There are no more jobs'
     if has('nvim')
       " Vim returns 1 via job_stop usually.
       AssertEqual ret, 0, "CancelJob (1) returned ".ret
@@ -183,39 +187,42 @@ Execute (neomake#CancelJob with invalid job):
     else
       AssertNeomakeMessage 'job_stop: job was not running anymore', 2, jobinfo
     endif
-    Assert len(neomake#GetJobs()), 'There are jobs'
 
     let ret = neomake#CancelJob(job_id)
     if has('nvim')
       " Vim returns 1 via job_stop usually.
       AssertEqual ret, 0, "CancelJob (2) returned ".ret
     endif
-    AssertNeomakeMessage 'Stopping job', 3, jobinfo
-
-    AssertNeomakeMessageAbsent 'exit: job was canceled.', 3
+    AssertNeomakeMessage 'CancelJob: job not found: '.job_id, 0, {}
     if has('nvim')
       " With Vim the exit callback is not invoked (since ch_close was used).
       NeomakeTestsWaitForNextMessage
-      AssertNeomakeMessage 'exit: job was canceled.', 3
+      AssertNeomakeMessage 'exit: job not found: '.job_id, 1, {}
     else
       NeomakeCancelJobs!
     endif
     let ret = neomake#CancelJob(job_id)
     AssertEqual ret, 0, "CancelJob (3) returned ".ret
-    AssertNeomakeMessage 'CancelJob: job not found: '.job_id, 0
   endif
 
 Execute (neomake#CancelJob! with invalid job):
   if NeomakeAsyncTestsSetup()
-    let job_id = neomake#Sh("sh -c 'sleep 1'")
+    let job_id = neomake#Sh("sh -c 'sleep 0.1'")
     let jobinfo = neomake#GetJob(job_id)
+
+    " Stop the job manually.
     if has('nvim')
       call jobstop(job_id)
     else
       let vim_job = jobinfo.vim_job
       call job_stop(vim_job)
     endif
+
+    AssertEqual len(neomake#GetJobs()), 1, 'There are jobs'
     let ret = neomake#CancelJob(job_id, 1)
+
+    " Jobinfo should have been cleaned already.  With Neovim it gets done
+    "" anyway, because jobstop fails.
     Assert !len(neomake#GetJobs()), 'There are no jobs'
     if has('nvim')
       " Vim returns 1 via job_stop usually.

--- a/tests/processing.vader
+++ b/tests/processing.vader
@@ -188,6 +188,8 @@ Execute (Sleep in postprocess gets handled correctly):
 
 Execute (Pending output with restarted job when not in normal/insert mode (loclist)):
   if NeomakeAsyncTestsSetup()
+    let g:neomake_test_inc_maker_counter = 0
+
     file b1
     let first_jobs = neomake#Make(1, [g:neomake_test_inc_maker])
     let make_id = neomake#GetStatus().last_make_id
@@ -196,18 +198,24 @@ Execute (Pending output with restarted job when not in normal/insert mode (locli
     AssertNeomakeMessage 'Not processing output for mode V', 3
     exe "norm! \<Esc>"
     call neomake#Make(1, [g:neomake_test_inc_maker])
-    AssertNeomakeMessage 'Restarting already running job ('
+    AssertNeomakeMessageAbsent 'Restarting already running job ('
       \ .make_id.'.'.first_jobs[0].') for the same maker.', 2, {'make_id': make_id+1}
     NeomakeTestsWaitForFinishedJobs
-    AssertEqual map(copy(getloclist(0)), 'v:val.text'), []
+    AssertEqual map(copy(getloclist(0)), 'v:val.text'),
+    \ ['2:0: buf: b1', '2:1: buf: b1']
     doautocmd CursorHold
 
-    " TODO: should have output from 2nd job, should work on serialize branch.
-    AssertEqual map(copy(getloclist(0)), 'v:val.text'), []
+    " TODO: should not overwrite later job!
+    AssertEqual map(copy(getloclist(0)), 'v:val.text'),
+    \ ['1:0: buf: b1']
+
+    AssertEqual len(g:neomake_test_finished), 2
   endif
 
 Execute (Pending output with restarted job when not in normal/insert mode (quickfix)):
   if NeomakeAsyncTestsSetup()
+    let g:neomake_test_inc_maker_counter = 0
+
     file b1
     let first_jobs = neomake#Make(0, [g:neomake_test_inc_maker])
     let make_id = neomake#GetStatus().last_make_id
@@ -216,14 +224,18 @@ Execute (Pending output with restarted job when not in normal/insert mode (quick
     AssertNeomakeMessage 'Not processing output for mode V', 3
     exe "norm! \<Esc>"
     call neomake#Make(0, [g:neomake_test_inc_maker])
-    AssertNeomakeMessage 'Restarting already running job ('
+    AssertNeomakeMessageAbsent 'Restarting already running job ('
       \ .make_id.'.'.first_jobs[0].') for the same maker.', 2, {'make_id': make_id+1}
     NeomakeTestsWaitForFinishedJobs
-    AssertEqual map(copy(getqflist()), 'v:val.text'), []
+    AssertEqual map(copy(getqflist()), 'v:val.text'),
+    \ ['2:0: buf: b1', '2:1: buf: b1']
     doautocmd CursorHold
 
-    " TODO: should have output from 2nd job, should work on serialize branch.
-    AssertEqual map(copy(getqflist()), 'v:val.text'), []
+    " TODO: should not overwrite later job!
+    AssertEqual map(copy(getqflist()), 'v:val.text'),
+    \ ['1:0: buf: b1']
+
+    AssertEqual len(g:neomake_test_finished), 2
   endif
 
 Execute (100 lines of output should not get processed one by one):

--- a/tests/processing.vader
+++ b/tests/processing.vader
@@ -192,24 +192,31 @@ Execute (Pending output with restarted job when not in normal/insert mode (locli
 
     file b1
     let first_jobs = neomake#Make(1, [g:neomake_test_inc_maker])
+    let jobinfo1 = neomake#GetJob(first_jobs[0])
     let make_id = neomake#GetStatus().last_make_id
     norm! V
     NeomakeTestsWaitForFinishedJobs
     AssertNeomakeMessage 'Not processing output for mode V', 3
     exe "norm! \<Esc>"
     call neomake#Make(1, [g:neomake_test_inc_maker])
+
+    " Maker is different because of args.
     AssertNeomakeMessageAbsent 'Restarting already running job ('
       \ .make_id.'.'.first_jobs[0].') for the same maker.', 2, {'make_id': make_id+1}
+    AssertNeomakeMessageAbsent 'Removing already finished job', 3, jobinfo1
     NeomakeTestsWaitForFinishedJobs
     AssertEqual map(copy(getloclist(0)), 'v:val.text'),
     \ ['2:0: buf: b1', '2:1: buf: b1']
     doautocmd CursorHold
 
-    " TODO: should not overwrite later job!
+    " TODO: Should have still the output from 2nd job.
+    " Discard output from earlier makes?"
+"     AssertEqual map(copy(getloclist(0)), 'v:val.text'),
+"     \ ['2:0: buf: b1', '2:1: buf: b1']
     AssertEqual map(copy(getloclist(0)), 'v:val.text'),
     \ ['1:0: buf: b1']
-
     AssertEqual len(g:neomake_test_finished), 2
+    AssertEqual len(g:neomake_test_jobfinished), 2
   endif
 
 Execute (Pending output with restarted job when not in normal/insert mode (quickfix)):
@@ -218,24 +225,31 @@ Execute (Pending output with restarted job when not in normal/insert mode (quick
 
     file b1
     let first_jobs = neomake#Make(0, [g:neomake_test_inc_maker])
+    let jobinfo1 = neomake#GetJob(first_jobs[0])
     let make_id = neomake#GetStatus().last_make_id
     norm! V
     NeomakeTestsWaitForFinishedJobs
     AssertNeomakeMessage 'Not processing output for mode V', 3
     exe "norm! \<Esc>"
     call neomake#Make(0, [g:neomake_test_inc_maker])
+
+    " Maker is different because of args.
     AssertNeomakeMessageAbsent 'Restarting already running job ('
       \ .make_id.'.'.first_jobs[0].') for the same maker.', 2, {'make_id': make_id+1}
+    AssertNeomakeMessageAbsent 'Removing already finished job', 3, jobinfo1
     NeomakeTestsWaitForFinishedJobs
     AssertEqual map(copy(getqflist()), 'v:val.text'),
     \ ['2:0: buf: b1', '2:1: buf: b1']
     doautocmd CursorHold
 
-    " TODO: should not overwrite later job!
+    " TODO: Should have still the output from 2nd job.
+"     AssertEqual map(copy(getloclist(0)), 'v:val.text'),
+"     \ ['2:0: buf: b1', '2:1: buf: b1']
     AssertEqual map(copy(getqflist()), 'v:val.text'),
     \ ['1:0: buf: b1']
 
     AssertEqual len(g:neomake_test_finished), 2
+    AssertEqual len(g:neomake_test_jobfinished), 2
   endif
 
 Execute (100 lines of output should not get processed one by one):

--- a/tests/serialize.vader
+++ b/tests/serialize.vader
@@ -14,11 +14,28 @@ Execute (NeomakeSh: simple serialized makers):
   Save g:neomake_serialize
   let g:neomake_serialize = 1
 
+  call neomake#Make(1, [g:sleep_maker, g:maker_success])
+  NeomakeTestsWaitForFinishedJobs
+  AssertEqual len(g:neomake_test_finished), 1
+  AssertEqual map(copy(getloclist(0)), 'v:val.text'),
+  \ ['slept', 'success']
+  AssertNeomakeMessage 'Running makers: sleep-maker, success-maker', 3
+  AssertNeomakeMessage 'exit: sleep-maker: 0'
+  AssertNeomakeMessage 'exit: success-maker: 0'
+
+Execute (NeomakeSh: simple serialized maker with error):
+  call g:NeomakeSetupAutocmdWrappers()
+  Save g:neomake_serialize
+  let g:neomake_serialize = 1
+
   call neomake#Make(1, [g:maker_error, g:maker_success])
   NeomakeTestsWaitForFinishedJobs
   AssertEqual len(g:neomake_test_finished), 1
   AssertEqual map(copy(getloclist(0)), 'v:val.text'),
   \ ['error', 'success']
+  AssertNeomakeMessage 'Running makers: error-maker, success-maker', 3
+  AssertNeomakeMessage 'exit: error-maker: 1'
+  AssertNeomakeMessage 'exit: success-maker: 0'
 
 Execute (NeomakeSh: serialized with global abort):
   call g:NeomakeSetupAutocmdWrappers()
@@ -55,7 +72,7 @@ Execute (NeomakeSh: serialized with abort from maker):
   NeomakeTestsWaitForFinishedJobs
   AssertEqual len(g:neomake_test_jobfinished), 1
   AssertEqual len(g:neomake_test_finished), 1
-  AssertNeomakeMessage 'Aborting next makers [success-maker] (status 1)'
+  AssertNeomakeMessage 'Aborting next makers [success-maker]'
   AssertEqual map(copy(getloclist(0)), 'v:val.text'), ['error']
 
 Execute (NeomakeSh: serialized with previous buffer overriding global abort):
@@ -76,6 +93,8 @@ Execute (NeomakeSh: serialized with previous buffer overriding global abort):
     AssertEqual map(copy(getloclist(0)), 'v:val.text'), ['slept', 'error']
     wincmd p
     bd
+
+    AssertNeomakeMessage 'Aborting next makers [success-maker]'
   endif
 
 Execute (NeomakeSh: serialized after doesnotexist: continue):
@@ -100,14 +119,16 @@ Execute (NeomakeSh: serialized after doesnotexist: abort):
   AssertEqual len(g:neomake_test_finished), 0
 
   AssertNeomakeMessage "Exe (doesnotexist) of maker unnamed_maker is not executable."
-  AssertNeomakeMessage "Aborting next makers [success-maker] (status 127)"
+  AssertNeomakeMessage 'Aborting next makers [success-maker]'
 
 Execute (Neomake#Make cancels previous jobs):
   if NeomakeAsyncTestsSetup()
     let first_jobs = neomake#GetJobs(neomake#Make(0, [g:sleep_maker, g:maker_error]))
     let make_id = neomake#GetStatus().last_make_id
     call neomake#Make(0, [g:sleep_maker, g:maker_error])
+    AssertEqual has_key(neomake#GetStatus().make_info, make_id), 1
     NeomakeTestsWaitForFinishedJobs
+    AssertEqual has_key(neomake#GetStatus().make_info, make_id), 0
     AssertEqual len(g:neomake_test_jobfinished), 2
     AssertEqual len(g:neomake_test_finished), 1
     AssertEqual map(copy(getqflist()), 'v:val.text'), ['error', 'slept']
@@ -123,6 +144,26 @@ Execute (Neomake#Make cancels previous jobs):
     " Restarted job should use new make_id.
     AssertNeomakeMessage "Starting async job: ['/bin/bash', '-c', 'echo error; false']",
     \ 2, {'make_id': make_id+1}
+  endif
+
+Execute (Neomake#Make starts new jobs before waiting for the old to finish):
+  if NeomakeAsyncTestsSetup()
+    let start = reltime()
+    let maker = NeomakeTestsCommandMaker('sleep', 'sleep .5')
+    call neomake#Make(0, [maker])
+    call neomake#Make(0, [maker])
+    call neomake#Make(0, [maker])
+    call neomake#Make(0, [maker])
+    call neomake#Make(0, [maker])
+    NeomakeTestsWaitForFinishedJobs
+    let end = reltime()
+    let duration = reltimefloat(end) - reltimefloat(start)
+    Assert duration < 1.0, printf(
+    \ 'Jobs have been restarted before being stopped (%.2f).', duration)
+
+    let restart_messages = filter(copy(g:neomake_test_messages),
+        \ "v:val[1] =~# '\\vRestarting already running job \\(\\d+\\.\\d+\\) for the same maker.'")
+    AssertEqual len(restart_messages), 4, 'Jobs have not been restarted: '.string(restart_messages)
   endif
 
 Execute (Neomake#Make does not cancel maker from same run):
@@ -188,7 +229,38 @@ Execute (Neomake#Make handles cwd properly):
 
     Assert !has_key(g:neomake_test_jobfinished[2].jobinfo.maker, 'tempfile_name'), 'No tempfile is used'
 
-    AssertEqual g:neomake_test_exit_cb, [jobinfo1, {'status': 0, 'name': 'maker1', 'has_next': 0}]
+    AssertEqual g:neomake_test_exit_cb[0], jobinfo1
+    AssertEqual g:neomake_test_exit_cb[1], {'status': 0, 'name': 'maker1', 'has_next': 1}
     AssertEqual map(copy(getloclist(0)), 'v:val.text'),
     \ ['maker_1 build: '.file1, 'maker_2 build: '.file1, 'maker_3 '.file1]
+  endif
+
+Execute (Uses correct maker filetypes when started in another buffer):
+  if NeomakeAsyncTestsSetup()
+    Save g:neomake_serialize
+    let g:neomake_serialize = 1
+
+    new
+    set filetype=orig_ft
+
+    let maker1 = NeomakeTestsCommandMaker('maker1', 'true')
+    function! maker1.exit_callback(job_status) dict
+      new
+      set filetype=another_ft
+    endfunction
+
+    let maker2 = NeomakeTestsCommandMaker('maker2', 'true')
+    function! maker2.exit_callback(job_status) dict
+      let g:neomake_test_exit_cb = [self, a:job_status]
+      AssertEqual &filetype, 'another_ft'
+      bwipe
+    endfunction
+
+    call neomake#Make(1, [maker1, maker2])
+    NeomakeTestsWaitForFinishedJobs
+
+    AssertEqual g:neomake_test_exit_cb[1], {'status': 0, 'name': 'maker2', 'has_next': 0}
+    AssertEqual g:neomake_test_exit_cb[0].maker.fts, ['orig_ft']
+
+    bwipe
   endif

--- a/tests/serialize.vader
+++ b/tests/serialize.vader
@@ -178,12 +178,15 @@ Execute (Neomake#Make handles cwd properly):
       NeomakeTestsWaitForFinishedJobs
       " Trigger processing.
       wincmd p
+
       " Cleanup.
       wincmd p
       bd
     finally
       exe 'cd '.orig_cwd
     endtry
+
+    Assert !has_key(g:neomake_test_jobfinished[2].jobinfo.maker, 'tempfile_name'), 'No tempfile is used'
 
     AssertEqual g:neomake_test_exit_cb, [jobinfo1, {'status': 0, 'name': 'maker1', 'has_next': 0}]
     AssertEqual map(copy(getloclist(0)), 'v:val.text'),

--- a/tests/tempfiles.vader
+++ b/tests/tempfiles.vader
@@ -1,0 +1,159 @@
+Include: include/setup.vader
+
+Execute (Neomake uses temporary file for unsaved buffer):
+  new
+  norm iline1
+  norm oline2
+
+  let maker = {
+  \ 'exe': 'cat',
+  \ 'append_file': 1,
+  \ 'errorformat': '%m',
+  \ 'tempfile_enabled': 1,
+  \ }
+  call neomake#Make(1, [maker])
+  if neomake#has_async_support()
+    let jobinfo = neomake#GetJobs()[0]
+
+    let temp_file = jobinfo.maker.tempfile_name
+    AssertEqual fnamemodify(temp_file, ':h:h'), fnamemodify(tempname(), ':h')
+    AssertEqual getfperm(temp_file), 'rw-r--r--'
+    NeomakeTestsWaitForFinishedJobs
+  endif
+
+  AssertEqual getloclist(0), [{
+  \ 'lnum': 0,
+  \ 'bufnr': bufnr('%'),
+  \ 'col': 0,
+  \ 'valid': 1,
+  \ 'vcol': 0,
+  \ 'nr': -1,
+  \ 'type': '',
+  \ 'pattern': '',
+  \ 'text': 'line1'},
+  \ {
+  \ 'lnum': 0,
+  \ 'bufnr': bufnr('%'),
+  \ 'col': 0,
+  \ 'valid': 1,
+  \ 'vcol': 0,
+  \ 'nr': -1,
+  \ 'type': '',
+  \ 'pattern': '',
+  \ 'text': 'line2'}]
+
+  if neomake#has_async_support()
+    AssertEqual filereadable(temp_file), 0, 'temp_file was removed'
+    AssertNeomakeMessage 'Removing temporary file: '.temp_file
+  else
+    AssertEqual len(filter(copy(g:neomake_test_messages), "v:val[1] =~# '^Removing temporary file:'")), 1, 'msg found'
+  endif
+
+  bwipe!
+
+Execute (Uses temporary file for unreadable buffer):
+  new
+  set ft=neomake_tests
+  let b:neomake_neomake_tests_enabled_makers = ['true']
+  let b:neomake_neomake_tests_true_tempfile_enabled = 1
+  file doesnotexist
+
+  let fname = fnamemodify(bufname('%'), ':p')
+  RunNeomake
+
+  let bufnr = bufnr('%')
+  AssertEqual len(filter(copy(g:neomake_test_messages),
+  \ "v:val[1] =~ '^Using tempfile for unreadable buffer '.bufnr")), 1, 'message found'
+
+  bd!
+
+Execute (2nd maker uses temporary file):
+  call g:NeomakeSetupAutocmdWrappers()
+
+  new
+  set ft=python
+  file doesnotexist
+
+  let maker1 = {
+      \ 'exe': 'true',
+      \ 'name': 'true_maker',
+      \ 'errorformat': '%m',
+      \ 'append_file': 0,
+      \ 'tempfile_enabled': 1,
+      \ }
+  let maker2 = copy(maker1)
+  let maker2.append_file = 1
+  let maker3 = copy(maker1)
+
+  let fname = fnamemodify(bufname('%'), ':p')
+  call neomake#Make(1, [maker1, maker2, maker3])
+  let make_id = neomake#GetStatus().last_make_id
+
+  let bufnr = bufnr('%')
+  AssertEqual len(filter(copy(g:neomake_test_messages),
+  \ "v:val[1] =~ '^Using tempfile for unreadable buffer '.bufnr")), 1, 'message not found'
+  NeomakeTestsWaitForFinishedJobs
+  AssertEqual len(g:neomake_test_finished), 1
+  AssertEqual len(g:neomake_test_jobfinished), 3
+  bd!
+
+Execute (Maker can specify temporary file to use via fn):
+  Save g:neomake_test_tempfile
+  let g:neomake_test_tempfile = tempname() . 'injected/with/subdir'
+
+  function! NeomakeTestsF(jobinfo) abort dict
+    let self.tempfile_name = g:neomake_test_tempfile
+  endfunction
+  let maker = {
+  \ 'exe': 'true',
+  \ 'fn': function('NeomakeTestsF'),
+  \ }
+
+  new
+  let bufnr = bufnr('%')
+  file unreadable
+  let maker = neomake#GetMaker(maker)
+  AssertEqual maker.args, []
+  let jobinfo = {'file_mode': 1, 'bufnr': bufnr}
+  call maker.fn(jobinfo)
+  AssertEqual maker.args, []
+  call maker._get_argv(jobinfo)
+  AssertEqual maker.args, []
+  AssertEqual maker.tempfile_name, g:neomake_test_tempfile
+  AssertNeomakeMessage 'Using tempfile for unreadable buffer '.bufnr.': '.g:neomake_test_tempfile
+
+  call neomake#Make(1, [maker])
+  AssertNeomakeMessage 'Using tempfile for unreadable buffer '.bufnr.': '.g:neomake_test_tempfile
+  NeomakeTestsWaitForFinishedJobs
+  if neomake#has_async_support()
+    AssertNeomakeMessage "Starting async job: ['true', '".g:neomake_test_tempfile."']"
+  else
+    AssertNeomakeMessage "Starting: true ".fnameescape(g:neomake_test_tempfile)
+  endif
+  bwipe
+
+Execute (maker._get_argv uses jobinfo for bufnr):
+  let maker = neomake#GetMaker({'name': 'my_maker', 'append_file': 1})
+
+  new
+  let bufnr = bufnr('%')
+  let jobinfo = {'file_mode': 1, 'bufnr': bufnr}
+  call maker._get_argv(jobinfo)
+  Assert !empty(maker.tempfile_name)
+
+  let maker = neomake#GetMaker({'name': 'my_maker', 'append_file': 1})
+  e! tests/fixtures/errors.py
+  call maker._get_argv(jobinfo)
+  Assert !has_key(maker, 'tempfile_name')
+
+  wincmd p
+  let jobinfo = {'file_mode': 1, 'bufnr': bufnr}
+  let expected = ['my_maker', fnameescape(fnamemodify(bufname(bufnr), ':p'))]
+  if neomake#has_async_support()
+    AssertEqual expected, maker._get_argv(jobinfo)
+  else
+    AssertEqual join(expected), maker._get_argv(jobinfo)
+  endif
+
+  wincmd p
+  bwipe

--- a/tests/utils.vader
+++ b/tests/utils.vader
@@ -253,7 +253,7 @@ Execute (neomake#utils#sort_by_col):
 Execute (neomake#utils#MakerFromCommand splits shell/shellcmdflag):
   Save &shell, &shellcmdflag
 
-  let jobinfo = {'file_mode': 0}
+  let jobinfo = {'file_mode': 0, 'bufnr': 0}
 
   let &shell = '/bin/bash -o pipefail'
   let &shellcmdflag = '-c'
@@ -264,7 +264,7 @@ Execute (neomake#utils#MakerFromCommand splits shell/shellcmdflag):
     let expected_argv = "/bin/bash -o pipefail -c 'echo 1'"
   endif
   let bound_maker = neomake#GetMaker(maker.fn(jobinfo))
-  AssertEqual bound_maker._get_argv(), expected_argv
+  AssertEqual bound_maker._get_argv(jobinfo), expected_argv
 
   let &shell = '/bin/bash'
   let &shellcmdflag = '-o pipefail -c'
@@ -275,21 +275,23 @@ Execute (neomake#utils#MakerFromCommand splits shell/shellcmdflag):
     let expected_argv = "/bin/bash -o pipefail -c 'echo 2'"
   endif
   let bound_maker = neomake#GetMaker(maker.fn(jobinfo))
-  AssertEqual bound_maker._get_argv(), expected_argv
+  AssertEqual bound_maker._get_argv(jobinfo), expected_argv
 
 Execute (neomake#utils#MakerFromCommand appends args for file_mode):
-  let maker = neomake#utils#MakerFromCommand('foo')
-  let jobinfo = {'file_mode': 0}
+  let maker = neomake#utils#MakerFromCommand('echo')
+  let jobinfo = {'file_mode': 0, 'bufnr': 0}
 
   AssertEqual maker.fn(jobinfo), {
-  \ 'args': [&shellcmdflag, 'foo'], 'exe': &shell, 'remove_invalid_entries': 0}
+  \ 'args': [&shellcmdflag, 'echo'], 'exe': &shell, 'remove_invalid_entries': 0}
 
-  file file\ with\ space
+  e! tests/fixtures/a\ filename\ with\ spaces
   let fname = expand('%:p')
   let jobinfo = {'maker': maker, 'file_mode': 1, 'bufnr': bufnr('%')}
-  AssertEqual maker.fn(jobinfo), {
-  \ 'args': [&shellcmdflag, 'foo '.fnameescape(fname)], 'append_file': 0,
-  \ 'exe': &shell, 'remove_invalid_entries': 0}
+  let bound_maker = neomake#GetMaker(maker).fn(jobinfo)
+  AssertEqual bound_maker.args, [&shellcmdflag, 'echo '.fname]
+  AssertEqual bound_maker.append_file, 0
+  AssertEqual bound_maker.exe, &shell
+  AssertEqual bound_maker.remove_invalid_entries, 0
 
 Execute (neomake#utils#Stringify):
   AssertEqual neomake#utils#Stringify(1), 1
@@ -349,3 +351,21 @@ Execute (neomake#utils#Stringify):
     AssertEqual neomake#utils#Stringify(obj.f2), "function('".(fnr_base + 1)."')"
   endif
   AssertEqual neomake#utils#Stringify(obj), "{f2: function('".(fnr_base + 1)."'), base: 1}"
+
+Execute (neomake#utils#MakerFromCommand uses tempfile):
+  let maker = neomake#utils#MakerFromCommand('echo')
+
+  new
+  let jobinfo = {'file_mode': 1, 'bufnr': bufnr('%')}
+  file dir/\ with\ spaces
+
+  set buftype=nofile
+  let bound_maker = neomake#GetMaker(maker).fn(jobinfo)
+  let temp_file = bound_maker.tempfile_name
+  AssertEqual bound_maker.args, [&shellcmdflag, 'echo '.temp_file]
+  AssertEqual bound_maker.append_file, 0
+  AssertEqual bound_maker.exe, &shell
+  AssertEqual bound_maker.remove_invalid_entries, 0
+  AssertNotEqual temp_file, fnameescape(temp_file)
+
+  bwipe

--- a/tests/utils.vader
+++ b/tests/utils.vader
@@ -369,3 +369,16 @@ Execute (neomake#utils#MakerFromCommand uses tempfile):
   AssertNotEqual temp_file, fnameescape(temp_file)
 
   bwipe
+
+Execute (neomake#utils#GetSortedFiletypes):
+  AssertEqual neomake#utils#GetSortedFiletypes('foo'), ['foo']
+  AssertEqual neomake#utils#GetSortedFiletypes('foo.bar'), ['foo', 'bar']
+  AssertEqual neomake#utils#GetSortedFiletypes('jsx.javascript'), ['jsx', 'javascript']
+  AssertEqual neomake#utils#GetSortedFiletypes('javascript.jsx'), ['jsx', 'javascript']
+  AssertEqual neomake#utils#GetSortedFiletypes('foo.jsx.javascript'), ['foo', 'jsx', 'javascript']
+  AssertEqual neomake#utils#GetSortedFiletypes('jsx.javascript.foo'), ['jsx', 'javascript', 'foo']
+
+  AssertEqual neomake#utils#GetSortedFiletypes(['foo']), ['foo']
+  AssertEqual neomake#utils#GetSortedFiletypes(['foo', 'bar']), ['foo', 'bar']
+  " If a list is passed, this gets not split on dots recursively.
+  AssertEqual neomake#utils#GetSortedFiletypes(['foo', 'bar.baz']), ['foo', 'bar.baz']


### PR DESCRIPTION
This manages active jobs in s:make_info, and keeps track of finished
ones.
It now restarts jobs for the same maker directly, instead of waiting for
the old one to do it from the exit handler.