### PR TITLE
Rubocop: add --force-exclusion

### DIFF
--- a/autoload/neomake/makers/ft/ruby.vim
+++ b/autoload/neomake/makers/ft/ruby.vim
@@ -6,7 +6,7 @@ endfunction
 
 function! neomake#makers#ft#ruby#rubocop() abort
     return {
-        \ 'args': ['--format', 'emacs'],
+        \ 'args': ['--format', 'emacs', '--force-exclusion'],
         \ 'errorformat': '%f:%l:%c: %t: %m,%E%f:%l: %m',
         \ 'postprocess': function('neomake#makers#ft#ruby#RubocopEntryProcess')
         \ }


### PR DESCRIPTION
Problem: Neomake was running rubocop on a file that had been ignored in `.rubocop.yml`
Solution: Used the recommended flag to indicate that `rubocop <file>` runs should still adhere to these exclusions. To quote a contributor [over in rubocop's github repo](https://github.com/bbatsov/rubocop/issues/2492#issuecomment-164375887):
> There's an option called --force-exclusion, which editor plugins should use. The problem is that when you give a single file name to rubocop, then Exclude parameters don't come into play. Unless you run with --force-exclusion. 