### PR TITLE
tests: use new/bwipe with :file

### DIFF
--- a/tests/errors.vader
+++ b/tests/errors.vader
@@ -13,10 +13,10 @@ Execute (Error with no filename):
 
 Execute (Error with non-existing filename):
   new
+  file doesnotexist
   set ft=neomake_tests
   let b:neomake_neomake_tests_enabled_makers = ['true']
   let b:neomake_neomake_tests_true_tempfile_enabled = 0
-  file doesnotexist
 
   let fname = fnamemodify(bufname('%'), ':p')
   Neomake
@@ -28,10 +28,10 @@ Execute (Error with non-existing filename for 2nd maker):
   call g:NeomakeSetupAutocmdWrappers()
 
   new
+  file doesnotexist
   set ft=neomake_tests
   let b:neomake_neomake_tests_enabled_makers = ['true']
   let b:neomake_neomake_tests_true_tempfile_enabled = 0
-  file doesnotexist
 
   let maker1 = {
       \ 'exe': 'true',

--- a/tests/ft_cs.vader
+++ b/tests/ft_cs.vader
@@ -3,6 +3,7 @@ Include: include/setup.vader
 Execute (cs: msbuild: errorformat):
   Save &errorformat
   let &errorformat = neomake#makers#ft#cs#msbuild().errorformat
+  new
   file FooBar.cs
 
   lgetexpr "FooBar.cs(21,63): error CS1002: ; expected [Foo\Foobar.csproj]"
@@ -28,3 +29,4 @@ Execute (cs: msbuild: errorformat):
     \ 'type': 'W',
     \ 'pattern': '',
     \ 'text': "The variable 'ex' is declared but never used"}]
+  bwipe

--- a/tests/ft_css.vader
+++ b/tests/ft_css.vader
@@ -1,6 +1,7 @@
 Include: include/setup.vader
 
 Execute (csslint: errorformat):
+  new
   file file1
   let output = [
   \ "file1: line 315, col 1, Warning - Don't use IDs in selectors. (ids)",
@@ -17,3 +18,4 @@ Execute (csslint: errorformat):
   \ {'lnum': 0, 'bufnr': bufnr('%'), 'col': 0, 'valid': 1, 'vcol': 0,
   \  'nr': -1, 'type': 'W', 'pattern': '',
   \  'text': 'You have 2 h1s, 3 h2s defined in this stylesheet. (unique-headings)'''}]
+  bwipe

--- a/tests/ft_vim.vader
+++ b/tests/ft_vim.vader
@@ -3,6 +3,7 @@ Include: include/setup.vader
 Execute (Vint: generic postprocessing for highlights):
   runtime autoload/neomake/highlights.vim
 
+  new
   file file1.vim
   norm! iecho l:undefined_var
   let vint_maker = neomake#makers#ft#vim#vint()
@@ -32,6 +33,7 @@ Execute (Vint: generic postprocessing for highlights):
   else
     AssertEqual highlights.file[bufnr('%')].NeomakeWarning, [[1, 6, 15]]
   endif
+  bwipe!
 
 Execute (vimlint: length postprocessing):
   " Monkeypatch to check setting of length.

--- a/tests/processing.vader
+++ b/tests/processing.vader
@@ -200,6 +200,7 @@ Execute (Pending output with restarted job when not in normal/insert mode (locli
   if NeomakeAsyncTestsSetup()
     let g:neomake_test_inc_maker_counter = 0
 
+    new
     file b1
     let first_jobs = neomake#Make(1, [g:neomake_test_inc_maker])
     let jobinfo1 = neomake#GetJob(first_jobs[0])
@@ -227,12 +228,14 @@ Execute (Pending output with restarted job when not in normal/insert mode (locli
     \ ['1:0: buf: b1']
     AssertEqual len(g:neomake_test_finished), 2
     AssertEqual len(g:neomake_test_jobfinished), 2
+    bwipe
   endif
 
 Execute (Pending output with restarted job when not in normal/insert mode (quickfix)):
   if NeomakeAsyncTestsSetup()
     let g:neomake_test_inc_maker_counter = 0
 
+    new
     file b1
     let first_jobs = neomake#Make(0, [g:neomake_test_inc_maker])
     let jobinfo1 = neomake#GetJob(first_jobs[0])
@@ -260,6 +263,7 @@ Execute (Pending output with restarted job when not in normal/insert mode (quick
 
     AssertEqual len(g:neomake_test_finished), 2
     AssertEqual len(g:neomake_test_jobfinished), 2
+    bwipe
   endif
 
 Execute (Handle finished job that got canceled (#1158)):

--- a/tests/signs.vader
+++ b/tests/signs.vader
@@ -52,8 +52,8 @@ Execute (Placing signs in project mode):
         \ }, 'error')
 
   new
-  let bufnr = bufnr('%')
   file 1
+  let bufnr = bufnr('%')
   call neomake#Make(0, [maker])
   NeomakeTestsWaitForFinishedJobs
   AssertNeomakeMessage 'Placing sign: sign place 7000 line=1 name=neomake_warn buffer='.bufnr

--- a/tests/tempfiles.vader
+++ b/tests/tempfiles.vader
@@ -52,10 +52,10 @@ Execute (Neomake uses temporary file for unsaved buffer):
 
 Execute (Uses temporary file for unreadable buffer):
   new
+  file doesnotexist
   set ft=neomake_tests
   let b:neomake_neomake_tests_enabled_makers = ['true']
   let b:neomake_neomake_tests_true_tempfile_enabled = 1
-  file doesnotexist
 
   let fname = fnamemodify(bufname('%'), ':p')
   RunNeomake
@@ -69,8 +69,8 @@ Execute (2nd maker uses temporary file):
   call g:NeomakeSetupAutocmdWrappers()
 
   new
-  set ft=python
   file doesnotexist
+  set ft=python
 
   let maker1 = {
       \ 'exe': 'true',
@@ -107,8 +107,8 @@ Execute (Maker can specify temporary file to use via fn):
   \ }
 
   new
-  let bufnr = bufnr('%')
   file unreadable
+  let bufnr = bufnr('%')
   let maker = neomake#GetMaker(maker)
   AssertEqual maker.args, []
   let jobinfo = NeomakeTestsFakeJobinfo()
@@ -163,8 +163,8 @@ Execute (maker._get_argv uses jobinfo for bufnr):
 
 Execute (_get_fname_for_buffer handles modified buffer with disabled tempfiles):
   new
-  let b:neomake_tempfile_enabled = 0
   file file1
+  let b:neomake_tempfile_enabled = 0
   set modified
   let maker = neomake#GetMaker({})
   let jobinfo = NeomakeTestsFakeJobinfo()

--- a/tests/utils.vader
+++ b/tests/utils.vader
@@ -375,9 +375,9 @@ Execute (neomake#utils#MakerFromCommand uses tempfile):
   let maker = neomake#utils#MakerFromCommand('echo')
 
   new
+  file dir/\ with\ spaces
   let b:neomake_tempfile_enabled = 1
   let jobinfo = NeomakeTestsFakeJobinfo()
-  file dir/\ with\ spaces
 
   set buftype=nofile
   let bound_maker = neomake#GetMaker(maker).fn(jobinfo)


### PR DESCRIPTION
This ensures to not mess with the '[Vader-workbench]' buffer's name.