### PR TITLE
Fix bufnr handling with get_list_entries/process_output

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -1693,7 +1693,7 @@ function! s:map_makers(options, makers, ...) abort
                 else
                     let cwd = expand(cwd, 1)
                 endif
-                let options.cwd = fnamemodify(cwd, ':p')
+                let options.cwd = substitute(fnamemodify(cwd, ':p'), '[\/]$', '', '')
             endif
 
             if has_key(maker, '_bind_args')

--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -1152,7 +1152,7 @@ function! s:ProcessJobOutput(jobinfo, lines, source) abort
             let entries = call(maker.process_output, [{
                         \ 'output': a:lines,
                         \ 'source': a:source,
-                        \ 'jobinfo': a:jobinfo}])
+                        \ 'jobinfo': a:jobinfo}], maker)
             call s:ProcessEntries(a:jobinfo, entries)
             return
         endif

--- a/doc/neomake.txt
+++ b/doc/neomake.txt
@@ -91,14 +91,14 @@ location/quickfix list: >
     let maker = {'name': 'My maker'}
     function! maker.get_list_entries(jobinfo) abort
       return [
-        \ {'text': 'Some error', 'lnum': 1, 'bufnr': bufnr('%')},
+        \ {'text': 'Some error', 'lnum': 1, 'bufnr': a:jobinfo.bufnr},
         \ {'text': 'Some warning', 'type': 'W', 'lnum': 2, 'col': 1,
-        \  'length': 5},
+        \  'length': 5, 'filename': '/path/to/file'},
         \ ]
     endfunction
 <
-The required keys for entries are `text` and `lnum`.  `bufnr` defaults to the
-jobs's buffer.
+The required keys for entries are `text` and `lnum`, and you should set one of
+`bufnr` or `filename` (otherwise the entry will not be valid).
 The `length` entry in the example is internal to Neomake, and sets the length
 for an highlight (see |neomake-highlight|).
 

--- a/tests/cwd.vader
+++ b/tests/cwd.vader
@@ -1,5 +1,15 @@
 Include: include/setup.vader
 
+Execute (neomake#Make handles invalid cwd):
+  let maker = {
+      \ 'name': 'custom_maker',
+      \ 'exe': 'true',
+      \ 'cwd': '/doesnotexist',
+      \ }
+  call neomake#Make(1, [maker])
+  NeomakeTestsWaitForFinishedJobs
+  AssertNeomakeMessage "custom_maker: could not change to maker's cwd (/doesnotexist): Vim(cd):E344: Can't find directory \"/doesnotexist\" in cdpath.", 0
+
 Execute (tcd is handled properly):
   if exists(':tcd') != 2
     NeomakeTestsSkip 'no :tcd'

--- a/tests/cwd.vader
+++ b/tests/cwd.vader
@@ -133,3 +133,301 @@ Execute (cwd per maker):
   NeomakeTestsWaitForFinishedJobs
 
   AssertEqual map(copy(getqflist()), 'v:val.text'), [maker1.cwd, maker2.cwd]
+
+Execute (get_list_entries: filename with cwd (non-existing file)):
+  let tempdir = tempname()
+  let slash = neomake#utils#Slash()
+  let subdir = tempdir . slash . 'project' . slash . 'sub'
+  call mkdir(subdir, 'p', 0700)
+
+  new
+  file project/sub/file_in_subdir_1
+  let bufnr = bufnr('%')
+
+  let maker = {'cwd': '%:p:h'}
+  function! maker.get_list_entries(...) abort dict
+    return [{
+      \ 'filename': 'file_in_subdir_1',
+      \ 'lnum': 23,
+      \ 'col': 42,
+      \ 'text': 'error message',
+      \ 'type': 'E',
+      \ }]
+  endfunction
+
+  " uses unlisted buffer if file does not exist
+  call neomake#Make(1, [maker])
+  NeomakeTestsWaitForFinishedJobs
+  AssertEqual getloclist(0), [{
+  \ 'lnum': 23,
+  \ 'bufnr': bufnr + 1,
+  \ 'col': 42,
+  \ 'valid': 1,
+  \ 'vcol': 0,
+  \ 'nr': -1,
+  \ 'type': 'E',
+  \ 'pattern': '',
+  \ 'text': 'error message'}]
+  let unlisted_bufnr = bufnr+1
+  let bwipe_buffers = [unlisted_bufnr]
+  AssertEqual bufname(unlisted_bufnr), 'file_in_subdir_1'
+  Assert !buflisted(unlisted_bufnr), 'buffer is unlisted (1)'
+
+  " uses unlisted buffer if file does not exist (cwd matches)
+  let orig_cwd = getcwd()
+  exe 'lcd' tempdir
+  call neomake#Make(1, [maker])
+  NeomakeTestsWaitForFinishedJobs
+
+  if has('patch-7.4.2017')
+    let expected_bufnr = unlisted_bufnr
+  else
+    let expected_bufnr = unlisted_bufnr + 1
+    let bwipe_buffers += [expected_bufnr]
+  endif
+  AssertEqual getloclist(0), [{
+  \ 'lnum': 23,
+  \ 'bufnr': expected_bufnr,
+  \ 'col': 42,
+  \ 'valid': 1,
+  \ 'vcol': 0,
+  \ 'nr': -1,
+  \ 'type': 'E',
+  \ 'pattern': '',
+  \ 'text': 'error message'}]
+  AssertEqual bufname(unlisted_bufnr), orig_cwd.'/file_in_subdir_1'
+  Assert !buflisted(unlisted_bufnr), 'buffer is unlisted (2)'
+
+  for b in bwipe_buffers
+    exe 'bwipe' b
+  endfor
+  bwipe
+
+Execute (get_list_entries: filename with cwd):
+  let tempdir = tempname()
+  let slash = neomake#utils#Slash()
+  let subdir = tempdir . slash . 'project' . slash . 'sub'
+  call mkdir(subdir, 'p', 0700)
+
+  let maker = {'cwd': '%:p:h'}
+  function! maker.get_list_entries(...) abort dict
+    return [{
+      \ 'filename': 'file_in_subdir_2',
+      \ 'lnum': 23,
+      \ 'col': 42,
+      \ 'text': 'error message',
+      \ 'type': 'E',
+      \ }]
+  endfunction
+
+  new
+  let bufnr = bufnr('%')
+  exe 'lcd' tempdir
+  write project/sub/file_in_subdir_2
+  AssertEqual expand('%:p'), tempdir.'/project/sub/file_in_subdir_2'
+  Assert filereadable('project/sub/file_in_subdir_2'), 'file is readable'
+
+  call neomake#Make(1, [maker])
+  NeomakeTestsWaitForFinishedJobs
+  AssertNeomakeMessage 'Updating entry bufnr: 0 => '.bufnr.'.'
+
+  AssertEqual getloclist(0), [{
+  \ 'lnum': 23,
+  \ 'bufnr': bufnr('%'),
+  \ 'col': 42,
+  \ 'valid': 1,
+  \ 'vcol': 0,
+  \ 'nr': -1,
+  \ 'type': 'E',
+  \ 'pattern': '',
+  \ 'text': 'error message'}]
+
+  bwipe
+
+Execute (process_output: filename with cwd):
+  let tempdir = tempname()
+  let slash = neomake#utils#Slash()
+  let subdir = tempdir . slash . 'project' . slash . 'sub'
+  call mkdir(subdir, 'p', 0700)
+
+  let maker = {'exe': 'printf', 'args': '1', 'cwd': '%:p:h'}
+  function! maker.process_output(...) abort dict
+    return [{
+      \ 'filename': 'file_in_subdir_3',
+      \ 'lnum': 23,
+      \ 'col': 42,
+      \ 'text': 'error message',
+      \ 'type': 'E',
+      \ }]
+  endfunction
+
+  new
+  let bufnr = bufnr('%')
+  exe 'lcd' tempdir
+  write project/sub/file_in_subdir_3
+  AssertEqual expand('%:p'), tempdir.'/project/sub/file_in_subdir_3'
+  Assert filereadable('project/sub/file_in_subdir_3'), 'file is readable'
+
+  call neomake#Make(1, [maker])
+  NeomakeTestsWaitForFinishedJobs
+
+  AssertNeomakeMessage 'Updating entry bufnr: 0 => '.bufnr.'.'
+
+  AssertEqual getloclist(0), [{
+  \ 'lnum': 23,
+  \ 'bufnr': bufnr('%'),
+  \ 'col': 42,
+  \ 'valid': 1,
+  \ 'vcol': 0,
+  \ 'nr': -1,
+  \ 'type': 'E',
+  \ 'pattern': '',
+  \ 'text': 'error message'}]
+
+  bwipe
+
+Execute (legacy errorformat maker: filename with cwd):
+  let tempdir = tempname()
+  let slash = neomake#utils#Slash()
+  let subdir = tempdir . slash . 'project' . slash . 'sub'
+  call mkdir(subdir, 'p', 0700)
+
+  let maker = {
+  \ 'exe': 'printf',
+  \ 'args': '"file_in_subdir_4:23:42:E:error message"',
+  \ 'errorformat': '%f:%l:%c:%t:%m',
+  \ 'cwd': '%:p:h'}
+
+  new
+  let bufnr = bufnr('%')
+  exe 'lcd' tempdir
+  write project/sub/file_in_subdir_4
+  AssertEqual expand('%:p'), tempdir.'/project/sub/file_in_subdir_4'
+  Assert filereadable('project/sub/file_in_subdir_4'), 'file is readable'
+
+  call neomake#Make(1, [maker])
+  NeomakeTestsWaitForFinishedJobs
+
+"   AssertNeomakeMessage 'Updating entry bufnr: 0 => '.bufnr.'.'
+
+  AssertEqual getloclist(0), [{
+  \ 'lnum': 23,
+  \ 'bufnr': bufnr('%'),
+  \ 'col': 42,
+  \ 'valid': 1,
+  \ 'vcol': 0,
+  \ 'nr': -1,
+  \ 'type': 'E',
+  \ 'pattern': '',
+  \ 'text': 'error message'}]
+
+  bwipe
+
+Execute (legacy errorformat maker: filename with cwd (error: removed)):
+  if v:version < 705 && !(v:version == 704 && has('patch1107'))
+    NeomakeTestsSkip 'cannot delete direcories easily'
+    return
+  endif
+  let tempdir = tempname()
+  let slash = neomake#utils#Slash()
+  let subdir = tempdir . slash . 'project' . slash . 'sub'
+  call mkdir(subdir, 'p', 0700)
+
+  let maker = NeomakeTestsCommandMaker('print_error',
+  \ 'printf "file_in_subdir_5:23:42:E:error message"')
+  call extend(maker, {
+  \ 'errorformat': '%f:%l:%c:%t:%m',
+  \ 'cwd': '%:p:h'})
+
+  new
+  exe 'lcd' tempdir
+  write project/sub/file_in_subdir_5
+  let tempfile = expand('%:p')
+  let bufnr = bufnr('%')
+  AssertEqual tempfile, tempdir.'/project/sub/file_in_subdir_5'
+  Assert filereadable('project/sub/file_in_subdir_5'), 'file is readable'
+
+  call neomake#Make(1, [maker])
+
+  if neomake#has_async_support()
+    " Delete the file and dir to trigger the cd error.
+    let tempfile_dir = fnamemodify(tempfile, ':h')
+    AssertEqual 0, delete(tempfile)
+    AssertEqual 0, delete(tempfile_dir, 'd')
+    NeomakeTestsWaitForFinishedJobs
+
+    AssertNeomakeMessage printf("Could not change to job's cwd (%s): %s",
+    \ tempfile_dir,
+    \ printf("Vim(lcd):E344: Can't find directory \"%s\" in cdpath.", tempfile_dir))
+
+    " A new unlisted buffer should have been created.
+    try
+      " try/catch for 'throw' in 'msg' setting.
+      let loclist_bufnr = bufnr('^file_in_subdir_5$')
+    catch
+      Assert 0, printf('could not find file_in_subdir_5 unlisted buffer: %s: %s',
+        \ v:exception, neomake#utils#redir('ls!'))
+    endtry
+    Assert !buflisted(loclist_bufnr), 'buffer is unlisted'
+    AssertNotEqual bufnr('%'), loclist_bufnr
+
+    let expected_bufnr = loclist_bufnr
+  else
+    let expected_bufnr = bufnr('%')
+  endif
+
+  " Filtering out 'shell-init: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory'
+  AssertEqual filter(copy(getloclist(0)), "v:val.text !~# '^shell-init'"), [{
+  \ 'lnum': 23,
+  \ 'bufnr': expected_bufnr,
+  \ 'col': 42,
+  \ 'valid': 1,
+  \ 'vcol': 0,
+  \ 'nr': -1,
+  \ 'type': 'E',
+  \ 'pattern': '',
+  \ 'text': 'error message'}]
+  if exists('loclist_bufnr')
+    exe 'bwipe' loclist_bufnr
+  endif
+  bwipe
+
+  AssertNeomakeMessage 'Placing sign: sign place 5000 line=23 name=neomake_err buffer='.expected_bufnr.'.'
+
+Execute (legacy errorformat maker: filename with cwd (error: maker rmdir)):
+  let tempdir = tempname()
+  call mkdir(tempdir, 'p', 0700)
+
+  let maker = NeomakeTestsCommandMaker('remove_dir_and_print_error',
+  \ printf('rmdir %s && printf "file_in_subdir_6:23:42:E:error message"', tempdir))
+  call extend(maker, {
+  \ 'errorformat': '%f:%l:%c:%t:%m',
+  \ 'cwd': tempdir})
+
+  new
+  call neomake#Make(1, [maker])
+  NeomakeTestsWaitForFinishedJobs
+
+  AssertNeomakeMessage printf("Could not change to job's cwd (%s): %s",
+  \ tempdir,
+  \ printf("Vim(cd):E344: Can't find directory \"%s\" in cdpath.", tempdir))
+
+  " A new unlisted buffer should have been created.
+  let unlisted_bufnr = bufnr('^file_in_subdir_6$')
+  Assert !buflisted(unlisted_bufnr), 'buffer is unlisted'
+  AssertNotEqual bufnr('%'), unlisted_bufnr
+
+  " Filtering out 'shell-init: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory'
+  AssertEqual filter(copy(getloclist(0)), "v:val.text !~# '^shell-init'"), [{
+  \ 'lnum': 23,
+  \ 'bufnr': unlisted_bufnr,
+  \ 'col': 42,
+  \ 'valid': 1,
+  \ 'vcol': 0,
+  \ 'nr': -1,
+  \ 'type': 'E',
+  \ 'pattern': '',
+  \ 'text': 'error message'}]
+
+  bwipe
+  exe 'bwipe' unlisted_bufnr

--- a/tests/makers.vader
+++ b/tests/makers.vader
@@ -292,7 +292,7 @@ Execute (Makers: get_list_entries via config):
 
   Save g:neomake_test_entries
   let g:neomake_test_entries = [{
-    \ 'filename': 'not_used_with_valid_bufnr',
+    \ 'filename': 'unloaded_filename_without_bufnr',
     \ 'lnum': 23,
     \ 'pattern': '',
     \ 'col': 42,
@@ -319,9 +319,12 @@ Execute (Makers: get_list_entries via config):
   let expected = map(copy(g:neomake_test_entries), "extend(v:val, {'valid': 1})")
   " filename is removed
   let expected = map(expected, "filter(v:val, 'v:key != \"filename\"')")
-  " bufnr gets added from jobinfo
-  let expected = map(expected, "extend(v:val, {'bufnr': bufnr})")
-  AssertEqual getloclist(0), g:neomake_test_entries
+  " Unlisted buffer gets added for filename.
+  let unlisted_bufnr = bufnr('unloaded_filename_without_bufnr')
+  Assert !empty(unlisted_bufnr), 'unlisted_bufnr is not empty'
+  let expected[0].bufnr = unlisted_bufnr
+
+  AssertEqual getloclist(0), expected
 
   AssertEqual len(g:neomake_test_countschanged), 1
   AssertEqual len(g:neomake_test_jobfinished), 1
@@ -334,28 +337,52 @@ Execute (get_list_entries: minimal example (from doc)):
   new
   call g:NeomakeSetupAutocmdWrappers()
   let buf1 = bufnr('%')
+  file get_list_entries_buf1
 
-  let maker = {'name': 'My maker'}
+  let maker = {'name': 'My maker', 'my_orig_bufnr': buf1}
   function! maker.get_list_entries(jobinfo) abort
     " Change bufnr.
     new
     return [
-      \ {'text': 'Some error', 'lnum': 1, 'bufnr': bufnr('%')},
-      \ {'text': 'Some warning', 'type': 'W', 'lnum': 2, 'col': 1, 'length': 5},
+      \ {'text': 'Some error', 'lnum': 1, 'bufnr': a:jobinfo.bufnr},
+      \ {'text': 'Some warning without bufnr', 'type': 'W', 'lnum': 2,
+      \  'col': 1, 'length': 5},
+      \ {'text': 'Some warning', 'type': 'W', 'lnum': 2, 'col': 1,
+      \  'bufnr': a:jobinfo.maker.my_orig_bufnr, 'length': 2},
+      \ {'text': 'Some info', 'type': 'I', 'lnum': 3, 'col': 1,
+      \  'filename': '/path/to/file'},
+      \ {'text': 'Some non-type', 'type': '', 'lnum': 4, 'col': 1, 'length': 23,
+      \  'filename': 'get_list_entries_buf1'},
       \ ]
   endfunction
   call neomake#Make(1, [maker])
 
-  " .length was transformed into a highlight.
-  AssertEqual [[1, -1], [2, 5]], g:neomake_tests_highlight_lengths
+  AssertEqual [[1, -1], [2, 2], [3, -1], [4, 23]], g:neomake_tests_highlight_lengths
 
-  AssertEqual getloclist(0), [
-  \ {'lnum': 1, 'bufnr': bufnr('%'), 'col': 0, 'valid': 1, 'vcol': 0, 'nr': -1,
+  let llist = getloclist(0)
+
+  " Check that unlisted buffer was created for filename.
+  let unlisted_bufnr = bufnr('/path/to/file')
+  Assert !empty(unlisted_bufnr), 'Unlisted buffer was created (1)'
+  Assert !buflisted(unlisted_bufnr), 'Unlisted buffer was created (2)'
+
+  " Check that existing buffer was used for filename.
+  AssertEqual llist[4].bufnr, buf1, 'get_list_entries_buf1 was picked up'
+
+  AssertEqual llist, [
+  \ {'lnum': 1, 'bufnr': buf1, 'col': 0, 'valid': 1, 'vcol': 0, 'nr': -1,
   \  'type': 'E', 'pattern': '', 'text': 'Some error'},
+  \ {'lnum': 2, 'bufnr': 0, 'col': 1, 'valid': 0, 'vcol': 0, 'nr': -1,
+  \  'type': 'W', 'pattern': '', 'text': 'Some warning without bufnr'},
   \ {'lnum': 2, 'bufnr': buf1, 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1,
-  \  'type': 'W', 'pattern': '', 'text': 'Some warning'}]
+  \  'type': 'W', 'pattern': '', 'text': 'Some warning'},
+  \ {'lnum': 3, 'bufnr': unlisted_bufnr, 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1,
+  \  'type': 'I', 'pattern': '', 'text': 'Some info'},
+  \ {'lnum': 4, 'bufnr': buf1, 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1,
+  \  'type': '', 'pattern': '', 'text': 'Some non-type'} ]
   bwipe
   bwipe
+  exe 'bwipe '.unlisted_bufnr
 
   AssertEqual len(g:neomake_test_countschanged), 1
   AssertEqual len(g:neomake_test_finished), 1

--- a/tests/neomake.vader
+++ b/tests/neomake.vader
@@ -201,16 +201,6 @@ Execute (neomake#CompleteJobs):
     NeomakeTestsWaitForFinishedJobs
   endif
 
-Execute (neomake#Make handles invalid cwd):
-  let maker = {
-      \ 'name': 'custom_maker',
-      \ 'exe': 'true',
-      \ 'cwd': '/doesnotexist',
-      \ }
-  call neomake#Make(1, [maker])
-  NeomakeTestsWaitForFinishedJobs
-  AssertNeomakeMessage "custom_maker: could not change to maker's cwd (/doesnotexist): Vim(cd):E344: Can't find directory \"/doesnotexist\" in cdpath.", 0
-
 Execute (Neomake picks up custom maker correctly):
   let g:neomake_c_lint_maker = {
     \ 'exe': 'echo',

--- a/tests/processing.vader
+++ b/tests/processing.vader
@@ -309,6 +309,7 @@ Execute (100 lines of output should not get processed one by one):
   NeomakeTestsWaitForFinishedJobs
   let c = g:neomake_test_countschanged
   Assert len(c) < 50, 'There were 50+ count changes: '.len(c)
+  AssertNeomakeMessage '\v^Skipped \d+ entries without bufnr\.'
 
 Execute (Mixed newlines get handled correctly):
   let maker = {

--- a/tests/signs.vader
+++ b/tests/signs.vader
@@ -222,7 +222,8 @@ Execute (neomake#signs#PlaceSigns with E and I):
 
 Execute (Signs get handled across multiple jobs):
   function! NeomakeTestsEntries(jobinfo) abort dict
-    return g:neomake_test_entries[self._idx]
+    return map(copy(g:neomake_test_entries[self._idx]),
+    \ "extend(v:val, {'bufnr': bufnr('%')}, 'keep')")
   endfunction
 
   let maker1 = {'get_list_entries': function('NeomakeTestsEntries'),


### PR DESCRIPTION
`bufnr` does not default to the job's bufnr anymore, but is expected to
be given as `bufnr` or `filename`.  The `bufnr` is then picked up from
the parsed location/quickfix list entries (where Vim will have created
an unlisted buffer for non-opened filename entries).

Ref: https://github.com/neomake/neomake/pull/1194#pullrequestreview-35487107
Ref: https://github.com/neomake/neomake/pull/1218

TODO:
 - [x] need to modify filename based on cwd
 - [x] tests for process_output / legacy errorformat makers