### PR TITLE
Do not use string representation for non-async "Starting" message

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -304,7 +304,7 @@ function! s:MakeJob(make_id, options) abort
             endif
         else
             call neomake#utils#DebugMessage('Running synchronously.')
-            call neomake#utils#LoudMessage(printf('Starting: %s.', string(argv)), jobinfo)
+            call neomake#utils#LoudMessage(printf('Starting: %s.', argv), jobinfo)
 
             let jobinfo.id = job_id
             let s:jobs[job_id] = jobinfo

--- a/tests/integration.vader
+++ b/tests/integration.vader
@@ -450,7 +450,7 @@ Execute (Neomake#Make: error with failing job via jobstart/argv):
   if neomake#has_async_support()
     AssertNeomakeMessage "Starting async job: ['doesnotexist']."
   else
-    AssertNeomakeMessage "Starting: 'doesnotexist'."
+    AssertNeomakeMessage "Starting: doesnotexist."
   endif
 
   if has('nvim-0.1.8')
@@ -489,7 +489,7 @@ Execute (Neomake#Make: error with failing job via jobstart/argv + true):
   if neomake#has_async_support()
     AssertNeomakeMessage "Starting async job: ['doesnotexist']."
   else
-    AssertNeomakeMessage "Starting: 'doesnotexist'."
+    AssertNeomakeMessage "Starting: doesnotexist."
   endif
 
   if has('nvim-0.1.8')

--- a/tests/neomake.vader
+++ b/tests/neomake.vader
@@ -229,6 +229,6 @@ Execute (Neomake picks up custom maker correctly):
     AssertNeomakeMessage "Starting async job: ['echo', '".fname."', '--foo', 'bar']."
     NeomakeTestsWaitForFinishedJobs
   else
-    AssertNeomakeMessage "Starting: 'echo ".fname." --foo bar'."
+    AssertNeomakeMessage printf('Starting: echo %s --foo bar.', fname)
   endif
   bwipe

--- a/tests/tempfiles.vader
+++ b/tests/tempfiles.vader
@@ -128,7 +128,7 @@ Execute (Maker can specify temporary file to use via fn):
   if neomake#has_async_support()
     AssertNeomakeMessage "Starting async job: ['true', '".g:neomake_test_tempfile."']."
   else
-    AssertNeomakeMessage "Starting: 'true ".fnameescape(g:neomake_test_tempfile)."'."
+    AssertNeomakeMessage printf('Starting: true %s.', fnameescape(g:neomake_test_tempfile))
   endif
   bwipe
 

--- a/tests/verbosity.vader
+++ b/tests/verbosity.vader
@@ -73,7 +73,7 @@ Execute (neomake#Make uses &verbose):
     \ [[2, "Starting async job: ['echo', '1'].", {'make_id': make_id, 'bufnr': bufnr}]]
   else
     AssertEqual g:neomake_test_messages,
-    \ [[2, "Starting: 'echo 1'.", {'make_id': make_id, 'bufnr': bufnr}]]
+    \ [[2, "Starting: echo 1.", {'make_id': make_id, 'bufnr': bufnr}]]
   endif
   AssertEqual len(g:neomake_test_messages), 1
 


### PR DESCRIPTION
This adds an extra quoting level, which makes it harder to copy'n'paste.