### PR TITLE
Remove \r at end of lines also with Neovim

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -1168,14 +1168,15 @@ endfunction
 " NOTE: can be skipped with Neovim 0.2.0+.
 let s:nvim_output_handler_queue = []
 function! s:nvim_output_handler(job_id, data, event_type) abort
+    let data = map(copy(a:data), "substitute(v:val, '\\r$', '', '')")
     " @vimlint(EVL108, 1)
     if has('nvim-0.2.0')
-        call s:output_handler(a:job_id, a:data, a:event_type)
+        call s:output_handler(a:job_id, data, a:event_type)
         return
     endif
     " @vimlint(EVL108, 0)
     let jobinfo = s:jobs[a:job_id]
-    let args = [a:job_id, a:data, a:event_type]
+    let args = [a:job_id, data, a:event_type]
     call add(s:nvim_output_handler_queue, args)
     if !exists('jobinfo._nvim_in_handler')
         let jobinfo._nvim_in_handler = 1

--- a/tests/processing.vader
+++ b/tests/processing.vader
@@ -237,16 +237,12 @@ Execute (100 lines of output should not get processed one by one):
   Assert len(c) < 50, 'There were 50+ count changes: '.len(c)
 
 Execute (Mixed newlines get handled correctly):
-  if has('nvim')
-    NeomakeTestsSkip 'only for Vim/Windows'
-  else
-    let maker = {
-    \ 'exe': 'printf',
-    \ 'args': 'line1\\nline2\\r\\nline3',
-    \ 'errorformat': '%m',
-    \ }
-    call neomake#Make(0, [maker])
-    NeomakeTestsWaitForFinishedJobs
-    AssertEqual map(copy(getqflist()), 'v:val.text'),
-    \ ['line1', 'line2', 'line3']
-  endif
+  let maker = {
+  \ 'exe': 'printf',
+  \ 'args': 'line1\\nline2\\r\\nline3',
+  \ 'errorformat': '%m',
+  \ }
+  call neomake#Make(0, [maker])
+  NeomakeTestsWaitForFinishedJobs
+  AssertEqual map(copy(getqflist()), 'v:val.text'),
+  \ ['line1', 'line2', 'line3']


### PR DESCRIPTION
This happens at least for the vimhelplint wrapper (to come).