### PR TITLE
Use json output in the clippy maker

### DIFF
--- a/autoload/neomake/makers/clippy.vim
+++ b/autoload/neomake/makers/clippy.vim
@@ -4,8 +4,6 @@
 let s:rustup_has_nightly = -1
 
 function! neomake#makers#clippy#clippy() abort
-    let errorfmt = neomake#makers#ft#rust#rustc()['errorformat']
-
     " When rustup and a nightly toolchain is installed, that is used.
     " Otherwise, the default cargo exectuable is used. If this is not part
     " of a nightly rust, this will fail.
@@ -22,17 +20,22 @@ function! neomake#makers#clippy#clippy() abort
         endif
     endif
 
+    let cargo_maker = neomake#makers#ft#rust#cargo()
+    let json_args = ['--message-format=json', '--quiet']
+
     if s:rustup_has_nightly
         return {
             \ 'exe': 'rustup',
-            \ 'args': ['run', 'nightly', 'cargo', 'clippy'],
-            \ 'errorformat': errorfmt,
+            \ 'args': ['run', 'nightly', 'cargo', 'clippy'] + json_args,
+            \ 'errorformat': cargo_maker.errorformat,
+            \ 'process_output': cargo_maker.process_output,
             \ }
     else
         return {
             \ 'exe': 'cargo',
-            \ 'args': ['clippy'],
-            \ 'errorformat': errorfmt,
+            \ 'args': ['clippy'] + json_args,
+            \ 'errorformat': cargo_maker.errorformat,
+            \ 'process_output': cargo_maker.process_output,
             \ }
     endif
 endfunction

--- a/autoload/neomake/makers/ft/rust.vim
+++ b/autoload/neomake/makers/ft/rust.vim
@@ -82,6 +82,29 @@ function! neomake#makers#ft#rust#CargoProcessOutput(context) abort
                         \ span.expansion.span)
             call add(errors, error)
         endif
+
+        if len(children) > 1
+            for child in children[1:]
+                if !has_key(child, 'message')
+                    continue
+                endif
+                let info = deepcopy(error)
+                let info.type = 'I'
+                let info.text = child.message
+                if has_key(child, 'rendered') && !(child.rendered is g:neomake#compat#json_null)
+                    let info.text = info.text . ': ' . child.rendered
+                endif
+                " if len(child.spans)
+                    " let span = child.spans[0]
+                    " call neomake#makers#ft#rust#FillErrorFromSpan(info, span)
+                    " let detail = span.label
+                    " if type(detail) == type('') && len(detail)
+                        " let info.text = info.text . ': ' . detail
+                    " endif
+                " endif
+                call add(errors, info)
+            endfor
+        endif
     endfor
     return errors
 endfunction

--- a/autoload/neomake/makers/ft/rust.vim
+++ b/autoload/neomake/makers/ft/rust.vim
@@ -100,6 +100,7 @@ function! neomake#makers#ft#rust#CargoProcessOutput(context) abort
             let info = deepcopy(error)
             let info.type = 'I'
             let info.text = child.message
+            call neomake#utils#CompressWhitespace(info)
             if has_key(child, 'rendered')
                         \ && !(child.rendered is g:neomake#compat#json_null)
                 let info.text = info.text . ': ' . child.rendered

--- a/autoload/neomake/makers/ft/rust.vim
+++ b/autoload/neomake/makers/ft/rust.vim
@@ -61,7 +61,18 @@ function! neomake#makers#ft#rust#CargoProcessOutput(context) abort
         endif
 
         let span = data.spans[0]
-        call neomake#makers#ft#rust#FillErrorFromSpan(error, span)
+        let expanded = 0
+        let has_expansion = type(span.expansion) == type({})
+                    \ && type(span.expansion.span) == type({})
+                    \ && type(span.expansion.def_site_span) == type({})
+
+        if span.file_name =~# '^<.*>$' && has_expansion
+            let expanded = 1
+            call neomake#makers#ft#rust#FillErrorFromSpan(error,
+                        \ span.expansion.span)
+        else
+            call neomake#makers#ft#rust#FillErrorFromSpan(error, span)
+        endif
 
         let error.text = data.message
         let detail = span.label
@@ -74,37 +85,45 @@ function! neomake#makers#ft#rust#CargoProcessOutput(context) abort
 
         call add(errors, error)
 
-        if type(span.expansion) == type({})
-                    \ && type(span.expansion.span) == type({})
-                    \ && type(span.expansion.def_site_span) == type({})
+        if has_expansion && !expanded
             let error = copy(error)
             call neomake#makers#ft#rust#FillErrorFromSpan(error,
                         \ span.expansion.span)
             call add(errors, error)
         endif
 
-        if len(children) > 1
-            for child in children[1:]
-                if !has_key(child, 'message')
-                    continue
+        for child in children[1:]
+            if !has_key(child, 'message')
+                continue
+            endif
+
+            let info = deepcopy(error)
+            let info.type = 'I'
+            let info.text = child.message
+            if has_key(child, 'rendered')
+                        \ && !(child.rendered is g:neomake#compat#json_null)
+                let info.text = info.text . ': ' . child.rendered
+            endif
+
+            if len(child.spans)
+                let span = child.spans[0]
+                if span.file_name =~# '^<.*>$'
+                            \ && type(span.expansion) == type({})
+                            \ && type(span.expansion.span) == type({})
+                            \ && type(span.expansion.def_site_span) == type({})
+                    call neomake#makers#ft#rust#FillErrorFromSpan(info,
+                                \ span.expansion.span)
+                else
+                    call neomake#makers#ft#rust#FillErrorFromSpan(info, span)
                 endif
-                let info = deepcopy(error)
-                let info.type = 'I'
-                let info.text = child.message
-                if has_key(child, 'rendered') && !(child.rendered is g:neomake#compat#json_null)
-                    let info.text = info.text . ': ' . child.rendered
+                let detail = span.label
+                if type(detail) == type('') && len(detail)
+                    let info.text = info.text . ': ' . detail
                 endif
-                " if len(child.spans)
-                    " let span = child.spans[0]
-                    " call neomake#makers#ft#rust#FillErrorFromSpan(info, span)
-                    " let detail = span.label
-                    " if type(detail) == type('') && len(detail)
-                        " let info.text = info.text . ': ' . detail
-                    " endif
-                " endif
-                call add(errors, info)
-            endfor
-        endif
+            endif
+
+            call add(errors, info)
+        endfor
     endfor
     return errors
 endfunction

--- a/tests/ft_rust.vader
+++ b/tests/ft_rust.vader
@@ -76,9 +76,19 @@ Execute (cargo error message):
     \ 'vcol': 0,
     \ 'pattern': '',
     \ 'text': 'mismatched types: expected str, found struct `proc_macro::TokenStream`'
+    \ }, {
+    \ 'type': 'I',
+    \ 'bufnr':  bufnr('%'),
+    \ 'nr': 308,
+    \ 'lnum': 25,
+    \ 'col': 1,
+    \ 'valid': 1,
+    \ 'vcol': 0,
+    \ 'pattern': '',
+    \ 'text': 'found type `&proc_macro::TokenStream`'
     \ }], getloclist(0)
 
-  AssertEqual [2, 40], g:lengths
+  AssertEqual [2, 40, 40], g:lengths
 
   bwipe
   " Undo monkeypatch.


### PR DESCRIPTION
This is solves #1196. I have a several questions/ideas regarding this PR and so this is at the moment regarded work in progress.

* As `clippy` heavily uses multiple information messages in the children array I decided to leave the first message appended to the parent message, and create subsequent `I` (information) messages for each child. This way we can retain certain important information visible, without the need to open the location list (see #793 for example).

* Currently i left out the information about the spans away from the created children (code for that is commented out on purpose), granting them effectively the same span as the parent. Ideally we could use the provided span if it exists, otherwise the parent's span should be used. However I am not sure if I didn't hit a bug/unwanted behavior in the `neomake#makers#ft#rust#CargoProcessOutput` function. Consider this example:

```
fn main() {
    let a = 1.0;
    let b = 2.0;
    assert_eq!(a, b);
}
```
`clippy` will yield this warning:

```
warning: strict comparison of f32 or f64
 --> src/main.rs:5:5
  |
5 |     assert_eq!(a, b);
  |     ^^^^^^^^^^^^^^^^^
  |
  = note: #[warn(float_cmp)] on by default
help: consider comparing them within some error
  | if ! (* left_val - * right_val).abs() < error {
note: std::f32::EPSILON and std::f64::EPSILON are available.
 --> src/main.rs:5:5
  |
5 |     assert_eq!(a, b);
  |     ^^^^^^^^^^^^^^^^^
  = help: for further information visit https://github.com/Manishearth/rust-clippy/wiki#float_cmp
  = note: this error originates in a macro outside of the current crate
```

Despite having a single warning, proposed maker gives two warnings (and 3 children, which are correct), namely:

```
<assert_eq macros>|5 col 6 warning| strict comparison of f32 or f64. #[warn(float_cmp)] on by default
src/main.rs|4 col 5 warning| strict comparison of f32 or f64. #[warn(float_cmp)] on by default
src/main.rs|4 col 5 info| consider comparing them within some error: if ! (* left_val - * right_val).abs() < error {
src/main.rs|4 col 5 info| std::f32::EPSILON and std::f64::EPSILON are available.
src/main.rs|4 col 5 info| for further information visit https://github.com/Manishearth/rust-clippy/wiki#float_cmp
```

It looks like either the processing function can't deal with the span that is given in the json, or the span itself is misleading. I wasn't able to reproduce this with the `cargo` maker and so I don't know which of these options is at play here. @JelteF do you have any ideas as to what might be the problem here?

@blueyed let me know what do you think about the additional `info` messages created from children. I think this is somewhat connected to [your comment in #793](https://github.com/neomake/neomake/issues/793#issuecomment-291766606)