### PR TITLE
tests: cleanup/improve vimrc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,8 +55,7 @@ _SED_HIGHLIGHT_ERRORS:=| contrib/highlight-log vader
 _REDIR_STDOUT:=2>&1 </dev/null >/dev/null $(_SED_HIGHLIGHT_ERRORS) >&2
 _run_vim: | build $(TESTS_VADER_DIR)
 _run_vim:
-	@echo $(TEST_VIM_PREFIX) $(TEST_VIM) -u $(TEST_VIMRC) -i NONE $(VIM_ARGS) >&2
-	@$(TEST_VIM_PREFIX) $(TEST_VIM) -u $(TEST_VIMRC) -i NONE $(VIM_ARGS) $(_REDIR_STDOUT)
+	$(TEST_VIM_PREFIX) $(TEST_VIM) --noplugin -Nu $(TEST_VIMRC) -i NONE $(VIM_ARGS) $(_REDIR_STDOUT)
 
 # Interactive tests, keep Vader open.
 _run_interactive: VADER:=Vader
@@ -132,7 +131,7 @@ DOCKER_IMAGE_DIGEST=:$(DOCKER_TAG)
 DOCKER_IMAGE=$(DOCKER_REPO)$(DOCKER_IMAGE_DIGEST)
 DOCKER_STREAMS:=-ti
 DOCKER=docker run $(DOCKER_STREAMS) --rm \
-       -v $(PWD):/testplugin -v $(abspath $(TESTS_VADER_DIR)):/home/plugins/vader $(DOCKER_IMAGE)
+       -v $(PWD):/testplugin -v $(abspath $(TESTS_VADER_DIR)):/testplugin/tests/vim/plugins/vader $(DOCKER_IMAGE)
 docker_image:
 	docker build -f Dockerfile.tests -t $(DOCKER_REPO):$(DOCKER_TAG) .
 docker_push:

--- a/tests/vim/vimrc
+++ b/tests/vim/vimrc
@@ -1,17 +1,19 @@
 " Based on https://github.com/tweekmonster/braceless.vim/blob/master/test/vim/vimrc
 " TODO: provide this by default in the Docker image already?!  e.g. /vimrc?!
 
-if filereadable('/rtp.vim')
-  " Dockerized tests.
-  source /rtp.vim
+set noloadplugins
+
+if exists('$TESTS_VADER_DIR')
+  let vader_dir = expand($TESTS_VADER_DIR)
 else
-  if exists('$TESTS_VADER_DIR')
-    exe 'set runtimepath+='.$TESTS_VADER_DIR
-  else
-    let &runtimepath .= ','.expand('<sfile>:p:h').'/plugins/vader'
-  endif
-  let &runtimepath .= ','.expand('<sfile>:p:h').'/../..'
+  let vader_dir = expand('<sfile>:p:h').'/plugins/vader'
 endif
+let &runtimepath .= ','.vader_dir
+exe 'source' vader_dir.'/plugin/vader.vim'
+
+let plugin_dir = expand('<sfile>:p:h:h:h')
+let &runtimepath .= ','.plugin_dir
+exe 'source' plugin_dir.'/plugin/neomake.vim'
 
 filetype plugin indent on
 
@@ -20,8 +22,6 @@ augroup ssshhhhhh
   autocmd GUIEnter * set visualbell t_vb=
 augroup END
 
-" Required for Vim.
-set nocompatible
 set noswapfile
 syntax on
 set number


### PR DESCRIPTION
This sets 'noloadplugins' to skip loading of global plugins, but only
user-defined ones (in case HOME would not be set to a temporary dir).

Vader and Neomake are then sourced manually.