### PR TITLE
Add add standard and semistandard makers to JSX filetypes

### DIFF
--- a/autoload/neomake/makers/ft/jsx.vim
+++ b/autoload/neomake/makers/ft/jsx.vim
@@ -22,6 +22,14 @@ function! neomake#makers#ft#jsx#eslint()
     return neomake#makers#ft#javascript#eslint()
 endfunction
 
+function! neomake#makers#ft#jsx#standard()
+    return neomake#makers#ft#javascript#standard()
+endfunction
+
+function! neomake#makers#ft#jsx#semistandard()
+    return neomake#makers#ft#javascript#semistandard()
+endfunction
+
 function! neomake#makers#ft#jsx#eslint_d()
     return neomake#makers#ft#javascript#eslint_d()
 endfunction


### PR DESCRIPTION
I'm using the [`vim-jsx`](https://github.com/mxw/vim-jsx) plugin, which has a setting to use JSX in regular `.js` files by setting the filetype to `javascript.jsx`, which breaks neomake unless both the JSX _and_ JavaScript makers are enabled. ([This is a known issue with neomake](https://github.com/neomake/neomake/issues/572).)

However, I've recently upgraded this plugin and noticed that the standard maker was working fine in `javascript` filetypes, but not in `javascript.jsx` filetypes, even though I had the maker enabled for both.

It looks as though the maker lists for `jsx.vim` and `javascript.vim` are getting out of sync. This is a patch to help standard and semistandard work again in JSX files.