### PR TITLE
add flow maker for jsx filetypes

### DIFF
--- a/autoload/neomake/makers/ft/jsx.vim
+++ b/autoload/neomake/makers/ft/jsx.vim
@@ -8,6 +8,10 @@ function! neomake#makers#ft#jsx#EnabledMakers()
     return ['jshint', 'eslint']
 endfunction
 
+function! neomake#makers#ft#jsx#flow()
+    return neomake#makers#ft#javascript#flow()
+endfunction
+
 function! neomake#makers#ft#jsx#jshint()
     let maker = neomake#makers#ft#javascript#jshint()
     let maker.exe = 'jsxhint'


### PR DESCRIPTION
Copying the flow maker over so it's available for jsx filetypes. Didn't think this needed a test, but please advise.