### PR TITLE
rust: remove neomake#utils#get_or_create_buffer

### DIFF
--- a/autoload/neomake/makers/ft/rust.vim
+++ b/autoload/neomake/makers/ft/rust.vim
@@ -88,7 +88,6 @@ endfunction
 
 function! neomake#makers#ft#rust#FillErrorFromSpan(error, span) abort
     let a:error.filename = a:span.file_name
-    let a:error.bufnr = neomake#utils#get_or_create_buffer(a:error.filename)
     let a:error.col = a:span.column_start
     let a:error.lnum = a:span.line_start
     let a:error.length = a:span.byte_end - a:span.byte_start

--- a/autoload/neomake/utils.vim
+++ b/autoload/neomake/utils.vim
@@ -555,17 +555,6 @@ function! neomake#utils#write_tempfile(bufnr, temp_file) abort
     call writefile(buflines, a:temp_file, 'b')
 endfunction
 
-function! neomake#utils#get_or_create_buffer(filename) abort
-    " TODO: Remove usage of this once not supplying a bufnr to process_output
-    " works if the filename is not opened in a buffer yet.
-    let nr = bufnr(a:filename)
-    if nr == -1
-        execute 'badd ' . substitute(a:filename, ' ', '\\ ', 'g')
-        let nr = bufnr(a:filename)
-    endif
-    return nr
-endfunction
-
 " Wrapper around fnamemodify that handles special buffers (e.g. fugitive).
 function! neomake#utils#fnamemodify(bufnr, modifier) abort
     let bufnr = +a:bufnr


### PR DESCRIPTION
Setting `filename` should be enough (Vim will add the buffer as unlisted).
This might need some fixes in Neomake itself to also look at `filename`,
and not only `bufnr`.

/cc @JelteF 
I've not found the previous discussion about it, but IIRC there was some.
I've stumbled upon this when noticing that Vim automatically adds buffers from `.filename` as unlisted buffers, so it might be something about the `cwd` not being correct etc only?!