### PR TITLE
Use empty()/!empty() in place of !len()/len()

### DIFF
--- a/autoload/neomake/makers/ft/go.vim
+++ b/autoload/neomake/makers/ft/go.vim
@@ -60,7 +60,7 @@ function! neomake#makers#ft#go#Paths() abort
         endif
     endif
 
-    if len(s:goroot) != 0 && isdirectory(s:goroot)
+    if !empty(s:goroot) && isdirectory(s:goroot)
         let dirs += [s:goroot]
     endif
 
@@ -79,7 +79,7 @@ function! neomake#makers#ft#go#ImportPath(arg) abort
 
     let workspace = ''
     for dir in dirs
-        if len(dir) && match(path, dir) == 0
+        if !empty(dir) && match(path, dir) == 0
             let workspace = dir
         endif
     endfor

--- a/autoload/neomake/makers/ft/javascript.vim
+++ b/autoload/neomake/makers/ft/javascript.vim
@@ -82,7 +82,7 @@ endfunction
 
 function! neomake#makers#ft#javascript#FlowProcess(entry) abort
     let l:lines = split(a:entry.text, '\n')
-    if len(l:lines)
+    if !empty(l:lines)
         let a:entry.text = join(l:lines[1:])
         let a:entry.length = l:lines[0] - a:entry.col + 1
     endif

--- a/autoload/neomake/makers/ft/python.vim
+++ b/autoload/neomake/makers/ft/python.vim
@@ -217,7 +217,7 @@ function! neomake#makers#ft#python#PylamaEntryProcess(entry) abort
     if a:entry.nr == -1
         " Get number from the beginning of text.
         let nr = matchstr(a:entry.text, '\v^\u\zs\d+')
-        if len(nr)
+        if !empty(nr)
             let a:entry.nr = nr + 0
         endif
     endif

--- a/autoload/neomake/makers/ft/rust.vim
+++ b/autoload/neomake/makers/ft/rust.vim
@@ -43,7 +43,7 @@ function! neomake#makers#ft#rust#CargoProcessOutput(context) abort
 
         let decoded = neomake#utils#JSONdecode(line)
         let data = get(decoded, 'message', -1)
-        if type(data) != type({}) || !len(data['spans'])
+        if type(data) != type({}) || empty(data['spans'])
             continue
         endif
 
@@ -66,9 +66,9 @@ function! neomake#makers#ft#rust#CargoProcessOutput(context) abort
         let error.text = data.message
         let detail = span.label
         let children = data.children
-        if type(detail) == type('') && len(detail)
+        if type(detail) == type('') && !empty(detail)
             let error.text = error.text . ': ' . detail
-        elseif len(children) && has_key(children[0], 'message')
+        elseif !empty(children) && has_key(children[0], 'message')
             let error.text = error.text . '. ' . children[0].message
         endif
 

--- a/autoload/neomake/makers/ft/sh.vim
+++ b/autoload/neomake/makers/ft/sh.vim
@@ -50,7 +50,7 @@ endfunction
 
 function! neomake#makers#ft#sh#sh() abort
     let shebang = matchstr(getline(1), '^#!\s*\zs.*$')
-    if len(shebang)
+    if !empty(shebang)
         let l = split(shebang)
         let exe = l[0]
         let args = l[1:] + ['-n']

--- a/autoload/neomake/signs.vim
+++ b/autoload/neomake/signs.vim
@@ -77,7 +77,7 @@ function! neomake#signs#PlaceSign(entry, type) abort
         let cmd = ''
     endif
 
-    if len(cmd)
+    if !empty(cmd)
         call neomake#utils#DebugMessage('Placing sign: '.cmd)
         exe cmd
     endif

--- a/autoload/neomake/statusline.vim
+++ b/autoload/neomake/statusline.vim
@@ -3,7 +3,7 @@ let s:loclist_counts = {}
 
 function! s:incCount(counts, item, buf) abort
     let type = toupper(a:item.type)
-    if len(type) && (!a:buf || a:item.bufnr ==# a:buf)
+    if !empty(type) && (!a:buf || a:item.bufnr ==# a:buf)
         let a:counts[type] = get(a:counts, type, 0) + 1
         return 1
     endif

--- a/autoload/neomake/utils.vim
+++ b/autoload/neomake/utils.vim
@@ -111,7 +111,7 @@ function! neomake#utils#LogMessage(level, msg, ...) abort
             echohl None
         endif
     endif
-    if type(logfile) ==# type('') && len(logfile)
+    if type(logfile) ==# type('') && !empty(logfile)
         let date = strftime('%H:%M:%S')
         if !exists('timediff')
             let timediff = s:reltime_lastmsg()
@@ -321,7 +321,7 @@ let s:unset = {}  " Sentinel.
 " namespace, defaulting to default.
 function! neomake#utils#GetSetting(key, maker, default, ft, bufnr) abort
   let maker_name = has_key(a:maker, 'name') ? a:maker.name : ''
-  if len(a:ft)
+  if !empty(a:ft)
       let fts = neomake#utils#get_config_fts(a:ft) + ['']
   else
       let fts = ['']
@@ -330,8 +330,8 @@ function! neomake#utils#GetSetting(key, maker, default, ft, bufnr) abort
     " Look through the override vars for a filetype maker, like
     " neomake_scss_sasslint_exe (should be a string), and
     " neomake_scss_sasslint_args (should be a list).
-    let part = join(filter([ft, maker_name], 'len(v:val)'), '_')
-    if !len(part)
+    let part = join(filter([ft, maker_name], '!empty(v:val)'), '_')
+    if empty(part)
         break
     endif
     let config_var = 'neomake_'.part.'_'.a:key
@@ -456,7 +456,7 @@ function! neomake#utils#hook(event, context, ...) abort
 
         let args = ['Calling User autocmd '.a:event
                     \ .' with context: '.string(map(copy(a:context), "v:key ==# 'jobinfo' ? '…' : v:val"))]
-        if len(jobinfo)
+        if !empty(jobinfo)
             let args += [jobinfo]
         endif
         call call('neomake#utils#LoudMessage', args)


### PR DESCRIPTION
VimL knows how to quickly return from empty(), so use it when
appropriate instead of unnecessarily calculating the length.