### PR TITLE
Remove neomake#compat#writefile

### DIFF
--- a/autoload/neomake/compat.vim
+++ b/autoload/neomake/compat.vim
@@ -69,22 +69,6 @@ lockvar neomake#compat#json_true
 lockvar neomake#compat#json_false
 lockvar neomake#compat#json_null
 
-if has('patch-7.4.503')
-    function! neomake#compat#writefile(lines, fname, flags) abort
-        return writefile(a:lines, a:fname, a:flags)
-    endfunction
-else
-    " Assume v7.3.150 with fix for readline()
-    function! neomake#compat#writefile(lines, fname, flags) abort
-        if a:flags =~# 'a' && filereadable(a:fname)
-          let lines = readfile(a:fname, a:flags) + a:lines
-        else
-          let lines = a:lines
-        endif
-        return writefile(lines, a:fname, a:flags)
-    endfunction
-endif
-
 if exists('*uniq')
     function! neomake#compat#uniq(l) abort
 	return uniq(a:l)

--- a/autoload/neomake/utils.vim
+++ b/autoload/neomake/utils.vim
@@ -4,6 +4,10 @@ scriptencoding utf-8
 let s:level_to_name = {0: 'error  ', 1: 'warning', 2: 'verbose', 3: 'debug  '}
 let s:short_level_to_name = {0: 'E', 1: 'W', 2: 'V', 3: 'D'}
 
+" Use 'append' with writefile, but only if it is available.  Otherwise, just
+" overwrite the file.
+let s:logfile_writefile_opts = has('patch-7.4.503') ? 'a' : ''
+
 if exists('*reltimefloat')
     function! s:reltimefloat() abort
         return reltimefloat(reltime())
@@ -111,9 +115,9 @@ function! neomake#utils#LogMessage(level, msg, ...) abort
         if !exists('timediff')
             let timediff = s:reltime_lastmsg()
         endif
-        call neomake#compat#writefile([printf('%s [%s %s] %s',
+        call writefile([printf('%s [%s %s] %s',
                     \ date, s:short_level_to_name[a:level], timediff, msg)],
-                    \ logfile, 'a')
+                    \ logfile, s:logfile_writefile_opts)
     endif
     " @vimlint(EVL104, 0, l:timediff)
 endfunction

--- a/doc/neomake.txt
+++ b/doc/neomake.txt
@@ -409,6 +409,8 @@ the verbosity temporarily: >
 Setting this to a file path will write all messages (regardless of the level
 configured through |g:neomake_verbose|) into it.
 This is useful for debugging/hacking, and when reporting issues.
+It requires Vim 7.4.503+ (or Neovim) to work properly, otherwise it will not
+append, but overwrite the file with each message.
 
                                                                *neomake-signs*
 *g:neomake_place_signs*

--- a/tests/utils.vader
+++ b/tests/utils.vader
@@ -6,7 +6,11 @@ Execute (neomake#utils#LogMessage writes to logfile always):
   let g:neomake_logfile = tempname()
   call neomake#utils#LogMessage(1, 'msg0')
   call neomake#utils#LogMessage(1, 'msg1')
-  let logfile_msg = readfile(g:neomake_logfile)[1]
+  if has('patch-7.4.503')
+    let logfile_msg = readfile(g:neomake_logfile)[1]
+  else
+    let logfile_msg = readfile(g:neomake_logfile)[0]
+  endif
   Assert logfile_msg =~# '\v\d\d:\d\d:\d\d \[W      \] msg1$', 'unexpected msg: '.logfile_msg
 
   sleep 10m


### PR DESCRIPTION
It was used for neomake_logfile only, and there it does not make sense
to simulate appending to the file by writing it completely again, since
that does not work as expected with `tail -f` etc.
Without patch-7.4.503 it will now just overwrite the logfile for every
log message.