### PR TITLE
s:handle_next_maker: continue with next makers

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -1445,7 +1445,10 @@ function! s:handle_next_maker(prev_jobinfo) abort
         endif
 
         try
-            return s:MakeJob(make_id, options)
+            let jobinfo = s:MakeJob(make_id, options)
+            if !empty(jobinfo)
+                return jobinfo
+            endif
         catch /^Neomake: /
             let error = substitute(v:exception, '^Neomake: ', '', '')
             call neomake#utils#ErrorMessage(error, {'make_id': s:make_id})

--- a/tests/makers.vader
+++ b/tests/makers.vader
@@ -46,6 +46,23 @@ Execute (Neomake with non-existing default makers):
   RunNeomake
   AssertNeomakeMessage "Exe (maker_without_exe) of auto-configured maker maker_without_exe is not executable, skipping.", 3
 
+Execute (Neomake with non-existing default maker handles following makers):
+  call g:NeomakeSetupAutocmdWrappers()
+
+  new
+  set filetype=neomake_tests
+  Save g:neomake_test_enabledmakers
+  let g:neomake_test_enabledmakers = ['maker_without_exe', 'echo_maker']
+  RunNeomake
+  AssertNeomakeMessage 'Running makers: maker_without_exe (auto), echo_maker (auto)'
+  AssertNeomakeMessage "Exe (maker_without_exe) of auto-configured maker maker_without_exe is not executable, skipping.", 3
+  AssertEqual 1, len(g:neomake_test_jobfinished), 'echo_maker should have run'
+  AssertEqual 1, len(g:neomake_test_finished)
+
+  RunNeomake
+  AssertNeomakeMessage "Exe (maker_without_exe) of auto-configured maker maker_without_exe is not executable, skipping.", 3
+  bwipe
+
 Execute (Neomake with non-existing default makers, explicitly called):
   Save &filetype
   set filetype=neomake_tests


### PR DESCRIPTION
In case s:MakeJob returns `{}` (e.g. because the `exe` does not exist)
we should continue with the next maker.