### PR TITLE
Migrate to cargo-check in cargo.vim maker by default

### DIFF
--- a/autoload/neomake/makers/ft/rust.vim
+++ b/autoload/neomake/makers/ft/rust.vim
@@ -22,8 +22,9 @@ function! neomake#makers#ft#rust#rustc() abort
 endfunction
 
 function! neomake#makers#ft#rust#cargo() abort
+    let maker_command = get(g:, 'neomake_rust_cargo_command', ['check'])
     return {
-        \ 'args': ['test', '--no-run', '--message-format=json', '--quiet'],
+        \ 'args': maker_command + ['--message-format=json', '--quiet'],
         \ 'append_file': 0,
         \ 'errorformat':
             \ '[%t%n] "%f" %l:%v %m,'.

--- a/autoload/neomake/makers/ft/rust.vim
+++ b/autoload/neomake/makers/ft/rust.vim
@@ -22,7 +22,8 @@ function! neomake#makers#ft#rust#rustc() abort
 endfunction
 
 function! neomake#makers#ft#rust#cargo() abort
-    let maker_command = get(b:, 'neomake_rust_cargo_command', ['check'])
+    let maker_command = get(b:, 'neomake_rust_cargo_command',
+                \ get(g:, 'neomake_rust_cargo_command', ['check']))
     return {
         \ 'args': maker_command + ['--message-format=json', '--quiet'],
         \ 'append_file': 0,

--- a/autoload/neomake/makers/ft/rust.vim
+++ b/autoload/neomake/makers/ft/rust.vim
@@ -22,7 +22,7 @@ function! neomake#makers#ft#rust#rustc() abort
 endfunction
 
 function! neomake#makers#ft#rust#cargo() abort
-    let maker_command = get(g:, 'neomake_rust_cargo_command', ['check'])
+    let maker_command = get(b:, 'neomake_rust_cargo_command', ['check'])
     return {
         \ 'args': maker_command + ['--message-format=json', '--quiet'],
         \ 'append_file': 0,


### PR DESCRIPTION
This PR introduces `cargo-check` as the default command run in the `cargo` maker. Users can set the command passed to `cargo` via specified option (`g:neomake_rust_cargo_command`). Most notably to enable test-checking support one would add this line to the .vimrc:
`let g:neomake_rust_cargo_command = ['test', '--no-run']`
This closes #843.