### PR TITLE
Travis: simplify build by not using pip cache, nor upgrade it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,6 @@ branches:
   only:
     - master
 
-cache:
-  pip: true
-before_cache:
-  # Remove pip's debug log, which is there already with Travis' base image.
-  - rm -f $HOME/.cache/pip/log/debug.log
-
 env:
   matrix:
     - ENV=testnvim
@@ -53,11 +47,6 @@ install:
       fi
     elif [ "$ENV" = "testnvim" ]; then
       eval "$(curl -Ss https://raw.githubusercontent.com/neovim/bot-ci/master/scripts/travis-setup.sh) nightly-x64"
-    fi
-
-    if [ "${ENV#vint}" != "$ENV" ]; then
-      pip install -U pip
-      pip install -U wheel
     fi
 
 script:


### PR DESCRIPTION
It is only used for the vint build and not necessary really.