### PR TITLE
Fix "E482: Can't create file <empty>"

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -324,6 +324,7 @@ endfunction
 " Check if a temporary file is used, and set self.tempfile_name in case it is.
 function! s:maker_base._get_fname_for_buffer(bufnr) abort
     let bufname = bufname(a:bufnr)
+    let temp_file = ''
     if !len(bufname)
         let temp_file = self._get_tempfilename(a:bufnr)
         if !empty(temp_file)
@@ -355,7 +356,7 @@ function! s:maker_base._get_fname_for_buffer(bufnr) abort
         let bufname = fnamemodify(bufname, ':p')
     endif
 
-    if exists('temp_file')
+    if len(temp_file)
         let temp_dir = fnamemodify(temp_file, ':h')
         if !isdirectory(temp_dir)
             call mkdir(temp_dir, 'p', 0750)

--- a/tests/tempfiles.vader
+++ b/tests/tempfiles.vader
@@ -158,3 +158,13 @@ Execute (maker._get_argv uses jobinfo for bufnr):
 
   wincmd p
   bwipe
+
+Execute (_get_fname_for_buffer handles modified buffer with disabled tempfiles):
+  new
+  let b:neomake_tempfile_enabled = 0
+  file file1
+  set modified
+  let maker = neomake#GetMaker({})
+  let fname = maker._get_fname_for_buffer(bufnr('%'))
+  AssertEqual fname, 'file1'
+  bwipe!


### PR DESCRIPTION
Neomake would try to use an empty temporary file.