### PR TITLE
Fix writing of temp files regarding EOL

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -372,8 +372,7 @@ function! s:command_maker_base._get_fname_for_buffer(jobinfo) abort
         if !isdirectory(temp_dir)
             call mkdir(temp_dir, 'p', 0750)
         endif
-        call writefile(getbufline(bufnr, 1, '$'), temp_file, 'b')
-
+        call neomake#utils#write_tempfile(bufnr, temp_file)
         let bufname = temp_file
         let a:jobinfo.tempfile_name = temp_file
     endif

--- a/autoload/neomake/utils.vim
+++ b/autoload/neomake/utils.vim
@@ -540,3 +540,16 @@ function! neomake#utils#shellescape(arg) abort
     return shellescape(a:arg)
   endif
 endfunction
+
+function! neomake#utils#write_tempfile(bufnr, temp_file) abort
+    let buflines = getbufline(a:bufnr, 1, '$')
+    " Special case: empty buffer; do not write an empty line in this case.
+    if len(buflines) > 1 || buflines != ['']
+        if getbufvar(a:bufnr, '&endofline')
+                    \ || (!getbufvar(a:bufnr, '&binary')
+                    \     && (!exists('+fixendofline') || getbufvar(a:bufnr, '&fixendofline')))
+            call add(buflines, '')
+        endif
+    endif
+    call writefile(buflines, a:temp_file, 'b')
+endfunction

--- a/tests/tempfiles.vader
+++ b/tests/tempfiles.vader
@@ -174,10 +174,60 @@ Execute (_get_fname_for_buffer handles modified buffer with disabled tempfiles):
 
 Execute (_get_fname_for_buffer does not add trailing newline):
   new
-  normal! iline1
-  let b:neomake_tempfile_enabled = 1
   let maker = neomake#GetMaker({})
   let jobinfo = {'bufnr': bufnr('%'), 'ft': ''}
+  let b:neomake_tempfile_enabled = 1
+  call maker._get_fname_for_buffer(jobinfo)
+  AssertEqual readfile(jobinfo.tempfile_name), []
+  normal! iline1
   call maker._get_fname_for_buffer(jobinfo)
   AssertEqual readfile(jobinfo.tempfile_name), ['line1']
   bwipe!
+
+Execute (neomake#utils#write_tempfile):
+  Save &endofline, &binary
+  let vim_temp = tempname()
+  let neomake_temp = tempname()
+
+  if !exists('+fixeol')
+    NeomakeTestsSkip 'Skipping +fixeol variants'
+    let variants = [
+    \ 'endofline   binary',
+    \ 'endofline   nobinary',
+    \ 'noendofline binary',
+    \ 'noendofline nobinary',
+    \ ]
+  else
+    Save &fixeol
+    let variants = [
+    \ 'fixeol   endofline   binary',
+    \ 'fixeol   endofline   nobinary',
+    \ 'fixeol   noendofline binary',
+    \ 'fixeol   noendofline nobinary',
+    \ 'nofixeol endofline   binary',
+    \ 'nofixeol endofline   nobinary',
+    \ 'nofixeol noendofline binary',
+    \ 'nofixeol noendofline nobinary',
+    \ ]
+  endif
+
+  for variant in variants
+    new
+    let bufnr = bufnr('%')
+    exe 'set' variant
+
+    exe 'w!' vim_temp
+    new
+    call neomake#utils#write_tempfile(bufnr, neomake_temp)
+    AssertEqual readfile(vim_temp, 'b'), readfile(neomake_temp, 'b')
+
+    b#
+    normal! ifoo
+    exe 'w!' vim_temp
+    b#
+    call neomake#utils#write_tempfile(bufnr, neomake_temp)
+    AssertEqual readfile(vim_temp, 'b'), readfile(neomake_temp, 'b')
+
+    bwipe!
+    bwipe
+  endfor


### PR DESCRIPTION
Moves it to neomake#utils#write_tempfile and adds tests to ensure it
behaves like (Neo)Vims `:write` regarding the various options.