### PR TITLE
tests: sleep_maker: sleep a bit more

### DIFF
--- a/tests/include/init.vim
+++ b/tests/include/init.vim
@@ -306,7 +306,7 @@ let g:sleep_efm_maker = {
     \ 'errorformat': '%f:%l:%t:%m',
     \ 'append_file': 0,
     \ }
-let g:sleep_maker = NeomakeTestsCommandMaker('sleep-maker', 'sleep .01; echo slept')
+let g:sleep_maker = NeomakeTestsCommandMaker('sleep-maker', 'sleep .05; echo slept')
 let g:error_maker = NeomakeTestsCommandMaker('error-maker', 'echo error; false')
 let g:success_maker = NeomakeTestsCommandMaker('success-maker', 'echo success')
 let g:doesnotexist_maker = {'exe': 'doesnotexist'}

--- a/tests/processing.vader
+++ b/tests/processing.vader
@@ -289,6 +289,7 @@ Execute (Job does not get restarted when canceled):
     let jobinfo = neomake#GetJob(jobs[0])
     NeomakeTestsWaitForMessage "stdout: mymaker: ['output', ''].", 3, jobinfo
     call neomake#CancelJob(jobinfo.id)
+
     let jobinfo2 = neomake#GetJob(neomake#Make(1, [maker])[0])
     NeomakeTestsWaitForFinishedJobs
 

--- a/tests/tempfiles.vader
+++ b/tests/tempfiles.vader
@@ -264,10 +264,10 @@ Execute (same tempfile is used for all jobs (serialized)):
 
     AssertEqual [
     \ 'cat '.make_info.tempfile,
-    \ 'sleep .01; echo slept',
+    \ 'sleep .05; echo slept',
     \ 'cat '.maker2.tempfile_name,
     \ 'cat '.make_info.tempfile,
-    \ 'sleep .01; echo slept'], map(copy(g:neomake_test_jobfinished),
+    \ 'sleep .05; echo slept'], map(copy(g:neomake_test_jobfinished),
     \                              'v:val.jobinfo.maker.args[-1]')
 
     AssertEqual map(copy(getloclist(0)), 'v:val.text'),


### PR DESCRIPTION
This should fix flakyness of "Neomake#Make cancels previous jobs".