### PR TITLE
Fix handling of multiple fts (foo.bar)

### DIFF
--- a/autoload/neomake/makers/ft/angular.vim
+++ b/autoload/neomake/makers/ft/angular.vim
@@ -1,26 +1,9 @@
-" vim: ts=4 sw=4 et
-
-function! neomake#makers#ft#angular#SupersetOf()
+function! neomake#makers#ft#angular#SupersetOf() abort
     return 'javascript'
 endfunction
 
-function! neomake#makers#ft#angular#EnabledMakers()
+function! neomake#makers#ft#angular#EnabledMakers() abort
     return ['jshint', 'eslint', 'jscs']
 endfunction
 
-function! neomake#makers#ft#angular#jshint()
-    return neomake#makers#ft#javascript#jshint()
-endfunction
-
-function! neomake#makers#ft#angular#eslint()
-    return neomake#makers#ft#javascript#eslint()
-endfunction
-
-function! neomake#makers#ft#angular#eslint_d()
-    return neomake#makers#ft#javascript#eslint_d()
-endfunction
-
-function! neomake#makers#ft#angular#jscs()
-    return neomake#makers#ft#javascript#jscs()
-endfunction
-
+" vim: ts=4 sw=4 et

--- a/autoload/neomake/makers/ft/jasmine.vim
+++ b/autoload/neomake/makers/ft/jasmine.vim
@@ -1,25 +1,9 @@
-" vim: ts=4 sw=4 et
-
-function! neomake#makers#ft#jasmine#SupersetOf()
+function! neomake#makers#ft#jasmine#SupersetOf() abort
     return 'javascript'
 endfunction
 
-function! neomake#makers#ft#jasmine#EnabledMakers()
+function! neomake#makers#ft#jasmine#EnabledMakers() abort
     return ['jshint', 'eslint', 'jscs']
 endfunction
 
-function! neomake#makers#ft#jasmine#jshint()
-    return neomake#makers#ft#javascript#jshint()
-endfunction
-
-function! neomake#makers#ft#jasmine#eslint()
-    return neomake#makers#ft#javascript#eslint()
-endfunction
-
-function! neomake#makers#ft#jasmine#eslint_d()
-    return neomake#makers#ft#javascript#eslint_d()
-endfunction
-
-function! neomake#makers#ft#jasmine#jscs()
-    return neomake#makers#ft#javascript#jscs()
-endfunction
+" vim: ts=4 sw=4 et

--- a/autoload/neomake/makers/ft/jsx.vim
+++ b/autoload/neomake/makers/ft/jsx.vim
@@ -1,31 +1,13 @@
-" vim: ts=4 sw=4 et
-
-function! neomake#makers#ft#jsx#SupersetOf()
+function! neomake#makers#ft#jsx#SupersetOf() abort
     return 'javascript'
 endfunction
 
-function! neomake#makers#ft#jsx#EnabledMakers()
+function! neomake#makers#ft#jsx#EnabledMakers() abort
     return ['jshint', 'eslint']
 endfunction
 
-function! neomake#makers#ft#jsx#jshint()
-    let maker = neomake#makers#ft#javascript#jshint()
-    let maker.exe = 'jsxhint'
-    return maker
+function! neomake#makers#ft#jsx#jsxhint() abort
+    return neomake#makers#ft#javascript#jshint()
 endfunction
 
-function! neomake#makers#ft#jsx#jsxhint()
-    return neomake#makers#ft#jsx#jshint()
-endfunction
-
-function! neomake#makers#ft#jsx#eslint()
-    return neomake#makers#ft#javascript#eslint()
-endfunction
-
-function! neomake#makers#ft#jsx#eslint_d()
-    return neomake#makers#ft#javascript#eslint_d()
-endfunction
-
-function! neomake#makers#ft#jsx#rjsx()
-    return neomake#makers#ft#javascript#rjsx()
-endfunction
+" vim: ts=4 sw=4 et

--- a/autoload/neomake/makers/ft/node.vim
+++ b/autoload/neomake/makers/ft/node.vim
@@ -1,25 +1,9 @@
-" vim: ts=4 sw=4 et
-
-function! neomake#makers#ft#node#SupersetOf()
+function! neomake#makers#ft#node#SupersetOf() abort
     return 'javascript'
 endfunction
 
-function! neomake#makers#ft#node#EnabledMakers()
+function! neomake#makers#ft#node#EnabledMakers() abort
     return ['jshint', 'eslint', 'jscs']
 endfunction
 
-function! neomake#makers#ft#node#jshint()
-    return neomake#makers#ft#javascript#jshint()
-endfunction
-
-function! neomake#makers#ft#node#eslint()
-    return neomake#makers#ft#javascript#eslint()
-endfunction
-
-function! neomake#makers#ft#node#eslint_d()
-    return neomake#makers#ft#javascript#eslint_d()
-endfunction
-
-function! neomake#makers#ft#node#jscs()
-    return neomake#makers#ft#javascript#jscs()
-endfunction
+" vim: ts=4 sw=4 et

--- a/autoload/neomake/makers/ft/tsx.vim
+++ b/autoload/neomake/makers/ft/tsx.vim
@@ -1,19 +1,15 @@
-" vim: ts=4 sw=4 et
-
-function! neomake#makers#ft#tsx#SupersetOf()
+function! neomake#makers#ft#tsx#SupersetOf() abort
     return 'typescript'
 endfunction
 
-function! neomake#makers#ft#tsx#EnabledMakers()
+function! neomake#makers#ft#tsx#EnabledMakers() abort
     return ['tsc', 'tslint']
 endfunction
 
-function! neomake#makers#ft#tsx#tsc()
+function! neomake#makers#ft#tsx#tsc() abort
     let config = neomake#makers#ft#typescript#tsc()
     let config.args = config.args + ['--jsx', 'preserve']
     return config
 endfunction
 
-function! neomake#makers#ft#tsx#tslint()
-    return neomake#makers#ft#typescript#tslint()
-endfunction
+" vim: ts=4 sw=4 et

--- a/autoload/neomake/utils.vim
+++ b/autoload/neomake/utils.vim
@@ -282,23 +282,6 @@ function! neomake#utils#load_ft_maker(ft) abort
     endif
 endfunction
 
-" Attempt to get list of filetypes in order of most specific to least specific.
-" NOTE: Obsolete, not used anymore.
-function! neomake#utils#GetSortedFiletypes(fts) abort
-    function! CompareFiletypes(ft1, ft2) abort
-        if neomake#utils#GetSupersetOf(a:ft1) ==# a:ft2
-            return -1
-        elseif neomake#utils#GetSupersetOf(a:ft2) ==# a:ft1
-            return 1
-        else
-            return 0
-        endif
-    endfunction
-
-    let fts = type(a:fts) == type('') ? split(a:fts, '\.') : a:fts
-    return sort(copy(fts), function('CompareFiletypes'))
-endfunction
-
 function! neomake#utils#get_ft_confname(ft) abort
     return substitute(a:ft, '\W', '_', 'g')
 endfunction

--- a/autoload/neomake/utils.vim
+++ b/autoload/neomake/utils.vim
@@ -258,15 +258,32 @@ function! neomake#utils#MakerFromCommand(command) abort
     return maker
 endfunction
 
+let s:super_ft_cache = {}
 function! neomake#utils#GetSupersetOf(ft) abort
-    try
-        return eval('neomake#makers#ft#' . a:ft . '#SupersetOf()')
-    catch /^Vim\%((\a\+)\)\=:\(E117\|E121\)/
-        return ''
-    endtry
+    if !has_key(s:super_ft_cache, a:ft)
+        call neomake#utils#load_ft_maker(a:ft)
+        let SupersetOf = 'neomake#makers#ft#'.a:ft.'#SupersetOf'
+        if exists('*'.SupersetOf)
+            let s:super_ft_cache[a:ft] = call(SupersetOf, [])
+        else
+            let s:super_ft_cache[a:ft] = ''
+        endif
+    endif
+    return s:super_ft_cache[a:ft]
+endfunction
+
+let s:loaded_ft_maker_runtime = []
+function! neomake#utils#load_ft_maker(ft) abort
+    " Load ft maker, but only once (for performance reasons and to allow for
+    " monkeypatching it in tests).
+    if index(s:loaded_ft_maker_runtime, a:ft) == -1
+        exe 'runtime autoload/neomake/makers/ft/'.a:ft.'.vim'
+        call add(s:loaded_ft_maker_runtime, a:ft)
+    endif
 endfunction
 
 " Attempt to get list of filetypes in order of most specific to least specific.
+" NOTE: Obsolete, not used anymore.
 function! neomake#utils#GetSortedFiletypes(fts) abort
     function! CompareFiletypes(ft1, ft2) abort
         if neomake#utils#GetSupersetOf(a:ft1) ==# a:ft2
@@ -282,13 +299,40 @@ function! neomake#utils#GetSortedFiletypes(fts) abort
     return sort(copy(fts), function('CompareFiletypes'))
 endfunction
 
+function! neomake#utils#get_ft_confname(ft) abort
+    return substitute(a:ft, '\W', '_', 'g')
+endfunction
+
+" Resolve filetype a:ft into a list of filetypes suitable for config vars
+" (i.e. 'foo.bar' => ['foo_bar', 'foo', 'bar']).
+function! neomake#utils#get_config_fts(ft) abort
+    let r = []
+    let fts = split(a:ft, '\.')
+    for ft in fts
+        call add(r, ft)
+        let super_ft = neomake#utils#GetSupersetOf(ft)
+        if !empty(super_ft) && index(fts, super_ft) == -1
+            call add(r, super_ft)
+        endif
+    endfor
+    if len(fts) > 1
+      call insert(r, a:ft, 0)
+    endif
+    return map(r, 'neomake#utils#get_ft_confname(v:val)')
+endfunction
+
 let s:unset = {}  " Sentinel.
 
 " Get a setting by key, based on filetypes, from the buffer or global
 " namespace, defaulting to default.
-function! neomake#utils#GetSetting(key, maker, default, fts, bufnr) abort
+function! neomake#utils#GetSetting(key, maker, default, ft, bufnr) abort
   let maker_name = has_key(a:maker, 'name') ? a:maker.name : ''
-  for ft in a:fts + ['']
+  if len(a:ft)
+      let fts = neomake#utils#get_config_fts(a:ft) + ['']
+  else
+      let fts = ['']
+  endif
+  for ft in fts
     " Look through the override vars for a filetype maker, like
     " neomake_scss_sasslint_exe (should be a string), and
     " neomake_scss_sasslint_args (should be a list).

--- a/tests/filetypes.vader
+++ b/tests/filetypes.vader
@@ -2,7 +2,11 @@ Include: include/setup.vader
 
 Execute (GetEnabledMakers for javascript.jsx):
   AssertEqual map(neomake#GetEnabledMakers('javascript.jsx'), 'v:val.name'),
-  \ ['jshint', 'eslint', 'jshint', 'jscs', 'eslint']
+  \ ['jshint', 'jscs', 'eslint']
+
+Execute (GetEnabledMakers for jsx.javascript):
+  AssertEqual map(neomake#GetEnabledMakers('jsx.javascript'), 'v:val.name'),
+  \ ['jshint', 'eslint']
 
 Execute (GetEnabledMakers for javascript):
   AssertEqual map(neomake#GetEnabledMakers('javascript'), 'v:val.name'),
@@ -15,33 +19,82 @@ Execute (GetEnabledMakers for jsx):
 
 Execute (GetMakers for javascript.jsx):
   AssertEqual neomake#GetMakers('javascript.jsx'),
-  \ ['eslint', 'eslint_d', 'jshint', 'jsxhint', 'rjsx', 'flow', 'gjslint', 'jscs', 'semistandard', 'standard', 'xo']
+  \ ['eslint', 'eslint_d', 'flow', 'gjslint', 'jscs', 'jshint', 'rjsx', 'semistandard', 'standard', 'xo', 'jsxhint']
+
+Execute (GetMakers for jsx.javascript):
+  " jsxhint comes first, since it is defined in jsx.vim.
+  let expected = ['jsxhint', 'eslint', 'eslint_d', 'flow', 'gjslint', 'jscs', 'jshint', 'rjsx', 'semistandard', 'standard', 'xo']
+  AssertEqual neomake#GetMakers('jsx.javascript'), expected
+
+  Save b:neomake_jsx_javascript_foo_maker
+  let b:neomake_jsx_javascript_foo_maker = {'name': 'foo'}
+  AssertEqual neomake#GetMakers('jsx.javascript'), ['foo'] + expected
 
 Execute (GetMakers for javascript):
   AssertEqual neomake#GetMakers('javascript'),
   \ ['eslint', 'eslint_d', 'flow', 'gjslint', 'jscs', 'jshint', 'rjsx', 'semistandard', 'standard', 'xo']
 
 Execute (GetMakers for jsx):
-  AssertEqual neomake#GetMakers('jsx'),
-  \ ['eslint', 'eslint_d', 'jshint', 'jsxhint', 'rjsx']
+  AssertEqual neomake#GetMakers('jsx'), ['jsxhint'] + neomake#GetMakers('javascript')
 
 Execute (standard maker in javascript.jsx):
   new
   set filetype=javascript.jsx
+  AssertEqual map(neomake#GetEnabledMakers('jsx'), 'v:val.name'), ['jshint', 'eslint']
   let b:neomake_javascript_enabled_makers = ['standard']
   let b:neomake_javascript_standard_exe = 'true'
   let b:neomake_jsx_jshint_exe = 'true'
   let b:neomake_jsx_eslint_exe = 'true'
   AssertEqual map(neomake#GetEnabledMakers('javascript'), 'v:val.name'), ['standard']
-  AssertEqual map(neomake#GetEnabledMakers('jsx'), 'v:val.name'), ['jshint', 'eslint']
-  AssertEqual map(neomake#GetEnabledMakers('jsx.javascript'), 'v:val.name'), ['jshint', 'eslint', 'standard']
+  AssertEqual map(neomake#GetEnabledMakers('jsx'), 'v:val.name'), ['standard']
+  AssertEqual map(neomake#GetEnabledMakers('jsx.javascript'), 'v:val.name'), ['standard']
   AssertEqual neomake#utils#GetSortedFiletypes('jsx.javascript'), ['jsx', 'javascript']
   Neomake
   NeomakeTestsWaitForFinishedJobs
-  AssertNeomakeMessage 'Running makers: jshint (auto), eslint (auto), standard'
+  AssertNeomakeMessage 'Running makers: standard'
 
+  function! F() abort
+    return map(copy(neomake#GetEnabledMakers('jsx.javascript')),
+    \ '[v:val.name, v:val.exe]')
+  endfunction
+  AssertEqual F(), [['standard', 'true']]
   let b:neomake_jsx_enabled_makers = ['standard']
+  AssertEqual F(), [['standard', 'true']]
+  let b:neomake_jsx_standard_exe = 'exe1'
+  AssertEqual F(), [['standard', 'exe1']]
+  let b:neomake_jsx_javascript_standard_exe = 'exe2'
+  AssertEqual F(), [['standard', 'exe2']]
+
   Neomake
   NeomakeTestsWaitForFinishedJobs
   AssertNeomakeMessage 'Running makers: standard'
+  bwipe
+
+Execute (standard maker in javascript.jsx):
+  new
+  let b:neomake_jsx_javascript_enabled_makers = ['standard']
+  AssertEqual map(neomake#GetEnabledMakers('jsx.javascript'), 'v:val.name'), ['standard']
+  let b:neomake_javascript_jsx_enabled_makers = ['standard']
+  AssertEqual map(neomake#GetEnabledMakers('javascript.jsx'), 'v:val.name'), ['standard']
+  bwipe
+
+Execute (makers are picked up via SupersetOf for jsx):
+  new
+  let b:neomake_javascript_enabled_makers = ['eslint']
+  let b:neomake_jsx_enabled_makers = ['flow']
+
+  let maker = neomake#GetMaker('flow', 'jsx.javascript')
+  AssertEqual maker.name, 'flow'
+
+  let maker = neomake#GetMaker('jsxhint', 'jsx')
+  AssertEqual maker.name, 'jsxhint'
+  AssertEqual maker.exe, 'jsxhint'
+
+  let b:neomake_javascript_jshint_exe = 'customexe'
+  AssertEqual neomake#GetMaker('jshint', 'javascript').exe, 'customexe'
+  AssertThrows call neomake#GetMaker('jsxhint', 'javascript')
+  AssertEqual g:vader_exception, 'Neomake: Maker not found (for filetype javascript): jsxhint'
+  " Should not use jshint_exe config.
+  AssertEqual neomake#GetMaker('jsxhint', 'jsx').exe, 'jsxhint'
+
   bwipe

--- a/tests/filetypes.vader
+++ b/tests/filetypes.vader
@@ -48,7 +48,6 @@ Execute (standard maker in javascript.jsx):
   AssertEqual map(neomake#GetEnabledMakers('javascript'), 'v:val.name'), ['standard']
   AssertEqual map(neomake#GetEnabledMakers('jsx'), 'v:val.name'), ['standard']
   AssertEqual map(neomake#GetEnabledMakers('jsx.javascript'), 'v:val.name'), ['standard']
-  AssertEqual neomake#utils#GetSortedFiletypes('jsx.javascript'), ['jsx', 'javascript']
   Neomake
   NeomakeTestsWaitForFinishedJobs
   AssertNeomakeMessage 'Running makers: standard'

--- a/tests/integration.vader
+++ b/tests/integration.vader
@@ -243,6 +243,14 @@ Execute (NeomakeInfo with FuncRef):
   endfor
   bwipe
 
+Execute (NeomakeInfo with unusual filetype):
+  new
+  " Workaround for Vim's runtime/ftplugin/ruby.vim not liking HOME=/dev/null.
+  set filetype=ft1.gentoo-package-keywords
+  let info = split(neomake#utils#redir('NeomakeInfo'), '\n')
+  Assert index(info, 'NOTE: you can define g:neomake_ft1_gentoo_package_keywords_enabled_makers to configure it (or b:neomake_ft1_gentoo_package_keywords_enabled_makers).') != -1, 'Line was found'
+  bwipe
+
 Execute (Having an invalid &errorformat is OK):
   Save &errorformat
   let &efm = '%E%W'

--- a/tests/lists.vader
+++ b/tests/lists.vader
@@ -19,6 +19,9 @@ Execute (Postprocessing should update list):
   RunNeomake sh
   AssertEqual getloclist(0), expected_list
 
+  " Undo monkeypatching.
+  runtime autoload/neomake/makers/ft/sh.vim
+
 Execute (AddExprCallback with changed windows inbetween):
   if NeomakeAsyncTestsSetup()
     let g:neomake_tests_postprocess_count = 0

--- a/tests/makers.vader
+++ b/tests/makers.vader
@@ -19,7 +19,7 @@ Execute (neomake#GetEnabledMakers without make_id):
   Save g:neomake_myft_enabled_makers
   let g:neomake_myft_enabled_makers = ['nonexisting_custom']
   let makers = neomake#GetEnabledMakers('myft')
-  AssertNeomakeMessage "Maker not found (for filetypes ['myft']): nonexisting_custom", 0, {}
+  AssertNeomakeMessage "Maker not found (for filetype myft): nonexisting_custom", 0, {}
 
 Execute (Neomake with non-existing maker (configured)):
   Save &filetype
@@ -31,7 +31,7 @@ Execute (Neomake with non-existing maker (configured)):
   let make_id_before = neomake#GetStatus().last_make_id
   RunNeomake
   let make_id = neomake#GetStatus().last_make_id
-  AssertNeomakeMessage "Maker not found (for filetypes ['myft']): nonexisting_custom", 0, {'make_id': make_id}
+  AssertNeomakeMessage "Maker not found (for filetype myft): nonexisting_custom", 0, {'make_id': make_id}
   AssertNeomakeMessage 'Nothing to make: no enabled file mode makers.', 3, {'make_id': make_id}
   AssertEqual len(g:neomake_test_messages), 2
   AssertEqual make_id_before + 1, neomake#GetStatus().last_make_id
@@ -44,7 +44,7 @@ Execute (Neomake with non-existing default makers):
   Save g:neomake_test_enabledmakers
   let g:neomake_test_enabledmakers = ['maker_without_exe', 'nonexisting']
   RunNeomake
-  AssertNeomakeMessage "Maker not found (for filetypes ['neomake_tests']): nonexisting", 3
+  AssertNeomakeMessage "Maker not found (for filetype neomake_tests): nonexisting", 3
   AssertNeomakeMessage "Exe (maker_without_exe) of auto-configured maker maker_without_exe is not executable, skipping.", 3
   AssertNeomakeMessage 'Nothing to make: no valid makers.', 3
   AssertEqual 0, len(g:neomake_test_jobfinished)
@@ -79,12 +79,13 @@ Execute (Neomake with non-existing default makers, explicitly called):
   AssertNeomakeMessage "Exe (maker_without_exe) of maker maker_without_exe is not executable.", 3
 
 Execute (neomake#GetEnabledMakers with defaults):
-  Save &filetype
+  new
   set filetype=neomake_tests
   let makers = neomake#GetEnabledMakers(&ft)
   AssertEqual map(copy(makers), 'v:val.auto_enabled'), [1]
-  AssertNeomakeMessage "Maker not found (for filetypes ['neomake_tests']): nonexisting", 3
+  AssertNeomakeMessage "Maker not found (for filetype neomake_tests): nonexisting", 3
   AssertEqual len(g:neomake_test_messages), 1
+  bwipe
 
 Execute (neomake#GetEnabledMakers with configuration):
   Save &filetype
@@ -128,7 +129,7 @@ Execute (neomake#GetEnabledMakers without filetype):
 
 Execute (neomake#GetMaker errors):
   AssertThrows call neomake#GetMaker('cargo', 'foo')
-  AssertEqual g:vader_exception, "Neomake: Maker not found (for filetypes ['foo']): cargo"
+  AssertEqual g:vader_exception, "Neomake: Maker not found (for filetype foo): cargo"
 
 Execute (neomake#GetMaker for project maker):
   Save g:neomake_enabled_makers
@@ -136,7 +137,7 @@ Execute (neomake#GetMaker for project maker):
   set ft=myft
 
   AssertThrows call neomake#GetMaker('cargo', 'foo')
-  AssertEqual g:vader_exception, "Neomake: Maker not found (for filetypes ['foo']): cargo"
+  AssertEqual g:vader_exception, "Neomake: Maker not found (for filetype foo): cargo"
 
 Execute (maker.fn can set env var):
   let maker = {

--- a/tests/neomake.vader
+++ b/tests/neomake.vader
@@ -70,9 +70,18 @@ Execute (Neomake with unknown maker):
   Neomake doesnotexist
   let make_id = neomake#GetStatus().last_make_id
   AssertEqual g:neomake_test_messages, [
-  \ [0, 'Maker not found (for filetypes []): doesnotexist', {'make_id': make_id}],
-  \ [3, 'Nothing to make: no valid makers.', {}],
-  \ ]
+  \ [0, 'Maker not found (for empty filetype): doesnotexist', {'make_id': make_id}],
+  \ [3, 'Nothing to make: no valid makers.', {}]]
+
+Execute (Neomake with unknown maker for multiple fts):
+  new
+  set filetype=ft1.ft2
+  Neomake doesnotexist
+  let make_id = neomake#GetStatus().last_make_id
+  AssertEqual g:neomake_test_messages, [
+  \ [0, 'Maker not found (for filetype ft1.ft2): doesnotexist', {'make_id': make_id}],
+  \ [3, 'Nothing to make: no valid makers.', {}]]
+  bwipe
 
 Execute (neomake#GetMaker uses defined errorformat with makeprg):
   Save &errorformat

--- a/tests/serialize.vader
+++ b/tests/serialize.vader
@@ -289,7 +289,7 @@ Execute (Uses correct maker filetypes when started in another buffer):
     NeomakeTestsWaitForFinishedJobs
 
     AssertEqual g:neomake_test_exit_cb[1], {'status': 0, 'name': 'maker2', 'has_next': 0}
-    AssertEqual g:neomake_test_exit_cb[0].maker.fts, ['orig_ft']
+    AssertEqual g:neomake_test_exit_cb[0].maker.ft, 'orig_ft'
 
     bwipe
   endif

--- a/tests/utils.vader
+++ b/tests/utils.vader
@@ -39,9 +39,10 @@ Execute (neomake#utils#GetSetting serialize):
   let g:maker = {'name': 'mymaker'}
   function! GetSetting()
     return neomake#utils#GetSetting('serialize', g:maker, 'default',
-                                  \ ['myft'], bufnr('%'))
+                                  \ 'myft', bufnr('%'))
   endfunction
 
+  new
   Save g:neomake_serialize, b:neomake_serialize
   Save g:neomake_mymaker_serialize, b:neomake_mymaker_serialize
   Save g:neomake_myft_mymaker_serialize, b:neomake_myft_mymaker_serialize
@@ -103,13 +104,24 @@ Execute (neomake#utils#GetSetting serialize):
   AssertEqual GetSetting(), 98
   let g:maker = {}
   AssertEqual GetSetting(), 98
+  bwipe
+
+Execute (neomake#utils#GetSetting for multiple fts):
+  new
+  function! GetSetting(key)
+    return neomake#utils#GetSetting(a:key, {}, 'default',
+                                  \ 'jsx.javascript', bufnr('%'))
+  endfunction
+  let b:neomake_jsx_javascript_setting = '1'
+  AssertEqual GetSetting('setting'), '1'
+  bwipe
 
 Execute (neomake#utils#GetSetting accepts lists):
   Save g:maker
   let g:maker = {'name': 'mymaker'}
   function! GetSetting()
     return neomake#utils#GetSetting('args', g:maker, 'default',
-                                  \ ['myft'], bufnr('%'))
+                                  \ 'myft', bufnr('%'))
   endfunction
 
   Save g:neomake_myft_mymaker_args, b:neomake_myft_mymaker_args
@@ -130,7 +142,7 @@ Execute (neomake#utils#GetSetting without name):
   let g:maker = {}
   function! GetSetting(key)
     return neomake#utils#GetSetting(a:key, g:maker, [],
-                                  \ ['myft'], bufnr('%'))
+                                  \ 'myft', bufnr('%'))
   endfunction
   AssertEqual GetSetting('args'), []
 
@@ -383,3 +395,14 @@ Execute (neomake#utils#GetSortedFiletypes):
   AssertEqual neomake#utils#GetSortedFiletypes(['foo', 'bar']), ['foo', 'bar']
   " If a list is passed, this gets not split on dots recursively.
   AssertEqual neomake#utils#GetSortedFiletypes(['foo', 'bar.baz']), ['foo', 'bar.baz']
+
+Execute (neomake#utils#get_config_fts):
+  function! F(ft) abort
+    return neomake#utils#get_config_fts(a:ft)
+  endfunction
+  AssertEqual F('foo'), ['foo']
+  AssertEqual F('foo.bar'), ['foo_bar', 'foo', 'bar']
+  AssertEqual F('bar.foo'), ['bar_foo', 'bar', 'foo']
+  AssertEqual F('jsx.javascript'), ['jsx_javascript', 'jsx', 'javascript']
+  AssertEqual F('javascript.jsx'), ['javascript_jsx', 'javascript', 'jsx']
+  AssertEqual F('jsx'), ['jsx', 'javascript']

--- a/tests/utils.vader
+++ b/tests/utils.vader
@@ -383,19 +383,6 @@ Execute (neomake#utils#MakerFromCommand uses tempfile):
 
   bwipe
 
-Execute (neomake#utils#GetSortedFiletypes):
-  AssertEqual neomake#utils#GetSortedFiletypes('foo'), ['foo']
-  AssertEqual neomake#utils#GetSortedFiletypes('foo.bar'), ['foo', 'bar']
-  AssertEqual neomake#utils#GetSortedFiletypes('jsx.javascript'), ['jsx', 'javascript']
-  AssertEqual neomake#utils#GetSortedFiletypes('javascript.jsx'), ['jsx', 'javascript']
-  AssertEqual neomake#utils#GetSortedFiletypes('foo.jsx.javascript'), ['foo', 'jsx', 'javascript']
-  AssertEqual neomake#utils#GetSortedFiletypes('jsx.javascript.foo'), ['jsx', 'javascript', 'foo']
-
-  AssertEqual neomake#utils#GetSortedFiletypes(['foo']), ['foo']
-  AssertEqual neomake#utils#GetSortedFiletypes(['foo', 'bar']), ['foo', 'bar']
-  " If a list is passed, this gets not split on dots recursively.
-  AssertEqual neomake#utils#GetSortedFiletypes(['foo', 'bar.baz']), ['foo', 'bar.baz']
-
 Execute (neomake#utils#get_config_fts):
   function! F(ft) abort
     return neomake#utils#get_config_fts(a:ft)


### PR DESCRIPTION
 - filetype is not split by default anymore, but a new function is added
   to get a list of name for config lookups.  This will now also look at
   `g:neomake_foo_bar_maker_exe` for filetype=foo.bar.
   Fixes https://github.com/neomake/neomake/issues/272.
   Fixes https://github.com/neomake/neomake/issues/492.
 - This makes use of the optional SupersetOf callback (used by
   jsx/jsx.javascript) to get makers from the parent.
   Ref: https://github.com/neomake/neomake/pull/1122#issuecomment-287498327

Fixes https://github.com/neomake/neomake/issues/572.