### PR TITLE
Improved sign handling

### DIFF
--- a/autoload/neomake/signs.vim
+++ b/autoload/neomake/signs.vim
@@ -20,6 +20,10 @@ let s:neomake_sign_id = {
     \ 'file': {}
     \ }
 
+let s:base_sign_id = {'file': 5000, 'project': 7000}
+
+let s:signs_for_entries = {}
+
 exe 'sign define neomake_invisible'
 
 " Reset signs placed by a :Neomake! call
@@ -36,9 +40,6 @@ endfunction
 function! neomake#signs#ResetFile(bufnr) abort
     call neomake#signs#CleanOldSigns(a:bufnr, 'file')
     call neomake#signs#Reset(a:bufnr, 'file')
-    if has_key(s:neomake_sign_id.file, a:bufnr)
-        unlet s:neomake_sign_id.file[a:bufnr]
-    endif
 endfunction
 
 function! neomake#signs#Reset(bufnr, type) abort
@@ -48,39 +49,118 @@ function! neomake#signs#Reset(bufnr, type) abort
     endif
 endfunction
 
-" type may be either 'file' or 'project'
-function! neomake#signs#PlaceSign(entry, type) abort
-    if a:entry.type ==? 'W'
-        let sign_type = 'neomake_warn'
-    elseif a:entry.type ==? 'I'
-        let sign_type = 'neomake_info'
-    elseif a:entry.type ==? 'M'
-        let sign_type = 'neomake_msg'
-    else
-        let sign_type = 'neomake_err'
-    endif
+let s:sign_order = {'neomake_err': 0, 'neomake_warn': 1,
+                 \  'neomake_info': 2, 'neomake_msg': 3}
 
-    let s:placed_signs[a:type][a:entry.bufnr] = get(s:placed_signs[a:type], a:entry.bufnr, {})
-    if !has_key(s:placed_signs[a:type][a:entry.bufnr], a:entry.lnum)
-        let default = a:type ==# 'file' ? 5000 : 7000
-        let sign_id = get(s:neomake_sign_id[a:type], a:entry.bufnr, default)
-        let s:neomake_sign_id[a:type][a:entry.bufnr] = sign_id + 1
-        let cmd = 'sign place '.sign_id.' line='.a:entry.lnum.
-                                      \ ' name='.sign_type.
-                                      \ ' buffer='.a:entry.bufnr
-        let s:placed_signs[a:type][a:entry.bufnr][a:entry.lnum] = sign_id
-    elseif sign_type ==# 'neomake_err'
-        " Upgrade this sign to an error
-        let sign_id = s:placed_signs[a:type][a:entry.bufnr][a:entry.lnum]
-        let cmd =  'sign place '.sign_id.' name='.sign_type.' buffer='.a:entry.bufnr
-    else
-        let cmd = ''
+function! neomake#signs#by_lnum(bufnr) abort
+    if !bufexists(a:bufnr + 0)
+        return {}
     endif
+    let signs_output = split(neomake#utils#redir('sign place buffer='.a:bufnr), '\n')
 
-    if !empty(cmd)
-        call neomake#utils#DebugMessage('Placing sign: '.cmd)
-        exe cmd
-    endif
+    " Via ALE.
+    " Matches output like :
+    " line=4  id=1  name=neomake_err
+    " строка=1  id=1000001  имя=neomake_err
+    " 行=1  識別子=1000001  名前=neomake_err
+    " línea=12 id=1000001 nombre=neomake_err
+    " riga=1 id=1000001, nome=neomake_err
+    let pattern = '^.*=\(\d\+\)\s\+.*=\(\d\+\)\,\?\s\+.*=\(neomake_\w\+\)'
+
+    let d = {}
+    for line in signs_output
+        let m = matchlist(line, pattern)
+        if !empty(m)
+            " let l[m[2]] = l[m[1]] + 0
+            let d[m[1]] = [m[2] + 0, m[3]]
+        endif
+    endfor
+    return d
+endfunction
+
+function! neomake#signs#PlaceSigns(bufnr, entries, type) abort
+    let entries_by_bufnr = {}
+    let bufnr = a:bufnr
+
+    let entries_by_bufnr[bufnr] = a:entries
+    " let entries_by_bufnr = {}
+    " for entry in a:entries
+    "     let entries_by_bufnr[entry.bufnr] = entry
+    " endfor
+
+    for [bufnr, entries] in items(entries_by_bufnr)
+        " Query the list of currently placed signs.
+        " This allows to cope with movements, e.g. when lines where added.
+        let placed_signs = neomake#signs#by_lnum(bufnr)
+
+        let entries_by_linenr = {}
+        for entry in entries
+            if entry.lnum == 0
+                continue
+            endif
+            if entry.type ==? 'W'
+                let sign_type = 'neomake_warn'
+            elseif entry.type ==? 'I'
+                let sign_type = 'neomake_info'
+            elseif entry.type ==? 'M'
+                let sign_type = 'neomake_msg'
+            else
+                let sign_type = 'neomake_err'
+            endif
+
+            if ! exists('entries_by_linenr[entry.lnum]')
+                        \ || s:sign_order[entries_by_linenr[entry.lnum][1]]
+                        \    > s:sign_order[sign_type]
+                let entries_by_linenr[entry.lnum] = [entry, sign_type]
+            endif
+        endfor
+
+        let place_new = []
+        let kept_signs = []
+        for [lnum, entry_info] in items(entries_by_linenr)
+            let [entry, sign_type] = entry_info
+
+            " Keep this sign from being cleaned.
+            if exists('s:last_placed_signs[a:type][bufnr][lnum]')
+                unlet s:last_placed_signs[a:type][bufnr][lnum]
+            endif
+
+            let existing_sign = get(placed_signs, entry.lnum, [])
+            if !empty(existing_sign)
+                if existing_sign[1] == sign_type
+                    call neomake#utils#DebugMessage(printf(
+                                \ 'Reusing sign: id=%d, type=%s, lnum=%d',
+                                \ existing_sign[0], existing_sign[1], lnum))
+                else
+                    let cmd = 'sign place '.existing_sign[0].' name='.sign_type.' buffer='.bufnr
+                    call neomake#utils#DebugMessage('Upgrading sign for lnum='.lnum.': '.cmd)
+                    exe cmd
+                endif
+                call add(kept_signs, existing_sign[0])
+                continue
+            endif
+            call add(place_new, [lnum, sign_type])
+        endfor
+
+        for [lnum, sign_type] in place_new
+            if !exists('next_sign_id')
+                if !empty(placed_signs)
+                    let next_sign_id = max(map(values(copy(placed_signs)), 'v:val[0]')) + 1
+                else
+                    let next_sign_id = s:base_sign_id[a:type]
+                endif
+            else
+                let next_sign_id += 1
+            endif
+            let cmd = 'sign place '.next_sign_id.' line='.lnum.
+                        \ ' name='.sign_type.
+                        \ ' buffer='.bufnr
+            call neomake#utils#DebugMessage('Placing sign: '.cmd)
+            let placed_signs[lnum] = [next_sign_id, sign_type]
+            exe cmd
+        endfor
+        let s:placed_signs[a:type][bufnr] = placed_signs
+    endfor
 endfunction
 
 function! neomake#signs#CleanAllOldSigns(type) abort
@@ -95,13 +175,15 @@ function! neomake#signs#CleanOldSigns(bufnr, type) abort
     if !has_key(s:last_placed_signs[a:type], a:bufnr)
         return
     endif
-    call neomake#utils#DebugObject('Cleaning old signs in buffer '.a:bufnr.': ', s:last_placed_signs[a:type])
-    for ln in keys(s:last_placed_signs[a:type][a:bufnr])
-        let cmd = 'sign unplace '.s:last_placed_signs[a:type][a:bufnr][ln].' buffer='.a:bufnr
+    let placed_signs = s:last_placed_signs[a:type][a:bufnr]
+    unlet s:last_placed_signs[a:type][a:bufnr]
+    call neomake#utils#DebugObject('Cleaning old signs in buffer '.a:bufnr.':', placed_signs)
+    for sign_info in values(placed_signs)
+        let sign_id = sign_info[0]
+        let cmd = 'sign unplace '.sign_id.' buffer='.a:bufnr
         call neomake#utils#DebugMessage('Unplacing sign: '.cmd)
         exe cmd
     endfor
-    unlet s:last_placed_signs[a:type][a:bufnr]
 endfunction
 
 function! neomake#signs#RedefineSign(name, opts) abort
@@ -114,9 +196,10 @@ function! neomake#signs#RedefineSign(name, opts) abort
     for type in keys(s:placed_signs)
         for buf in keys(s:placed_signs[type])
             for ln in keys(s:placed_signs[type][buf])
-                let sign_id = s:placed_signs[type][buf][ln]
-                exe 'sign place '.sign_id.' name=neomake_invisible buffer='.buf
-                exe 'sign place '.sign_id.' name='.a:name.' buffer='.buf
+                let [sign_id, sign_type] = s:placed_signs[type][buf][ln]
+                if sign_type == a:name
+                    exe 'sign place '.sign_id.' name='.a:name.' buffer='.buf
+                endif
             endfor
         endfor
     endfor

--- a/tests/include/setup.vader
+++ b/tests/include/setup.vader
@@ -309,6 +309,12 @@ Before:
         \ 'append_file': 0,
         \ }
 
+  function! NeomakeTestsGetSigns()
+    let signs = split(neomake#utils#redir('sign place'), '\n')
+    call map(signs, "substitute(substitute(v:val, '\\m^\\s\\+', '', ''), '\\m\\s\\+$', '', '')")
+    return signs[1:-1]
+  endfunction
+
   function! s:After()
     Restore
     unlet! g:expected  " for old Vim with Vader, that does not wrap tests in a function.

--- a/tests/integration.vader
+++ b/tests/integration.vader
@@ -28,13 +28,9 @@ Execute (Test Neomake on errors.sh with one maker):
 
   " Basic verification that signs are placed.
   AssertNeomakeMessage 'Placing sign: sign place 5000 line=5 name=neomake_err buffer='.bufnr, 3, {}
-  AssertNeomakeMessage 'Unplacing sign: sign unplace 5000 buffer='.bufnr, 3, {}
-  AssertNeomakeMessage 'Placing sign: sign place 5000 line=5 name=neomake_err buffer='.bufnr, 3, {}
+  AssertNeomakeMessage 'Reusing sign: id=5000, type=neomake_err, lnum=5', 3, {}
 
-  let signs = split(neomake#utils#redir('sign place'), '\n')
-  call map(signs, "substitute(substitute(v:val, '\\m^\\s\\+', '', ''), '\\m\\s\\+$', '', '')")
-  AssertEqual signs, [
-    \ '--- Signs ---',
+  AssertEqual NeomakeTestsGetSigns(), [
     \ 'Signs for tests/fixtures/errors.sh:',
     \ 'line=5  id=5000  name=neomake_err']
   bwipe
@@ -51,6 +47,8 @@ Execute (Test Neomake on errors.sh with two makers):
   bwipe
 
 Execute (Neomake: handle result for current window):
+  runtime autoload/neomake/signs.vim
+
   call g:NeomakeSetupAutocmdWrappers()
   new
   file file_sleep_efm

--- a/tests/signs.vader
+++ b/tests/signs.vader
@@ -12,7 +12,7 @@ Execute (neomake#signs#HlexistsAndIsNotCleared):
 
 Execute (neomake#signs#RedefineErrorSign):
   let maker = neomake#utils#MakerFromCommand(
-    \ 'echo 1: E: error; echo 1:2: W: warning')
+    \ 'echo file1: E: error without line; echo file1:2: W: warning')
   call extend(maker, {
         \ 'name': 'custom_maker',
         \ 'errorformat': '%E%f:%l: %t: %m,%E%f: %t: %m',
@@ -20,7 +20,7 @@ Execute (neomake#signs#RedefineErrorSign):
         \ }, 'error')
 
   new
-  file 1
+  file file1
   let bufnr = bufnr('%')
 
   call neomake#Make(1, [maker])
@@ -30,19 +30,30 @@ Execute (neomake#signs#RedefineErrorSign):
   AssertNeomakeMessage printf("Could not place signs for 1 entries without line number: %s.",
   \ string([{'lnum': 0, 'bufnr': bufnr, 'col': 0, 'valid': 1, 'vcol': 0,
   \          'nr': -1, 'type': 'E', 'maker_name': 'custom_maker', 'pattern': '',
-  \          'text': 'error'}]))
+  \          'text': 'error without line'}]))
 
   " Test #736.
-  call neomake#signs#RedefineErrorSign({'text': '✗', 'texthl': 'ErrorMsg'})
+  call neomake#signs#RedefineErrorSign({'text': 'X', 'texthl': 'ErrorMsg'})
+  let sign = substitute(neomake#utils#redir('sign list neomake_err'), '\v^[\n]*', '', '')
+  AssertEqual sign, 'sign neomake_err text=X  texthl=ErrorMsg'
+  AssertEqual neomake#signs#by_lnum(bufnr('%')), {'2': [5000, 'neomake_warn']}
 
-  call neomake#Make(1, [g:success_maker])
+"   call neomake#signs#RedefineErrorSign({'text': 'W', 'texthl': 'MyWarningSign'})
+"   AssertEqual neomake#signs#by_lnum(bufnr('%')), {'2': [5000, 'neomake_warn']}
+
+  call neomake#Make(1, [maker])
   NeomakeTestsWaitForFinishedJobs
-  AssertNeomakeMessage 'Cleaning old signs in buffer '.bufnr.':  {'.bufnr.': {2: 5000}}', 3, {}
+  AssertNeomakeMessage 'Reusing sign: id=5000, type=neomake_warn, lnum=2'
+  AssertNeomakeMessage 'Cleaning old signs in buffer '.bufnr.': {}'
 
-  bd!
+"   AssertNeomakeMessage 'Cleaning old signs in buffer '.bufnr.':
+"   \ {'.bufnr.': {2: [5000, neomake_warn]}}', 3, {}
+
   call neomake#signs#Reset(bufnr, 'file')
   call neomake#signs#CleanAllOldSigns('file')
-  AssertNeomakeMessage 'Removing signs {file: {}, project: {}}', 3
+  AssertNeomakeMessage 'Removing signs {file: {'.bufnr.': '
+  \ .'{2: [5000, neomake_warn]}}, project: {}}'
+  bwipe
 
 Execute (Placing signs in project mode):
   let maker = neomake#utils#MakerFromCommand('echo 1:1: W: warning')
@@ -61,12 +72,264 @@ Execute (Placing signs in project mode):
 
   call neomake#signs#Reset(bufnr, 'project')
   call neomake#signs#CleanAllOldSigns('project')
-  AssertNeomakeMessage 'Cleaning old signs in buffer '.bufnr.':  {'.bufnr.': {1: 7000}}', 3, {}
+  AssertNeomakeMessage 'Cleaning old signs in buffer '.bufnr.': {1: [7000, neomake_warn]}', 3, {}
   AssertNeomakeMessage 'Unplacing sign: sign unplace 7000 buffer='.bufnr
 
 Execute (Signs are wiped when buffer gets wiped):
   new
-  call neomake#signs#PlaceSign({'type': 'E', 'bufnr': bufnr('%'), 'lnum': 1}, 'file')
+  call neomake#signs#PlaceSigns(bufnr('%'),
+  \ [{'type': 'E', 'bufnr': bufnr('%'), 'lnum': 1}], 'file')
   bwipe
   " Should not cause 'E158: Invalid buffer name'
-  call neomake#signs#RedefineSign('neomake_foobar', {})
+  call neomake#signs#RedefineSign('neomake_err', {})
+
+Execute (Signs are not wiped when buffer gets wiped with removed augroup):
+  new
+  au! neomake_signs
+  call neomake#signs#PlaceSigns(bufnr('%'),
+  \ [{'type': 'E', 'bufnr': bufnr('%'), 'lnum': 1}], 'file')
+  bwipe
+  AssertThrows call neomake#signs#RedefineSign('neomake_err', {})
+  AssertEqual g:vader_exception, 'Vim(sign):E158: Invalid buffer name: '
+  runtime autoload/neomake/signs.vim
+
+Execute (neomake#signs#by_lnum):
+  new
+  let bufnr = bufnr('%')
+
+  exe 'sign place 5000 name=neomake_err line=1 buffer='.bufnr
+  exe 'sign place 5001 name=neomake_warn line=2 buffer='.bufnr
+  exe 'sign place 5002 name=neomake_info line=3 buffer='.bufnr
+
+  AssertEqual neomake#signs#by_lnum(bufnr('%')), {
+  \ '1': [5000, 'neomake_err'], '2': [5001, 'neomake_warn'], '3': [5002, 'neomake_info']}
+
+  bwipe
+
+Execute (neomake#signs#by_lnum for invalid bufnr):
+  AssertEqual neomake#signs#by_lnum(9999), {}
+  AssertEqual neomake#signs#by_lnum('9999'), {}
+
+Execute (neomake#signs#PlaceSigns):
+  new
+  let bufnr = bufnr('%')
+
+  let entries = [
+  \ {'lnum': 1, 'type': 'E', 'bufnr': bufnr},
+  \ {'lnum': 2, 'type': 'W', 'bufnr': bufnr},
+  \ {'lnum': 3, 'type': 'I', 'bufnr': bufnr},
+  \ ]
+
+"   call neomake#signs#Reset(bufnr, 'file')
+  call neomake#signs#PlaceSigns(bufnr, entries, 'file')
+
+  AssertEqual neomake#signs#by_lnum(bufnr('%')), {
+  \ '1': [5000, 'neomake_err'],
+  \ '2': [5001, 'neomake_warn'],
+  \ '3': [5002, 'neomake_info']}
+
+  let entries = [
+  \ {'lnum': 1, 'type': 'E', 'bufnr': bufnr},
+  \ {'lnum': 2, 'type': 'W', 'bufnr': bufnr},
+  \ {'lnum': 3, 'type': 'I', 'bufnr': bufnr},
+  \ {'lnum': 3, 'type': 'E', 'bufnr': bufnr},
+  \ ]
+  call neomake#signs#PlaceSigns(bufnr, entries, 'file')
+
+  AssertEqual neomake#signs#by_lnum(bufnr), {
+  \ '1': [5000, 'neomake_err'],
+  \ '2': [5001, 'neomake_warn'],
+  \ '3': [5002, 'neomake_err']}
+
+  let entries = [
+  \ {'lnum': 2, 'type': 'E', 'bufnr': bufnr},
+  \ {'lnum': 3, 'type': 'W', 'bufnr': bufnr},
+  \ {'lnum': 4, 'type': 'E', 'bufnr': bufnr},
+  \ {'lnum': 4, 'type': 'I', 'bufnr': bufnr},
+  \ ]
+  call neomake#signs#PlaceSigns(bufnr, entries, 'file')
+  AssertEqual neomake#signs#by_lnum(bufnr), {
+  \ '1': [5000, 'neomake_err'],
+  \ '2': [5001, 'neomake_err'],
+  \ '3': [5002, 'neomake_warn'],
+  \ '4': [5003, 'neomake_err']}
+
+  call neomake#signs#Reset(bufnr, 'file')
+  call neomake#signs#CleanOldSigns(bufnr, 'file')
+  AssertEqual neomake#signs#by_lnum(bufnr), {}
+  call neomake#signs#PlaceSigns(bufnr, entries, 'file')
+"   call neomake#signs#ResetFile(bufnr)
+
+  AssertEqual neomake#signs#by_lnum(bufnr), {
+  \ '2': [5000, 'neomake_err'],
+  \ '3': [5001, 'neomake_warn'],
+  \ '4': [5002, 'neomake_err']}
+
+  let entries = [
+  \ {'lnum': 4, 'type': 'E', 'bufnr': bufnr},
+  \ {'lnum': 3, 'type': 'W', 'bufnr': bufnr},
+  \ {'lnum': 2, 'type': 'E', 'bufnr': bufnr},
+  \ {'lnum': 2, 'type': 'I', 'bufnr': bufnr},
+  \ ]
+  call neomake#signs#PlaceSigns(bufnr, entries, 'file')
+
+  AssertEqual neomake#signs#by_lnum(bufnr), {
+  \ '2': [5000, 'neomake_err'],
+  \ '3': [5001, 'neomake_warn'],
+  \ '4': [5002, 'neomake_err']}
+
+
+  let entries = [
+  \ {'lnum': 4, 'type': 'E', 'bufnr': bufnr},
+  \ {'lnum': 3, 'type': 'W', 'bufnr': bufnr},
+  \ {'lnum': 2, 'type': 'E', 'bufnr': bufnr},
+  \ {'lnum': 5, 'type': 'I', 'bufnr': bufnr},
+  \ ]
+  call neomake#signs#PlaceSigns(bufnr, entries, 'file')
+
+  AssertEqual neomake#signs#by_lnum(bufnr), {
+  \ '2': [5000, 'neomake_err'],
+  \ '3': [5001, 'neomake_warn'],
+  \ '4': [5002, 'neomake_err'],
+  \ '5': [5003, 'neomake_info']}
+
+  call neomake#signs#Reset(bufnr, 'file')
+  call neomake#signs#CleanOldSigns(bufnr, 'file')
+
+  AssertEqual neomake#signs#by_lnum(bufnr), {}
+
+  bwipe
+
+Execute (neomake#signs#PlaceSigns with E and I):
+  new
+  let bufnr = bufnr('%')
+
+  let entries = [
+  \ {'lnum': 1, 'type': 'E', 'bufnr': bufnr},
+  \ {'lnum': 2, 'type': 'W', 'bufnr': bufnr},
+  \ {'lnum': 3, 'type': 'I', 'bufnr': bufnr},
+  \ {'lnum': 3, 'type': 'E', 'bufnr': bufnr},
+  \ ]
+
+  call neomake#signs#PlaceSigns(bufnr, entries, 'file')
+
+  AssertEqual neomake#signs#by_lnum(bufnr('%')), {
+  \ '1': [5000, 'neomake_err'],
+  \ '2': [5001, 'neomake_warn'],
+  \ '3': [5002, 'neomake_err']}
+
+  bwipe
+
+Execute (Signs get handled across multiple jobs):
+  function! NeomakeTestsEntries(jobinfo) abort dict
+    return g:neomake_test_entries[self._idx]
+  endfunction
+
+  let maker1 = {'get_list_entries': function('NeomakeTestsEntries'),
+  \             '_idx': 'maker1'}
+  let maker2 = copy(maker1)
+  let maker2._idx = 'maker2'
+
+  new
+
+  let bufnr = bufnr('%')
+
+  let g:neomake_test_entries = {
+  \ 'maker1': [{'type': 'E', 'lnum': 1, 'text': 'error'}],
+  \ 'maker2': [{'type': 'W', 'lnum': 2, 'text': 'warning'}],
+  \ }
+
+  call neomake#Make(1, [maker1])
+  AssertEqual neomake#signs#by_lnum(bufnr), {
+  \ '1': [5000, 'neomake_err'],
+  \ }
+
+  call neomake#Make(1, [maker1, maker2])
+  AssertEqual neomake#signs#by_lnum(bufnr), {
+  \ '1': [5000, 'neomake_err'],
+  \ '2': [5001, 'neomake_warn'],
+  \ }
+
+  call neomake#Make(1, [maker1])
+  AssertEqual neomake#signs#by_lnum(bufnr), {
+  \ '1': [5000, 'neomake_err'],
+  \ }
+
+  bwipe
+
+Execute (next sign_id based on max):
+  new
+  let bufnr = bufnr('%')
+  exe 'sign place 5002 line=1 name=neomake_warn buffer='.bufnr
+  exe 'sign place 5001 line=2 name=neomake_warn buffer='.bufnr
+  call neomake#signs#PlaceSigns(bufnr, [{'lnum': 3, 'type': 'W'}], 'file')
+  AssertEqual neomake#signs#by_lnum(bufnr), {
+  \ '1': [5002, 'neomake_warn'],
+  \ '2': [5001, 'neomake_warn'],
+  \ '3': [5003, 'neomake_warn']}
+  bwipe
+
+Execute (file mode signs get placed when job finishes):
+  if NeomakeAsyncTestsSetup()
+    let maker1 = NeomakeTestsCommandMaker('maker1', 'echo 1:I:msg1; echo 3:W:msg2')
+    let maker1.errorformat = '%f:%l:%t:%m'
+    let maker1.mapexpr = "bufname('%').':'.v:val"
+
+    let maker2 = extend(copy(maker1), {'__command': 'sleep .1; echo 1:W:msg3; echo 2:E:msg4'})
+    new
+    file signs.test
+    let bufnr = bufnr('%')
+
+    call neomake#Make(1, [maker1, maker2])
+    NeomakeTestsWaitForNextFinishedJob
+
+    AssertEqual neomake#signs#by_lnum(bufnr), {
+    \ '1': [5000, 'neomake_info'],
+    \ '3': [5001, 'neomake_warn'],
+    \ }
+    NeomakeTestsWaitForFinishedJobs
+    AssertEqual neomake#signs#by_lnum(bufnr), {
+    \ '1': [5000, 'neomake_warn'],
+    \ '2': [5002, 'neomake_err'],
+    \ '3': [5001, 'neomake_warn'],
+    \ }
+
+    bwipe
+  endif
+
+Execute (project mode signs get placed when job finishes):
+  if NeomakeAsyncTestsSetup()
+    let maker1 = NeomakeTestsCommandMaker('maker1',
+    \ 'echo signs1.test:1:I:msg1; echo signs2.test:3:W:msg2')
+    let maker1.errorformat = '%f:%l:%t:%m'
+    let maker2 = extend(copy(maker1), {
+    \ '__command': 'sleep .1; echo signs1.test:1:W:msg3; echo signs2.test:2:E:msg4'})
+
+    new
+    file signs1.test
+    let bufnr1 = bufnr('%')
+    new
+    file signs2.test
+    let bufnr2 = bufnr('%')
+
+    call neomake#Make(0, [maker1, maker2])
+    NeomakeTestsWaitForNextFinishedJob
+
+    AssertEqual neomake#signs#by_lnum(bufnr1), {
+    \ '1': [7000, 'neomake_info'],
+    \ }
+    AssertEqual neomake#signs#by_lnum(bufnr2), {
+    \ '3': [7000, 'neomake_warn'],
+    \ }
+    NeomakeTestsWaitForFinishedJobs
+    AssertEqual neomake#signs#by_lnum(bufnr1), {
+    \ '1': [7000, 'neomake_warn'],
+    \ }
+    AssertEqual neomake#signs#by_lnum(bufnr2), {
+    \ '2': [7001, 'neomake_err'],
+    \ '3': [7000, 'neomake_warn'],
+    \ }
+
+    bwipe
+    bwipe
+  endif


### PR DESCRIPTION
One of the main ideas here is to clean old signs only after new jobs have finished, where existing signs were re-used/recycled.  Only at the end old/left-over signs are removed.
This keeps existing signs for longer, which is useful while waiting for the new make run to finish, and avoids flickering in general.