### PR TITLE
sh: add dash maker

### DIFF
--- a/autoload/neomake/makers/ft/sh.vim
+++ b/autoload/neomake/makers/ft/sh.vim
@@ -68,3 +68,10 @@ function! neomake#makers#ft#sh#sh() abort
             \ '%E%f: %l: %m'
         \}
 endfunction
+
+function! neomake#makers#ft#sh#dash() abort
+    return {
+        \ 'args': ['-n'],
+        \ 'errorformat': '%E%f: %l: %m',
+        \}
+endfunction

--- a/tests/neomake.vader
+++ b/tests/neomake.vader
@@ -57,7 +57,7 @@ Execute (neomake#GetMakers):
   AssertEqual neomake#GetMakers('non-existent'), []
   AssertEqual neomake#GetMakers('pug'), ['puglint']
 
-  let sh_makers = ['checkbashisms', 'sh', 'shellcheck']
+  let sh_makers = ['checkbashisms', 'dash', 'sh', 'shellcheck']
   AssertEqual sort(neomake#GetMakers('sh')), sh_makers
 
   Save g:neomake_sh_enabled_makers


### PR DESCRIPTION
This is useful to explicitly use `dash` as a POSIX shell, in case
`/bin/sh` links to `bash`.