### PR TITLE
Fix/harden some tests

### DIFF
--- a/autoload/neomake/compat.vim
+++ b/autoload/neomake/compat.vim
@@ -10,6 +10,10 @@ else
   endfunction
 endif
 
+unlockvar neomake#compat#json_true
+unlockvar neomake#compat#json_false
+unlockvar neomake#compat#json_null
+
 if exists('*json_decode')
   let neomake#compat#json_true = v:true
   let neomake#compat#json_false = v:false

--- a/tests/json.vader
+++ b/tests/json.vader
@@ -24,5 +24,6 @@ Execute (neomake#utils#JSONdecode):
   endif
 
 Execute (neomake#compat#json_null cannot be changed):
+  runtime autoload/neomake/compat.vim
   AssertThrows let g:neomake#compat#json_null = 'changed'
   AssertEqual g:vader_exception, 'Vim(let):E741: Value is locked: g:neomake#compat#json_null'

--- a/tests/lists.vader
+++ b/tests/lists.vader
@@ -44,9 +44,12 @@ Execute (AddExprCallback with changed windows inbetween):
     " Start 2 makers.
     call neomake#Make(1, [maker_1, maker_2])
     " Wait until partly finished.
-    while g:neomake_tests_postprocess_count < 2
+    let maxwait = 50
+    while g:neomake_tests_postprocess_count < 2 && maxwait
       sleep 10m
+      let maxwait -= 1
     endwhile
+    Assert maxwait > 0, 'Postprocessing was not triggered.'
     let loclist_texts = map(copy(getloclist(0)), 'v:val.text')
     AssertEqual sort(copy(loclist_texts)), ['1a SUFFIX:0', '2 SUFFIX:0']
 


### PR DESCRIPTION
"AddExprCallback with changed windows inbetween" causes the testsuite to
hang on Neovim currently, since Vim patch 7.4.2299 was merged, but
8.0.0068 was not.

Ref: https://github.com/neovim/neovim/pull/6243