### PR TITLE
Clone of #1218 with added test case

### DIFF
--- a/autoload/neomake/makers/ft/rust.vim
+++ b/autoload/neomake/makers/ft/rust.vim
@@ -131,7 +131,6 @@ endfunction
 
 function! neomake#makers#ft#rust#FillErrorFromSpan(error, span) abort
     let a:error.filename = a:span.file_name
-    let a:error.bufnr = neomake#utils#get_or_create_buffer(a:error.filename)
     let a:error.col = a:span.column_start
     let a:error.lnum = a:span.line_start
     let a:error.length = a:span.byte_end - a:span.byte_start

--- a/autoload/neomake/makers/ft/rust.vim
+++ b/autoload/neomake/makers/ft/rust.vim
@@ -131,6 +131,7 @@ endfunction
 
 function! neomake#makers#ft#rust#FillErrorFromSpan(error, span) abort
     let a:error.filename = a:span.file_name
+    let a:error.bufnr = neomake#utils#get_or_create_buffer(a:error.filename)
     let a:error.col = a:span.column_start
     let a:error.lnum = a:span.line_start
     let a:error.length = a:span.byte_end - a:span.byte_start

--- a/autoload/neomake/utils.vim
+++ b/autoload/neomake/utils.vim
@@ -556,6 +556,17 @@ function! neomake#utils#write_tempfile(bufnr, temp_file) abort
     call writefile(buflines, a:temp_file, 'b')
 endfunction
 
+function! neomake#utils#get_or_create_buffer(filename) abort
+    " TODO: Remove usage of this once not supplying a bufnr to process_output
+    " works if the filename is not opened in a buffer yet.
+    let nr = bufnr(a:filename)
+    if nr == -1
+        execute 'badd ' . substitute(a:filename, ' ', '\\ ', 'g')
+        let nr = bufnr(a:filename)
+    endif
+    return nr
+endfunction
+
 " Wrapper around fnamemodify that handles special buffers (e.g. fugitive).
 function! neomake#utils#fnamemodify(bufnr, modifier) abort
     let bufnr = +a:bufnr

--- a/autoload/neomake/utils.vim
+++ b/autoload/neomake/utils.vim
@@ -556,17 +556,6 @@ function! neomake#utils#write_tempfile(bufnr, temp_file) abort
     call writefile(buflines, a:temp_file, 'b')
 endfunction
 
-function! neomake#utils#get_or_create_buffer(filename) abort
-    " TODO: Remove usage of this once not supplying a bufnr to process_output
-    " works if the filename is not opened in a buffer yet.
-    let nr = bufnr(a:filename)
-    if nr == -1
-        execute 'badd ' . substitute(a:filename, ' ', '\\ ', 'g')
-        let nr = bufnr(a:filename)
-    endif
-    return nr
-endfunction
-
 " Wrapper around fnamemodify that handles special buffers (e.g. fugitive).
 function! neomake#utils#fnamemodify(bufnr, modifier) abort
     let bufnr = +a:bufnr

--- a/tests/ft_rust.vader
+++ b/tests/ft_rust.vader
@@ -114,6 +114,42 @@ Execute (cargo warning message):
   AssertEqual [[2, 7]], g:neomake_tests_highlight_lengths
   bwipe
 
+Execute (cargo warning for file that is not open):
+  " Monkeypatch to check setting of length.
+  Save g:lengths
+  let g:lengths = []
+  function! neomake#highlights#AddHighlight(entry, type) abort
+      call add(g:lengths, a:entry.length)
+  endfunction
+
+  new
+  file src/some_other_file.rs
+  let cargo = neomake#makers#ft#rust#cargo()
+  let cargo.exe = 'cat'
+  let cargo.args = 'tests/fixtures/rust/cargo_warning.json'
+
+  call neomake#Make(1, [cargo])
+  NeomakeTestsWaitForFinishedJobs
+
+  new
+  file src/add_assign_like.rs
+
+  AssertEqual [{
+    \ 'type': 'W',
+    \ 'bufnr': bufnr('%'),
+    \ 'nr': -1,
+    \ 'lnum': 2,
+    \ 'col': 24,
+    \ 'valid': 1,
+    \ 'vcol': 0,
+    \ 'pattern': '',
+    \ 'text': 'unused import: `Variant`, #[warn(unused_imports)] on by default'}], getloclist(0)
+
+  AssertEqual [7], g:lengths
+  bwipe
+  " Undo monkeypatch.
+  runtime autoload/neomake/highlights.vim
+
 Execute (cargo error message children):
   NeomakeTestsMonkeypatchHighlights
 

--- a/tests/ft_rust.vader
+++ b/tests/ft_rust.vader
@@ -114,29 +114,30 @@ Execute (cargo warning message):
   AssertEqual [[2, 7]], g:neomake_tests_highlight_lengths
   bwipe
 
+  " Work around https://github.com/vim/vim/issues/1676 for next test(s).
+  cgetexpr 'bust_cache:1676:workaround_vim_issue'
+  bwipe bust_cache
+
 Execute (cargo warning for file that is not open):
-  " Monkeypatch to check setting of length.
-  Save g:lengths
-  let g:lengths = []
-  function! neomake#highlights#AddHighlight(entry, type) abort
-      call add(g:lengths, a:entry.length)
-  endfunction
+  NeomakeTestsMonkeypatchHighlights
 
   new
   file src/some_other_file.rs
 
   let cargo = neomake#makers#ft#rust#cargo()
   let cargo.exe = 'cat'
+  " Uses src/add_assign_like.rs.
   let cargo.args = 'tests/fixtures/rust/cargo_warning.json'
 
   call neomake#Make(1, [cargo])
   NeomakeTestsWaitForFinishedJobs
 
-  edit src/add_assign_like.rs
+  let unlisted_bufnr = bufnr('^src/add_assign_like.rs$')
+  AssertNotEqual -1, unlisted_bufnr
 
   AssertEqual [{
     \ 'type': 'W',
-    \ 'bufnr': bufnr('%'),
+    \ 'bufnr': unlisted_bufnr,
     \ 'nr': -1,
     \ 'lnum': 2,
     \ 'col': 24,
@@ -145,10 +146,9 @@ Execute (cargo warning for file that is not open):
     \ 'pattern': '',
     \ 'text': 'unused import: `Variant`, #[warn(unused_imports)] on by default'}], getloclist(0)
 
-  AssertEqual [7], g:lengths
+  AssertEqual [[2, 7]], g:neomake_tests_highlight_lengths
   bwipe
-  " Undo monkeypatch.
-  runtime autoload/neomake/highlights.vim
+  exe 'bwipe' unlisted_bufnr
 
 Execute (cargo error message children):
   NeomakeTestsMonkeypatchHighlights

--- a/tests/ft_rust.vader
+++ b/tests/ft_rust.vader
@@ -124,6 +124,7 @@ Execute (cargo warning for file that is not open):
 
   new
   file src/some_other_file.rs
+
   let cargo = neomake#makers#ft#rust#cargo()
   let cargo.exe = 'cat'
   let cargo.args = 'tests/fixtures/rust/cargo_warning.json'
@@ -131,8 +132,7 @@ Execute (cargo warning for file that is not open):
   call neomake#Make(1, [cargo])
   NeomakeTestsWaitForFinishedJobs
 
-  new
-  file src/add_assign_like.rs
+  edit src/add_assign_like.rs
 
   AssertEqual [{
     \ 'type': 'W',


### PR DESCRIPTION
This highlights the issue that I was having and shows why I created
get_or_create_buffer. If another file is open an no bufnr is given the current
bufnr is used.