### PR TITLE
Makefile: add testwatch{,x} targets, via inotifywait

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,11 +28,12 @@ TEST_VIMRC:=tests/vim/vimrc
 # This is expected in tests.
 TEST_VIM_PREFIX:=SHELL=/bin/bash
 
+testwatch: override export VADER_OPTIONS+=-q
 testwatch:
 	contrib/run-tests-watch
 
-testwatchx:
-	VADER_OPTIONS=-x contrib/run-tests-watch
+testwatchx: override export VADER_OPTIONS+=-x
+testwatchx: testwatch
 
 testx: VADER_OPTIONS=-x
 testx: test

--- a/Makefile
+++ b/Makefile
@@ -2,15 +2,14 @@
 CDPATH:=
 SHELL:=/bin/bash -o pipefail
 
-
 IS_NEOVIM=$(findstring nvim,$(TEST_VIM))$(findstring neovim,$(TEST_VIM))
 # Run testnvim and testvim by default, and only one if TEST_VIM is given.
 test: $(if $(TEST_VIM),$(if $(IS_NEOVIM),testnvim,testvim),testnvim testvim)
 
 VADER:=Vader!
-VADER_OPTIONS?=
-VADER_ARGS=tests/neomake.vader $(VADER_OPTIONS)
-VIM_ARGS='+$(VADER) $(VADER_ARGS)'
+VADER_OPTIONS:=
+VADER_ARGS=tests/neomake.vader
+VIM_ARGS='+$(VADER) $(VADER_ARGS) $(VADER_OPTIONS)'
 
 DEFAULT_VADER_DIR:=tests/vim/plugins/vader
 export TESTS_VADER_DIR:=$(firstword $(realpath $(wildcard tests/vim/plugins/vader.override)) $(DEFAULT_VADER_DIR))
@@ -29,10 +28,16 @@ TEST_VIMRC:=tests/vim/vimrc
 # This is expected in tests.
 TEST_VIM_PREFIX:=SHELL=/bin/bash
 
-testx: export VADER_OPTIONS=-x
+testwatch:
+	contrib/run-tests-watch
+
+testwatchx:
+	VADER_OPTIONS=-x contrib/run-tests-watch
+
+testx: VADER_OPTIONS=-x
 testx: test
 
-testnvimx: export VADER_OPTIONS=-x
+testnvimx: VADER_OPTIONS=-x
 testnvimx: testnvim
 
 # Neovim might quit after ~5s with stdin being closed.  Use --headless mode to
@@ -88,15 +93,15 @@ runvim: testvim_interactive
 runnvim: VIM_ARGS:=
 runnvim: testnvim_interactive
 
-TEST_TARGET:=test
-
 # Add targets for .vader files, absolute and relative.
 # This can be used with `b:dispatch = ':Make %'` in Vim.
 TESTS:=$(wildcard tests/*.vader tests/*/*.vader)
 uniq = $(if $1,$(firstword $1) $(call uniq,$(filter-out $(firstword $1),$1)))
 _TESTS_REL_AND_ABS:=$(call uniq,$(abspath $(TESTS)) $(TESTS))
+# Use nvim if it is installed, otherwise vim.
+FILE_TEST_TARGET=$(shell command -v nvim >/dev/null && echo testnvim || echo testvim)
 $(_TESTS_REL_AND_ABS):
-	make $(TEST_TARGET) VADER_ARGS='$@ $(VADER_OPTIONS)'
+	make $(FILE_TEST_TARGET) VADER_ARGS='$@'
 .PHONY: $(_TESTS_REL_AND_ABS)
 
 tags:

--- a/contrib/run-tests-watch
+++ b/contrib/run-tests-watch
@@ -1,18 +1,20 @@
-#!/bin/sh
+#!/bin/sh -x
 #
 # Wrapper around inotifywait to run tests on file changes.
-# If a test file changes, only this file is run, otherwise the whole test suite.
+# If a test file changes, only this file is run (first), while whole test suite
+# is run afterwards (and initially).
 #
 # The recommended way to run it is via `make testwatch`, or `make testwatchx`
 # (to exit on first failure).
 #
-# The default run command is "make %s" (where %s is # replaced with the test
-# file), and can be given as first argument.
+# # Internal documentation:
+#   The default run command is "make %s" (where %s gets replaced with the test
+#   file(s)), and can be given as first argument.
 #
-# You can specify VADER_OPTIONS=-x to exit on the first test failure:
-#     VADER_OPTIONS=-x contrib/run-tests-watch
-# Or
-#     contrib/run-tests-watch 'make %s VADER_OPTIONS=-x'
+#   You can specify VADER_OPTIONS=-x to exit on the first test failure:
+#       VADER_OPTIONS=-x contrib/run-tests-watch
+#   or use the following:
+#       contrib/run-tests-watch 'make %s VADER_OPTIONS=-x'
 
 watch="autoload plugin tests"
 echo "Watching: $watch"
@@ -20,7 +22,7 @@ echo "Watching: $watch"
 if [ -n "$1" ]; then
   cmdpattern="$1"
 else
-  cmdpattern="make %s VADER_OPTIONS=$VADER_OPTIONS"
+  cmdpattern="make %s VADER_OPTIONS='$VADER_OPTIONS'"
 fi
 
 title() {
@@ -28,38 +30,77 @@ title() {
   printf '\e]2;%s\a' "$*"
 }
 
+status_file=$(mktemp)
+handle_cmd_result() {
+  if [ "$1" = 0 ]; then
+    title "✔ $2"
+    if [ "$last_changed_testsfile" = "$alltestsfile" ]; then
+      alltests_succeeded=1
+    fi
+  else
+    title "✘ $2"
+    if [ "$last_changed_testsfile" = "$alltestsfile" ]; then
+      alltests_succeeded=0
+    fi
+  fi
+  echo "$alltests_succeeded" > "$status_file"
+}
+
 # Recursively kill childs - required to get out of a running pdb.
 kill_with_childs() {
   for p in $(pgrep -P "$1"); do
     kill_with_childs "$p"
   done
-  kill "$1"
+  if kill -0 "$1" 2>/dev/null; then
+    kill "$1" || true
+  fi
 }
 
+alltestsfile='tests/neomake.vader'
+alltests_succeeded=0
 pid=
 output=
-set -x
 set -e
+last_changed_testsfile="$alltestsfile"
+
 while true; do
   # reset
+  testfiles="$last_changed_testsfile"
   if [ -n "$output" ]; then
+    # There was a previous run
     echo "================================================================="
-    # echo "$output"
-    testfiles="$output"
-  else
-    testfiles='tests/neomake.vader'
-  fi
+    echo "$output"
 
-  if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
-    echo 'Killing previous run…'
-    kill_with_childs "$pid"
+    read -r alltests_succeeded < $status_file
+
+    if [ "${output#tests/}" != "$output" ]; then
+      last_changed_testsfile="$output"
+      testfiles="$output"
+      # Run full tests afterwards (if it has not succeeded before).
+      if [ "$output" != "$alltestsfile" ]; then
+        if [ "$alltests_succeeded" = 0 ]; then
+          testfiles="$testfiles $alltestsfile"
+        fi
+      fi
+    else
+      alltests_succeeded=0
+      if [ "$testfiles" != "$alltestsfile" ]; then
+        testfiles="$testfiles $alltestsfile"
+      fi
+    fi
+
+    if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+      echo 'Killing previous run…'
+      kill_with_childs "$pid"
+    fi
   fi
 
   # shellcheck disable=SC2059
-  cmd=$(printf "$cmdpattern" "$testfiles")
-  title "… $cmd"
+  cmd="$(printf "$cmdpattern" "$testfiles")"
+  echo "Running $cmd"
+  title "… $testfiles"
   # shellcheck disable=SC2015
-  ($cmd && title "✔ $cmd" || title "✘ $cmd") </dev/tty &
+  (set +e; eval "$cmd"; handle_cmd_result "$?" "$testfiles") </dev/tty &
   pid=$!
 
   sleep 1

--- a/contrib/run-tests-watch
+++ b/contrib/run-tests-watch
@@ -1,0 +1,70 @@
+#!/bin/sh
+#
+# Wrapper around inotifywait to run tests on file changes.
+# If a test file changes, only this file is run, otherwise the whole test suite.
+#
+# The recommended way to run it is via `make testwatch`, or `make testwatchx`
+# (to exit on first failure).
+#
+# The default run command is "make %s" (where %s is # replaced with the test
+# file), and can be given as first argument.
+#
+# You can specify VADER_OPTIONS=-x to exit on the first test failure:
+#     VADER_OPTIONS=-x contrib/run-tests-watch
+# Or
+#     contrib/run-tests-watch 'make %s VADER_OPTIONS=-x'
+
+watch="autoload plugin tests"
+echo "Watching: $watch"
+
+if [ -n "$1" ]; then
+  cmdpattern="$1"
+else
+  cmdpattern="make %s VADER_OPTIONS=$VADER_OPTIONS"
+fi
+
+title() {
+  printf '\e]1;%s\a' "$*"
+  printf '\e]2;%s\a' "$*"
+}
+
+# Recursively kill childs - required to get out of a running pdb.
+kill_with_childs() {
+  for p in $(pgrep -P "$1"); do
+    kill_with_childs "$p"
+  done
+  kill "$1"
+}
+
+pid=
+output=
+set -x
+set -e
+while true; do
+  # reset
+  if [ -n "$output" ]; then
+    echo "================================================================="
+    # echo "$output"
+    testfiles="$output"
+  else
+    testfiles='tests/neomake.vader'
+  fi
+
+  if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+    echo 'Killing previous run…'
+    kill_with_childs "$pid"
+  fi
+
+  # shellcheck disable=SC2059
+  cmd=$(printf "$cmdpattern" "$testfiles")
+  title "… $cmd"
+  # shellcheck disable=SC2015
+  ($cmd && title "✔ $cmd" || title "✘ $cmd") </dev/tty &
+  pid=$!
+
+  sleep 1
+  # shellcheck disable=SC2086
+  output="$(inotifywait -r -e close_write \
+    --exclude '/(__pycache__/|\.)|.*\.neomaketmp_.*' \
+    --format '%w%f' $watch)"
+done


### PR DESCRIPTION
This uses a new script (`contrib/run-tests-watch`) to help with running
tests on file changes.