### PR TITLE
dict based config

### DIFF
--- a/autoload/neomake/config.vim
+++ b/autoload/neomake/config.vim
@@ -1,0 +1,147 @@
+let g:neomake#config#undefined = {}
+
+" Resolve a:name (split on dots) and init a:dict accordingly.
+function! s:resolve_name(dict, name) abort
+    let c = a:dict
+    let parts = split(a:name, '\.')
+    for p in parts[0:-2]
+        if !has_key(c, p)
+            let c[p] = {}
+        endif
+        let c = c[p]
+    endfor
+    return [c, parts[-1]]
+endfunction
+
+" Get a:name (resolved; split on dots) from a:dict, using a:context.
+function! s:get(dict, name, context) abort
+    let ft = has_key(a:context, 'ft') ? a:context.ft : &filetype
+    let parts = split(a:name, '\.')
+    let prefixes = ['']
+    if !empty(ft)
+        call insert(prefixes, 'ft.'.ft.'.', 0)
+    endif
+    for prefix in prefixes
+        let [c, k] = s:resolve_name(a:dict, prefix.join(parts[0:-1], '.'))
+        if has_key(c, k)
+            return c[k]
+        endif
+    endfor
+    return g:neomake#config#undefined
+endfunction
+
+" Get a:name from config.
+" Optional args:
+"  - a:1: default
+"  - a:2: context
+function! neomake#config#get(name, ...) abort
+    let Default = a:0 ? a:1 : g:neomake#config#undefined
+    let context = a:0 > 1 ? a:2 : {}
+    if a:name =~# '^b:'
+        if !has_key(context, 'bufnr')
+            let context.bufnr = bufnr('%')
+        endif
+        let name = a:name[2:-1]
+    else
+        let name = a:name
+    endif
+    let bufnr = has_key(context, 'bufnr') ? context.bufnr : bufnr('%')
+
+    for lookup in [
+                \ getbufvar(bufnr, 'neomake'),
+                \ get(t:, 'neomake', {}),
+                \ get(g:, 'neomake', {}),
+                \ get(context, 'maker', {})]
+        if !empty(lookup)
+            let R = s:get(lookup, name, context)
+            if R isnot# g:neomake#config#undefined
+                return R
+            endif
+        endif
+        unlet! lookup R  " old vim
+    endfor
+    return Default
+endfunction
+
+" Get a:name from config with information about the setting's source.
+" This is mostly the same as neomake#config#get, but kept seperate since it
+" is not used as much (?!).
+" Optional args:
+"  - a:1: default
+"  - a:2: context
+function! neomake#config#get_with_source(name, ...) abort
+    let Default = a:0 ? a:1 : g:neomake#config#undefined
+    let context = a:0 > 1 ? a:2 : {}
+    if a:name =~# '^b:'
+        if !has_key(context, 'bufnr')
+            let context.bufnr = bufnr('%')
+        endif
+        let name = a:name[2:-1]
+    else
+        let name = a:name
+    endif
+    let bufnr = has_key(context, 'bufnr') ? context.bufnr : bufnr('%')
+
+    for [source, lookup] in [
+                \ ['buffer', getbufvar(bufnr, 'neomake')],
+                \ ['tab', get(t:, 'neomake', {})],
+                \ ['global', get(g:, 'neomake', {})],
+                \ ['maker', get(context, 'maker', {})]]
+        if !empty(lookup)
+            let R = s:get(lookup, name, context)
+            if R isnot# g:neomake#config#undefined
+                return [R, source]
+            endif
+        endif
+        unlet! lookup R  " old vim
+    endfor
+    return [Default, 'default']
+endfunction
+
+
+" Set a:name in a:dict to a:value, after resolving it (split on dots).
+function! s:set(dict, name, value) abort
+    let [c, k] = s:resolve_name(a:dict, a:name)
+    let c[k] = a:value
+    return c
+endfunction
+
+" Set a:name (resolved on dots) to a:value in the config.
+function! neomake#config#set(name, value) abort
+    if a:name =~# '^b:'
+        return neomake#config#set_buffer(bufnr('%'), a:name[2:-1], a:value)
+    endif
+    if !has_key(g:, 'neomake')
+        let g:neomake = {}
+    endif
+    return s:set(g:neomake, a:name, a:value)
+endfunction
+
+" Set a:name (resolved on dots) to a:value for buffer a:bufnr.
+function! neomake#config#set_buffer(bufnr, name, value) abort
+    let bufnr = +a:bufnr
+    let bneomake = getbufvar(bufnr, 'neomake')
+    if bneomake is# ''
+        unlet bneomake  " old vim
+        let bneomake = {}
+        call setbufvar(bufnr, 'neomake', bneomake)
+    endif
+    return s:set(bneomake, a:name, a:value)
+endfunction
+
+" Set a:name (resolved on dots) to a:value in a:scope.
+" This is meant for advanced usage, e.g.:
+"   set_scope(t:, 'neomake.disabled', 1)
+function! neomake#config#set_dict(dict, name, value) abort
+    return s:set(a:dict, a:name, a:value)
+endfunction
+
+" Unset a:name (resolved on dots).
+" This is meant for advanced usage, e.g.:
+"   unset_dict(t:, 'neomake.disabled', 1)
+function! neomake#config#unset_dict(dict, name) abort
+    let [c, k] = s:resolve_name(a:dict, a:name)
+    if has_key(c, k)
+        unlet c[k]
+    endif
+endfunction

--- a/autoload/neomake/utils.vim
+++ b/autoload/neomake/utils.vim
@@ -320,6 +320,17 @@ let s:unset = {}  " Sentinel.
 " Get a setting by key, based on filetypes, from the buffer or global
 " namespace, defaulting to default.
 function! neomake#utils#GetSetting(key, maker, default, ft, bufnr) abort
+    " Check new-style config.
+    " Add maker and bufnr to context only if g:neomake or b:neomake exist.
+    let context = {'ft': a:ft}
+    if exists('g:neomake') || !empty(getbufvar(a:bufnr, 'neomake'))
+        call extend(context, {'maker': a:maker, 'bufnr': a:bufnr})
+    endif
+    let Ret = neomake#config#get(a:key, g:neomake#config#undefined, context)
+    if Ret isnot g:neomake#config#undefined
+        return Ret
+    endif
+
     let maker_name = has_key(a:maker, 'name') ? a:maker.name : ''
     if !empty(a:ft)
         let fts = neomake#utils#get_config_fts(a:ft) + ['']

--- a/tests/config.vader
+++ b/tests/config.vader
@@ -1,0 +1,118 @@
+Include: include/setup.vader
+
+Execute (neomake#config#get: basic):
+  Save g:neomake
+  new
+
+  AssertEqual neomake#config#get('foo', 'default'), 'default'
+  let g:neomake = {}
+  AssertEqual neomake#config#get('foo', 'default'), 'default'
+  let g:neomake = {'foo': 'global'}
+  AssertEqual neomake#config#get('foo', 'default'), 'global'
+  let b:neomake = {}
+  AssertEqual neomake#config#get('foo', 'default'), 'global'
+  let b:neomake = {'foo': 'buffer'}
+  AssertEqual neomake#config#get('foo', 'default'), 'buffer'
+
+  let maker = {'foo': 'maker'}
+  let jobinfo = {'maker': maker}
+  AssertEqual neomake#config#get('foo', 'default', jobinfo), 'buffer'
+  unlet b:neomake
+  AssertEqual neomake#config#get('foo', 'default', jobinfo), 'global'
+  unlet g:neomake
+  AssertEqual neomake#config#get('foo', 'default', jobinfo), 'maker'
+  let jobinfo.maker = {}
+  AssertEqual neomake#config#get('foo', 'default', jobinfo), 'default'
+
+  bwipe
+
+Execute (neomake#config#get with filetypes):
+  Save g:neomake
+  new
+
+  set filetype=myft
+
+  AssertEqual neomake#config#get('foo', []), []
+  let g:neomake = {'foo': ['maker1']}
+  AssertEqual neomake#config#get('foo', 'default'), ['maker1']
+
+  let g:neomake = {'ft': {'myft': {'foo': ['myft_maker']}}}
+  AssertEqual neomake#config#get('foo', 'default'), ['myft_maker']
+
+  bwipe
+
+Execute (neomake#config#get with b: prefix, no default and bufnr context):
+  new
+  let b:neomake = {'foo': 'bar'}
+  AssertEqual neomake#config#get('b:foo'), 'bar'
+  unlet b:neomake
+
+  let b:neomake = {'autolint': {'ignore_filetypes': ['startify']}}
+  AssertEqual neomake#config#get('b:autolint.ignore_filetypes'), ['startify']
+
+  let bufnr = bufnr('%')
+  new
+  AssertEqual neomake#config#get('b:autolint.ignore_filetypes', [],
+  \ {'bufnr': bufnr}), ['startify']
+
+  bwipe
+  bwipe
+
+Execute (neomake#config#set):
+  Save g:neomake
+  let config = neomake#config#set('foo', 'bar')
+  AssertEqual config, {'foo': 'bar'}
+  AssertEqual g:neomake, {'foo': 'bar'}
+  unlet g:neomake
+
+  call neomake#config#set('autolint.ignore_filetypes', ['startify'])
+  AssertEqual g:neomake, {'autolint': {'ignore_filetypes': ['startify']}}
+
+Execute (neomake#config#set_buffer):
+  new
+  let bufnr = bufnr('%')
+  call neomake#config#set_buffer(bufnr, 'foo', 'bar')
+  AssertEqual b:neomake, {'foo': 'bar'}
+  unlet b:neomake
+
+  call neomake#config#set_buffer(bufnr, 'autolint.ignore_filetypes', ['startify'])
+  let expected = {'autolint': {'ignore_filetypes': ['startify']}}
+  AssertEqual b:neomake, expected
+  b#
+
+  AssertEqual getbufvar(bufnr, 'neomake'), expected
+  b#
+  bwipe!
+
+Execute (neomake#config#set with b: prefix):
+  new
+  call neomake#config#set('b:foo', 'bar')
+  AssertEqual b:neomake, {'foo': 'bar'}
+  unlet b:neomake
+
+  call neomake#config#set('b:autolint.ignore_filetypes', ['startify'])
+  AssertEqual b:neomake, {'autolint': {'ignore_filetypes': ['startify']}}
+  bwipe!
+
+Execute (neomake#config#get handles Funcref variables):
+  new
+
+  function! NeomakeTestsF()
+  endfunction
+  let Funcref = function('NeomakeTestsF')
+
+  call neomake#config#set('b:function', Funcref)
+  AssertEqual neomake#config#get('b:function'), Funcref
+  AssertEqual neomake#config#get_with_source('b:function'), [Funcref, 'buffer']
+
+  bwipe
+
+Execute (neomake#config#{un,}set_dict):
+  let foo = {}
+  call neomake#config#set_dict(foo, 'bar.baz', 42)
+  AssertEqual foo, {'bar': {'baz': 42}}
+
+  call neomake#config#unset_dict(foo, 'bar.baz')
+  AssertEqual foo, {'bar': {}}
+  call neomake#config#unset_dict(foo, 'bar')
+  AssertEqual foo, {}

--- a/tests/neomake.vader
+++ b/tests/neomake.vader
@@ -5,6 +5,7 @@
 ~ Features
 Include (Completion): completion.vader
 Include (Compat): compat.vader
+Include (Config): config.vader
 Include (Current working dir): cwd.vader
 Include (Environment variables): env.vader
 Include (Error handling): errors.vader

--- a/tests/utils.vader
+++ b/tests/utils.vader
@@ -157,6 +157,23 @@ Execute (neomake#utils#GetSetting without name):
   let g:neomake_myft_setting = {'custom': 1}
   AssertEqual GetSetting('setting'), {'custom': 1}
 
+Execute (neomake#utils#GetSetting with new-style config):
+  Save g:neomake
+  new
+  set ft=neomake_tests
+
+  let b:neomake_neomake_tests_foo = 'bar'
+  let maker = {'foo': 'baz'}
+  AssertEqual neomake#utils#GetSetting(
+  \ 'foo', maker, -1, 'neomake_tests', bufnr('%')), 'bar'
+
+  " New-style global setting overrides old-style buffer setting?!
+  call neomake#config#set('ft.neomake_tests.foo', 'new_bar')
+  AssertEqual neomake#utils#GetSetting(
+  \ 'foo', maker, -1, 'neomake_tests', bufnr('%')), 'new_bar'
+
+  bwipe
+
 Execute(neomake#utils#redir):
   command! NeomakeTestCommand echo 1 | echo 2
   command! NeomakeTestErrorCommand echoerr 'error'


### PR DESCRIPTION
This will lookup config settings in b:config, g:config, and has support
for `context` (for filetype and bufnr) (where `context.maker` is also
looked at in the end).

The idea is to prefer the new format, and fallback to looking up the current scheme.
I am not sure if it should be deprecated really, since it allows for easier one-shot configs (`let g:neomake_someft_maker_args` vs `g:neomake['ft:someft']['maker']['args']`, where you have to initialize the dict(s).
`g:neomake['ft:someft']['maker']['args']` is not really supported in this PR as of now.

My main intention for this is with the automaking, where I would like to have some config namespace, i.e. `g:neomake.automake` would allow to override other settings in the `automake` context.

TODO:
 - [x] ensure that it behaves like neomake#utils#GetSetting
 - [ ] doc