### PR TITLE
doc: add Neomake help tag

### DIFF
--- a/doc/neomake.txt
+++ b/doc/neomake.txt
@@ -1,4 +1,4 @@
-*neomake.txt* Asynchronous make for Vim version 7.4 and Neovim
+*Neomake* - asynchronous make for Vim version 7.4+ and Neovim
 
         ███╗   ██╗███████╗ ██████╗ ███╗   ███╗ █████╗ ██╗  ██╗███████╗
         ████╗  ██║██╔════╝██╔═══██╗████╗ ████║██╔══██╗██║ ██╔╝██╔════╝


### PR DESCRIPTION
Linking to `neomake.txt` does not work by default?! ('.' missing in
'iskeyword').