### PR TITLE
d: fix s:UpdateDub

### DIFF
--- a/autoload/neomake/makers/ft/d.vim
+++ b/autoload/neomake/makers/ft/d.vim
@@ -27,8 +27,8 @@ function! s:UpdateDub() abort
     let l:tmp_file = s:findDubRoot()
     if executable('dub') && !empty(l:tmp_file)
         let l:tmp_dir = fnamemodify(l:tmp_file,':p:h')
-        let l:dubCmd = 'dub describe --data=import-paths --annotate \
-                    \--skip-registry=all --vquiet --data-list --root='
+        let l:dubCmd = 'dub describe --data=import-paths --annotate '
+                    \ .'--skip-registry=all --vquiet --data-list --root='
         let l:output = system(l:dubCmd . tmp_dir)
         if(v:shell_error == 0 && !empty(l:output))
             " Is \n portable?


### PR DESCRIPTION
The following results in '1 \2' and not '1 2':

    let foo = '1 \
          \2'

/cc @rsw0x (since you added it in https://github.com/neomake/neomake/pull/239)