### PR TITLE
Adds missing js.vim makers to jsx.vim

### DIFF
--- a/autoload/neomake/makers/ft/jsx.vim
+++ b/autoload/neomake/makers/ft/jsx.vim
@@ -1,32 +1,32 @@
 " vim: ts=4 sw=4 et
 
-function! neomake#makers#ft#jsx#SupersetOf()
+function! neomake#makers#ft#jsx#SupersetOf() abort
     return 'javascript'
 endfunction
 
-function! neomake#makers#ft#jsx#EnabledMakers()
+function! neomake#makers#ft#jsx#EnabledMakers() abort
     return ['jshint', 'eslint']
 endfunction
 
-function! neomake#makers#ft#jsx#jshint()
+function! neomake#makers#ft#jsx#jshint() abort
     let maker = neomake#makers#ft#javascript#jshint()
     let maker.exe = 'jsxhint'
     return maker
 endfunction
 
-function! neomake#makers#ft#jsx#jsxhint()
+function! neomake#makers#ft#jsx#jsxhint() abort
     return neomake#makers#ft#jsx#jshint()
 endfunction
 
-function! neomake#makers#ft#jsx#eslint()
+function! neomake#makers#ft#jsx#eslint() abort
     return neomake#makers#ft#javascript#eslint()
 endfunction
 
-function! neomake#makers#ft#jsx#eslint_d()
+function! neomake#makers#ft#jsx#eslint_d() abort
     return neomake#makers#ft#javascript#eslint_d()
 endfunction
 
-function! neomake#makers#ft#jsx#rjsx()
+function! neomake#makers#ft#jsx#rjsx() abort
     return neomake#makers#ft#javascript#rjsx()
 endfunction
 

--- a/autoload/neomake/makers/ft/jsx.vim
+++ b/autoload/neomake/makers/ft/jsx.vim
@@ -29,3 +29,7 @@ endfunction
 function! neomake#makers#ft#jsx#rjsx()
     return neomake#makers#ft#javascript#rjsx()
 endfunction
+
+function! neomake#makers#ft#jsx#flow() abort
+    return neomake#makers#ft#javascript#flow()
+endfunction

--- a/autoload/neomake/makers/ft/jsx.vim
+++ b/autoload/neomake/makers/ft/jsx.vim
@@ -26,6 +26,14 @@ function! neomake#makers#ft#jsx#eslint_d() abort
     return neomake#makers#ft#javascript#eslint_d()
 endfunction
 
+function! neomake#makers#ft#jsx#standard() abort
+    return neomake#makers#ft#javascript#standard()
+endfunction
+
+function! neomake#makers#ft#jsx#semistandard() abort
+    return neomake#makers#ft#javascript#semistandard()
+endfunction
+
 function! neomake#makers#ft#jsx#rjsx() abort
     return neomake#makers#ft#javascript#rjsx()
 endfunction


### PR DESCRIPTION
This adds the Flow, Standard, and Semistandard makers from javascript.vim to jsx.vim, and updates the functions to have the abort attribute.

Rolls in changes from #1085, #1114, and #1121 with vint passing on Travis. 