### PR TITLE
Fix pandoc after making markdown use SupersetOf

### DIFF
--- a/autoload/neomake/makers/ft/pandoc.vim
+++ b/autoload/neomake/makers/ft/pandoc.vim
@@ -1,19 +1,7 @@
+function! neomake#makers#ft#pandoc#SupersetOf() abort
+    return 'markdown'
+endfunction
+
 function! neomake#makers#ft#pandoc#EnabledMakers() abort
     return neomake#makers#ft#markdown#EnabledMakers()
-endfunction
-
-function! neomake#makers#ft#pandoc#mdl() abort
-    return neomake#makers#ft#markdown#mdl()
-endfunction
-
-function! neomake#makers#ft#pandoc#markdownlint() abort
-    return neomake#makers#ft#markdown#markdownlint()
-endfunction
-
-function! neomake#makers#ft#pandoc#proselint() abort
-    return neomake#makers#ft#markdown#proselint()
-endfunction
-
-function! neomake#makers#ft#pandoc#writegood() abort
-    return neomake#makers#ft#markdown#writegood()
 endfunction

--- a/autoload/neomake/utils.vim
+++ b/autoload/neomake/utils.vim
@@ -294,9 +294,15 @@ function! neomake#utils#get_config_fts(ft) abort
     for ft in fts
         call add(r, ft)
         let super_ft = neomake#utils#GetSupersetOf(ft)
-        if !empty(super_ft) && index(fts, super_ft) == -1
-            call add(r, super_ft)
-        endif
+        while !empty(super_ft)
+            if empty(super_ft)
+                break
+            endif
+            if index(fts, super_ft) == -1
+                call add(r, super_ft)
+            endif
+            let super_ft = neomake#utils#GetSupersetOf(super_ft)
+        endwhile
     endfor
     if len(fts) > 1
       call insert(r, a:ft, 0)

--- a/tests/ft_pandoc.vader
+++ b/tests/ft_pandoc.vader
@@ -1,0 +1,3 @@
+Execute (pandoc: makers):
+  AssertEqual neomake#GetMakers('pandoc'),
+  \ ['alex', 'markdownlint', 'mdl', 'proselint', 'writegood']

--- a/tests/neomake.vader
+++ b/tests/neomake.vader
@@ -39,6 +39,7 @@ Include (SQL): ft_sql.vader
 Include (Help): ft_help.vader
 Include (Asciidoc): ft_asciidoc.vader
 Include (Markdown): ft_markdown.vader
+Include (Pandoc): ft_pandoc.vader
 
 ~ Regression tests
 Include (cwd: tcd): cwd-tcd.vader


### PR DESCRIPTION
SupersetOf can be chained now.

Fixes https://github.com/neomake/neomake/issues/1141.