### PR TITLE
Add ft makers for help files; vimhelplint wrapper

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,9 @@ install:
       fi
     elif [ "$ENV" = "testnvim" ]; then
       eval "$(curl -Ss https://raw.githubusercontent.com/neovim/bot-ci/master/scripts/travis-setup.sh) nightly-x64"
+
+      # Install vim-vimhelplint for one build.
+      make build/vimhelplint
     fi
 
 script:

--- a/Makefile
+++ b/Makefile
@@ -116,19 +116,14 @@ vimlint-errors: build/vimlint build/vimlparser
 build build/neovim-test-home:
 	mkdir $@
 build/neovim-test-home: | build
-build/vim-vimhelplint-master: | build
+build/vimhelplint: | build
 	cd build \
 	&& wget -O- https://github.com/machakann/vim-vimhelplint/archive/master.tar.gz \
-	  | tar xz
-vimhelplint: VIMHELPLINT_VIM:=vim
-vimhelplint: | build/vim-vimhelplint-master
-	out="$$($(VIMHELPLINT_VIM) -esN -c 'e doc/neomake.txt' -c 'set ft=help' \
-	  -c 'source build/vim-vimhelplint-master/ftplugin/help_lint.vim' \
-	  -c 'verb VimhelpLintEcho' -c q 2>&1)"; \
-	  if [ -n "$$out" ]; then \
-	    echo "$$out"; \
-	    exit 1; \
-	  fi
+	  | tar xz \
+	&& mv vim-vimhelplint-master vimhelplint
+vimhelplint: export VIMHELPLINT_VIM:=vim
+vimhelplint: | build/vimhelplint
+	contrib/vimhelplint doc/neomake.txt
 
 # Run tests in dockerized Vims.
 DOCKER_IMAGE:=neomake/vims-for-tests

--- a/autoload/neomake/makers/ft/help.vim
+++ b/autoload/neomake/makers/ft/help.vim
@@ -1,0 +1,26 @@
+function! neomake#makers#ft#help#EnabledMakers() abort
+  let makers = ['proselint', 'writegood']
+  if executable('vim')
+    call insert(makers, 'vimhelplint')
+  endif
+  return makers
+endfunction
+
+let s:slash = neomake#utils#Slash()
+let s:vimhelplint = expand('<sfile>:p:h:h:h:h:h', 1).s:slash.'contrib'.s:slash.'vimhelplint'
+
+function! neomake#makers#ft#help#vimhelplint() abort
+  return {
+        \ 'exe': s:vimhelplint,
+        \ 'errorformat': '%f:%l:%c:%trror:%n:%m,%f:%l:%c:%tarning:%n:%m',
+        \ 'postprocess': function('neomake#postprocess#GenericLengthPostprocess'),
+        \ }
+endfunction
+
+function! neomake#makers#ft#help#proselint() abort
+    return neomake#makers#ft#text#proselint()
+endfunction
+
+function! neomake#makers#ft#help#writegood() abort
+    return neomake#makers#ft#text#writegood()
+endfunction

--- a/contrib/vimhelplint
+++ b/contrib/vimhelplint
@@ -1,0 +1,40 @@
+#!/bin/sh
+# A wrapper around vim-vimhelp (https://github.com/machakann/vim-vimhelplint).
+# It uses vimhelplint from Neomake's build dir.
+
+# Change to parent dir (POSIXly).
+CDPATH='' cd -P -- "$(dirname -- "$0")/.." || exit
+vimhelplint=$PWD/build/vimhelplint/ftplugin/help_lint.vim
+cd - >/dev/null || exit
+
+if ! [ -f "$vimhelplint" ]; then
+  echo "$vimhelplint not found." >&2
+  echo "Run 'make build/vim-vimhelplint' Neomake's root directory to install it." >&2
+  exit 64
+fi
+
+file="$1"
+if [ -z "$file" ]; then
+  echo 'No input file specified.' >&2
+  exit 64
+fi
+if ! [ -e "$file" ]; then
+  echo "File $file is not readable." >&2
+  exit 1
+fi
+
+out=$(${VIMHELPLINT_VIM:-vim} -esN -u NONE -i NONE \
+  -c "silent edit $1" \
+  -c 'set ft=help' \
+  -c "source $vimhelplint" \
+  -c 'verb VimhelpLintEcho' \
+  -c 'qall!' 2>&1)
+if [ -z "$out" ]; then
+  exit 0
+fi
+echo "$out"
+exit 1
+
+# \   'watchdogs_checker/vimhelplint' : {
+# \     'command': 'vim',
+# \     'exec' : '%C -X -N -u NONE -i NONE -V1 -e -s -c "set rtp+=' . s:get_plugin_dir() . '" -c "silent filetype plugin on" -c "silent edit %s" -c "VimhelpLintEcho" -c "qall!"',

--- a/tests/ft_help.vader
+++ b/tests/ft_help.vader
@@ -1,0 +1,42 @@
+Include: include/setup.vader
+
+Execute (No vimhelplint issues in doc/neomake.txt):
+  if !filereadable(fnamemodify(g:vader_file, ':p:h:h').'/build/vimhelplint/ftplugin/help_lint.vim')
+    NeomakeTestsSkip 'vimhelplint not installed'
+  elseif !executable('vim')
+    NeomakeTestsSkip 'vim not found in PATH'
+  else
+    new
+    e doc/neomake.txt
+    set filetype=help
+    RunNeomake vimhelplint
+    AssertNeomakeMessage 'exit: vimhelplint: 0'
+    bwipe
+  endif
+
+Execute (vimhelplint reports errors):
+  if !filereadable(fnamemodify(g:vader_file, ':p:h:h').'/build/vimhelplint/ftplugin/help_lint.vim')
+    NeomakeTestsSkip 'vimhelplint not installed'
+  elseif !executable('vim')
+    NeomakeTestsSkip 'vim not found in PATH'
+  else
+    call writefile(['*duplicate-tag*', '*duplicate-tag*'], 'build/help.txt')
+    new
+    e build/help.txt
+    set filetype=help
+    RunNeomake vimhelplint
+    AssertEqual getloclist(0), [
+    \ {'lnum': 1, 'bufnr': bufnr('%'), 'col': 2, 'valid': 1, 'vcol': 0,
+    \  'nr': 2, 'type': 'E', 'pattern': '', 'text': 'A tag "duplicate-tag" is duplicate with another in this file.'},
+    \ {'lnum': 2, 'bufnr': bufnr('%'), 'col': 2, 'valid': 1, 'vcol': 0,
+    \  'nr': 2, 'type': 'E', 'pattern': '', 'text': 'A tag "duplicate-tag" is duplicate with another in this file.'}]
+    call delete('build/help.txt')
+    bwipe
+  endif
+
+Execute (neomake#makers#ft#help#EnabledMakers):
+  let expected = ['proselint', 'writegood']
+  if executable('vim')
+    call insert(expected, 'vimhelplint')
+  endif
+  AssertEqual expected, neomake#makers#ft#help#EnabledMakers()

--- a/tests/neomake.vader
+++ b/tests/neomake.vader
@@ -34,6 +34,7 @@ Include (Css): ft_css.vader
 Include (Idris): ft_idris.vader
 Include (Vim): ft_vim.vader
 Include (SQL): ft_sql.vader
+Include (Help): ft_help.vader
 
 ~ Regression tests
 Include (cwd: tcd): cwd-tcd.vader


### PR DESCRIPTION
This adds makers for Vim's help filetype, where vimhelplint is used
through a wrapper script (contrib/vimhelplint).