### PR TITLE
Fix readme markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#[![Neomake](https://cloud.githubusercontent.com/assets/111942/22717189/9e3e1760-ed67-11e6-94c5-e8955869d6d0.png)](#neomake)
+# [![Neomake](https://cloud.githubusercontent.com/assets/111942/22717189/9e3e1760-ed67-11e6-94c5-e8955869d6d0.png)](#neomake)
 
 [![Build Status](https://travis-ci.org/neomake/neomake.svg?branch=master)](https://travis-ci.org/neomake/neomake)
 


### PR DESCRIPTION
Github changed it's markdown parser, breaking headings that do not separate the hash from the text.

**Works**

`# Heading`

**Doesn't Work**

`#Heading`