### PR TITLE
Add Elm maker using elm-make

### DIFF
--- a/autoload/neomake/makers/ft/elm.vim
+++ b/autoload/neomake/makers/ft/elm.vim
@@ -8,48 +8,44 @@ function! neomake#makers#ft#elm#elmMake() abort
     return {
         \ 'exe': 'elm-make',
         \ 'args': ['--report=json', '--output=' . neomake#utils#DevNull()],
-        \ 'mapexpr': 'neomake#makers#ft#elm#ElmMakeMapexpr(v:val)',
-        \ 'errorformat':
-            \ '[%t%n] "%f" %l:%v %m,'.
-            \ '[%t] "%f" %l:%v %m',
-        \ 'postprocess': function('neomake#makers#ft#elm#ElmMakePostProcess')
+        \ 'process_output': function('neomake#makers#ft#elm#ElmMakeProcessOutput')
         \ }
 endfunction
 
-function! neomake#makers#ft#elm#ElmMakeMapexpr(val) abort
-    if a:val[0] !=# '['
-        return
+function! neomake#makers#ft#elm#ElmMakeProcessOutput(context) abort
+    " output will be a List, containing a JSON string of an array of objects
+    if a:context.output[0][0] !=# '['
+        return []
     endif
-    let l:decoded = neomake#utils#JSONdecode(a:val)
+    let l:decoded = neomake#utils#JSONdecode(a:context.output[0])
     if type(l:decoded) == type([])
-      for item in l:decoded
-        if get(item, 'type', '') ==# 'warning'
-          let l:code = 'W'
-        else
-          let l:code = 'E'
-        endif
+        let l:errors = []
+        for item in l:decoded
+            if get(item, 'type', '') ==# 'warning'
+                let l:code = 'W'
+            else
+                let l:code = 'E'
+            endif
 
-        let l:type = item['tag']
-        let l:message = item['overview']
-        let l:region_start = item['region']['start']
-        let l:region_end = item['region']['end']
-        let l:row = l:region_start['line']
-        let l:col = l:region_start['column']
-        let l:length = l:region_end['column'] - l:region_start['column']
-        let l:file = item['file']
+            let l:compiler_error = item['tag']
+            let l:message = item['overview']
+            let l:region_start = item['region']['start']
+            let l:region_end = item['region']['end']
+            let l:row = l:region_start['line']
+            let l:col = l:region_start['column']
+            let l:length = l:region_end['column'] - l:region_start['column']
 
-        let l:error = '[' . l:code . '] "' . l:file . '" ' .
-                    \ l:row . ':' . l:col .  ' ' . l:length . ' ' .
-                    \ l:type . ' : ' . l:message
-        return l:error
-      endfor
-    endif
-endfunction
-
-function! neomake#makers#ft#elm#ElmMakePostProcess(entry) abort
-    let l:lines = split(a:entry.text, ' ')
-    if len(l:lines)
-        let a:entry.text = join(l:lines[1:])
-        let a:entry.length = str2nr(l:lines[0])
+            let l:error = {
+                        \ 'text': l:compiler_error . ' : ' . l:message,
+                        \ 'type': l:code,
+                        \ 'lnum': l:row,
+                        \ 'col': l:col,
+                        \ 'length': l:length,
+                        \ }
+            call add(l:errors, l:error)
+        endfor
+        return l:errors
+    else
+        return []
     endif
 endfunction

--- a/autoload/neomake/makers/ft/elm.vim
+++ b/autoload/neomake/makers/ft/elm.vim
@@ -1,0 +1,55 @@
+" vim: ts=4 sw=4 et
+
+function! neomake#makers#ft#elm#EnabledMakers() abort
+    return ['elmMake']
+endfunction
+
+function! neomake#makers#ft#elm#elmMake() abort
+    return {
+        \ 'exe': 'elm-make',
+        \ 'args': ['--report=json', '--output=' . neomake#utils#DevNull()],
+        \ 'mapexpr': 'neomake#makers#ft#elm#ElmMakeMapexpr(v:val)',
+        \ 'errorformat':
+            \ '[%t%n] "%f" %l:%v %m,'.
+            \ '[%t] "%f" %l:%v %m',
+        \ 'postprocess': function('neomake#makers#ft#elm#ElmMakePostProcess')
+        \ }
+endfunction
+
+function! neomake#makers#ft#elm#ElmMakeMapexpr(val) abort
+    if a:val[0] !=# '['
+        return
+    endif
+    let l:decoded = neomake#utils#JSONdecode(a:val)
+    if type(l:decoded) == type([])
+      for item in l:decoded
+        if get(item, 'type', '') ==# 'warning'
+          let l:code = 'W'
+        else
+          let l:code = 'E'
+        endif
+
+        let l:type = item['tag']
+        let l:message = item['overview']
+        let l:region_start = item['region']['start']
+        let l:region_end = item['region']['end']
+        let l:row = l:region_start['line']
+        let l:col = l:region_start['column']
+        let l:length = l:region_end['column'] - l:region_start['column']
+        let l:file = item['file']
+
+        let l:error = '[' . l:code . '] "' . l:file . '" ' .
+                    \ l:row . ':' . l:col .  ' ' . l:length . ' ' .
+                    \ l:type . ' : ' . l:message
+        return l:error
+      endfor
+    endif
+endfunction
+
+function! neomake#makers#ft#elm#ElmMakePostProcess(entry) abort
+    let l:lines = split(a:entry.text, ' ')
+    if len(l:lines)
+        let a:entry.text = join(l:lines[1:])
+        let a:entry.length = str2nr(l:lines[0])
+    endif
+endfunction

--- a/tests/ft_elm.vader
+++ b/tests/ft_elm.vader
@@ -3,64 +3,30 @@ Include: include/setup.vader
 Execute (elmMake parses success message):
   let json = 'Successfully generated /dev/null'
 
-  Save &errorformat
-  let &errorformat = neomake#makers#ft#elm#elmMake().errorformat
-  let error = neomake#makers#ft#elm#ElmMakeMapexpr(json)
+  let result = neomake#makers#ft#elm#elmMake().process_output({'output': [json]})
 
-  AssertEqual 0, error
+  AssertEqual [], result
 
-Execute (elmMake error message):
+Execute (elmMake parses error message):
   let json = '[{"tag":"BAD MAIN TYPE","overview":"The `main` value has an unsupported type.","subregion":null,"details":"I need Html, Svg, or a Program so I have something to render on screen, but you\ngave me:\n\n    String","region":{"start":{"line":6,"column":1},"end":{"line":6,"column":5}},"type":"error","file":"Bingo.elm"}]'
 
-  Save &errorformat
-  let &errorformat = neomake#makers#ft#elm#elmMake().errorformat
+  let result = neomake#makers#ft#elm#elmMake().process_output({'output': [json]})
 
-  let error = neomake#makers#ft#elm#ElmMakeMapexpr(json)
-
-  AssertEqual '[E] "Bingo.elm" 6:1 4 BAD MAIN TYPE : The `main` value has an unsupported type.', error
-
-  cgetexpr error
-
-  let result = getqflist()[0]
-  unlet result.bufnr
-
-  call neomake#makers#ft#elm#ElmMakePostProcess(result)
-
-  AssertEqual {
+  AssertEqual [{
     \ 'type': 'E',
-    \ 'nr': -1,
     \ 'lnum': 6,
     \ 'col': 1,
     \ 'length': 4,
-    \ 'valid': 1,
-    \ 'vcol': 1,
-    \ 'pattern': '',
-    \ 'text': 'BAD MAIN TYPE : The `main` value has an unsupported type.'}, result
+    \ 'text': 'BAD MAIN TYPE : The `main` value has an unsupported type.'}], result
 
-Execute (elmMake warning message):
+Execute (elmMake parses warning message):
   let json = '[{"tag":"unused import","overview":"Module `Html` is unused.","details":"Best to remove it. Don''t save code quality for later!","region":{"start":{"line":3,"column":1},"end":{"line":3,"column":12}},"type":"warning","file":"Bingo.elm"}]'
 
-  Save &errorformat
-  let &errorformat = neomake#makers#ft#elm#elmMake().errorformat
+  let result = neomake#makers#ft#elm#elmMake().process_output({'output': [json]})
 
-  let error = neomake#makers#ft#elm#ElmMakeMapexpr(json)
-
-  AssertEqual '[W] "Bingo.elm" 3:1 11 unused import : Module `Html` is unused.', error
-
-  cgetexpr error
-
-  let result = getqflist()[0]
-  unlet result.bufnr
-
-  call neomake#makers#ft#elm#ElmMakePostProcess(result)
-
-  AssertEqual {
+  AssertEqual [{
     \ 'type': 'W',
-    \ 'nr': -1,
     \ 'lnum': 3,
     \ 'col': 1,
     \ 'length': 11,
-    \ 'valid': 1,
-    \ 'vcol': 1,
-    \ 'pattern': '',
-    \ 'text': 'unused import : Module `Html` is unused.'}, result
+    \ 'text': 'unused import : Module `Html` is unused.'}], result

--- a/tests/ft_elm.vader
+++ b/tests/ft_elm.vader
@@ -1,0 +1,66 @@
+Include: include/setup.vader
+
+Execute (elmMake parses success message):
+  let json = 'Successfully generated /dev/null'
+
+  Save &errorformat
+  let &errorformat = neomake#makers#ft#elm#elmMake().errorformat
+  let error = neomake#makers#ft#elm#ElmMakeMapexpr(json)
+
+  AssertEqual 0, error
+
+Execute (elmMake error message):
+  let json = '[{"tag":"BAD MAIN TYPE","overview":"The `main` value has an unsupported type.","subregion":null,"details":"I need Html, Svg, or a Program so I have something to render on screen, but you\ngave me:\n\n    String","region":{"start":{"line":6,"column":1},"end":{"line":6,"column":5}},"type":"error","file":"Bingo.elm"}]'
+
+  Save &errorformat
+  let &errorformat = neomake#makers#ft#elm#elmMake().errorformat
+
+  let error = neomake#makers#ft#elm#ElmMakeMapexpr(json)
+
+  AssertEqual '[E] "Bingo.elm" 6:1 4 BAD MAIN TYPE : The `main` value has an unsupported type.', error
+
+  cgetexpr error
+
+  let result = getqflist()[0]
+  unlet result.bufnr
+
+  call neomake#makers#ft#elm#ElmMakePostProcess(result)
+
+  AssertEqual {
+    \ 'type': 'E',
+    \ 'nr': -1,
+    \ 'lnum': 6,
+    \ 'col': 1,
+    \ 'length': 4,
+    \ 'valid': 1,
+    \ 'vcol': 1,
+    \ 'pattern': '',
+    \ 'text': 'BAD MAIN TYPE : The `main` value has an unsupported type.'}, result
+
+Execute (elmMake warning message):
+  let json = '[{"tag":"unused import","overview":"Module `Html` is unused.","details":"Best to remove it. Don''t save code quality for later!","region":{"start":{"line":3,"column":1},"end":{"line":3,"column":12}},"type":"warning","file":"Bingo.elm"}]'
+
+  Save &errorformat
+  let &errorformat = neomake#makers#ft#elm#elmMake().errorformat
+
+  let error = neomake#makers#ft#elm#ElmMakeMapexpr(json)
+
+  AssertEqual '[W] "Bingo.elm" 3:1 11 unused import : Module `Html` is unused.', error
+
+  cgetexpr error
+
+  let result = getqflist()[0]
+  unlet result.bufnr
+
+  call neomake#makers#ft#elm#ElmMakePostProcess(result)
+
+  AssertEqual {
+    \ 'type': 'W',
+    \ 'nr': -1,
+    \ 'lnum': 3,
+    \ 'col': 1,
+    \ 'length': 11,
+    \ 'valid': 1,
+    \ 'vcol': 1,
+    \ 'pattern': '',
+    \ 'text': 'unused import : Module `Html` is unused.'}, result

--- a/tests/neomake.vader
+++ b/tests/neomake.vader
@@ -31,6 +31,7 @@ Include (Python): ft_python.vader
 Include (Shell): ft_sh.vader
 Include (Text): ft_text.vader
 Include (Elixir): ft_elixir.vader
+Include (Elm): ft_elm.vader
 Include (PHP): ft_php.vader
 Include (Cs): ft_cs.vader
 Include (Css): ft_css.vader


### PR DESCRIPTION
This adds a maker for [Elm](http://elm-lang.org/). The compiler
errors provided by elm are quite detailed, but this only adds
handling for the base error/warning types and short messages.

This maker relies on the JSON output of elm-make and is *heavily*
based on #942 (it's basically a carbon copy).

![](https://cl.ly/0F2T3Q0m2T3p/Image%202017-03-15%20at%206.14.57%20PM.png)