### PR TITLE
Refactor pending output processing

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -145,15 +145,6 @@ function! s:gettabwinvar(t, w, v, d) abort
     return r
 endfunction
 
-function! s:AddMakeInfoForCurrentWin(job_id) abort
-    " Add jobinfo.make_id to current window.
-    let tabpagenr = tabpagenr()
-    let winnr = winnr()
-    let w_ids = s:gettabwinvar(tabpagenr, winnr, 'neomake_make_ids', [])
-    let w_ids += [a:job_id]
-    call settabwinvar(tabpagenr, winnr, 'neomake_make_ids', w_ids)
-endfunction
-
 function! s:MakeJob(make_id, options) abort
     let job_id = s:job_id
     let s:job_id += 1
@@ -755,7 +746,7 @@ function! s:Make(options) abort
         endif
     endif
 
-    call s:AddMakeInfoForCurrentWin(make_id)
+    let w:neomake_make_ids = add(get(w:, 'neomake_make_ids', []), make_id)
 
     " TODO: return jobinfos?!
     let job_ids = []

--- a/doc/neomake.txt
+++ b/doc/neomake.txt
@@ -590,16 +590,6 @@ By default, `LoclistCounts` returns the counts for the current buffer (i.e.
 will retrieve the counts for a particular buffer, while passing the string
 "`all`" will return a dictionary of counts for all buffers.
 
-*neomake#ProcessCurrentWindow*
-This is the function that takes the job output and puts it into the
-|location-list| or |quickfix| list, adds signs, etc. Currently, if you stay in
-the window you called |:Neomake| from, this will happen as the job output
-comes in. However, if you go to a different window, Neomake will wait until
-you return to that window for the job output to be processed. Currently, that
-will happen on |WinEnter| and |CursorHold|. You can also call this function
-directly if you need to force it. This function is not currently used for
-|:Neomake!|, which always processes its output as it arrives.
-
 ==============================================================================
 5. Autocommands/Hooks                                       *neomake-autocmds*
                                                                *neomake-hooks*

--- a/plugin/neomake.vim
+++ b/plugin/neomake.vim
@@ -23,8 +23,6 @@ command! -bar NeomakeInfo call neomake#DisplayInfo()
 
 augroup neomake
   au!
-  au WinEnter * call neomake#ProcessCurrentWindow()
-  au CursorHold * call neomake#ProcessPendingOutput()
   if !exists('*nvim_buf_add_highlight')
     au BufEnter * call neomake#highlights#ShowHighlights()
   endif

--- a/plugin/neomake.vim
+++ b/plugin/neomake.vim
@@ -25,7 +25,9 @@ augroup neomake
   au!
   au WinEnter * call neomake#ProcessCurrentWindow()
   au CursorHold * call neomake#ProcessPendingOutput()
-  au BufEnter * call neomake#highlights#ShowHighlights()
+  if !exists('*nvim_buf_add_highlight')
+    au BufEnter * call neomake#highlights#ShowHighlights()
+  endif
   if has('timers')
     au CursorMoved * call neomake#CursorMovedDelayed()
     " Force-redraw display of current error after resizing Vim, which appears

--- a/tests/highlights.vader
+++ b/tests/highlights.vader
@@ -5,11 +5,12 @@ Execute (No error when matches are cleared manually):
   if !has('nvim')
     AssertEqual w:neomake_highlights, []
   endif
-  call neomake#highlights#ShowHighlights()
+  doautocmd BufEnter
   if !has('nvim')
     AssertEqual len(w:neomake_highlights), 1
   endif
   call clearmatches()
+  " No-op in Neovim (same as BufEnter above), but should be defined.
   call neomake#highlights#ShowHighlights()
   if !has('nvim')
     AssertEqual len(w:neomake_highlights), 1

--- a/tests/integration.vader
+++ b/tests/integration.vader
@@ -116,18 +116,28 @@ Execute (Neomake: handle result for current window):
 Execute (Neomake: handle output for removed window):
   if NeomakeAsyncTestsSetup()
     new
+    file file_sleep_efm
+    let bufnr = bufnr('%')
     call neomake#Make(1, [g:sleep_efm_maker])
     let jobinfo = neomake#GetJobs()[0]
-    let bufnr = bufnr('%')
     quit
     NeomakeTestsWaitForFinishedJobs
     AssertEqual len(g:neomake_test_countschanged), 0,
       \ "counts changed (".len(g:neomake_test_countschanged).")"
-    AssertEqual len(g:neomake_test_finished), 1
+    AssertEqual len(g:neomake_test_finished), 0
+    AssertNeomakeMessage 'Output left to be processed, not cleaning job yet.'
 
-    AssertNeomakeMessage 'No window found for output!', 2, jobinfo
-    AssertEqual neomake#CancelJob(jobinfo.id), 0, "stale job was removed"
-    exe 'bwipe' bufnr
+    new
+    AssertEqual len(g:neomake_test_finished), 0
+    AssertNeomakeMessage 'Skipped pending job output for another buffer.', 3, jobinfo
+
+    " Opening the buffer in another window should process its output.
+    exe 'b' bufnr
+    AssertNeomakeMessage "Processing pending output for job's buffer in new window."
+    AssertEqual len(g:neomake_test_finished), 1
+    AssertEqual len(g:neomake_test_countschanged), 1
+
+    bwipe
   endif
 
 Execute (Neomake: handle wiped buffer):
@@ -142,11 +152,47 @@ Execute (Neomake: handle wiped buffer):
     NeomakeTestsWaitForFinishedJobs
     AssertEqual len(g:neomake_test_countschanged), 0,
       \ "counts changed (".len(g:neomake_test_countschanged).")"
-    AssertEqual len(g:neomake_test_finished), 1
+    AssertEqual len(g:neomake_test_jobfinished), 0
+    AssertEqual len(g:neomake_test_finished), 0
 
-    AssertNeomakeMessage 'No window found for output!', 2, jobinfo
+    " Trigger processing of pending output.
+    new
+    AssertEqual len(g:neomake_test_jobfinished), 1
+    AssertEqual len(g:neomake_test_finished), 1
+    AssertNeomakeMessage 'No buffer found for output!', 2, jobinfo
     AssertNeomakeMessage 'File-level errors cleaned in buffer '.bufnr.'.'
     AssertEqual neomake#CancelJob(jobinfo.id), 0, "stale job was removed"
+    bwipe
+  endif
+
+Execute (Neomake: handle pending output across windows/buffers):
+  " Check that there is no error, e.g. for highlights.
+  if NeomakeAsyncTestsSetup()
+    new
+    AssertEqual winnr(), 2
+    edit tests/fixtures/errors.sh
+    let bufnr = bufnr('%')
+    Neomake sh
+    new
+    let jobinfo = neomake#GetJobs()[0]
+    NeomakeTestsWaitForFinishedJobs
+    AssertNeomakeMessage 'Output left to be processed, not cleaning job yet.'
+
+    " Trigger processing of pending output.
+    new
+    AssertNeomakeMessage 'Skipped pending job output for another buffer.', 3, jobinfo
+    AssertEqual len(g:neomake_test_jobfinished), 0
+    AssertEqual len(g:neomake_test_finished), 0
+    exe 'b' bufnr
+    AssertNeomakeMessage 'Skipped pending job output (not in origin window).', 3, jobinfo
+    quit
+    AssertNeomakeMessage 'Skipped pending job output for another buffer.', 3, jobinfo
+    bwipe
+    AssertEqual len(g:neomake_test_jobfinished), 1
+    AssertEqual len(g:neomake_test_finished), 1
+
+    AssertEqual neomake#CancelJob(jobinfo.id), 0, "stale job was removed"
+    bwipe
   endif
 
 Execute (NeomakeSh: true):

--- a/tests/processing.vader
+++ b/tests/processing.vader
@@ -16,7 +16,9 @@ Execute (Output is only processed in normal/insert mode (loclist)):
     AssertEqual mode(), 'n'
     AssertEqual len(g:neomake_test_countschanged), 0
     AssertEqual len(g:neomake_test_finished), 0
+    Assert exists('#neomake_process_pending#CursorHold'), 'neomake_process_pending augroup exists'
     doautocmd CursorHold
+    Assert !exists('#neomake_process_pending#CursorHold'), 'neomake_process_pending is empty'
     AssertEqual len(g:neomake_test_countschanged), 1
     AssertEqual len(g:neomake_test_finished), 1, "b"
     AssertNeomakeMessage 'sleep_efm_maker: processing 3 lines of output.'
@@ -433,4 +435,46 @@ Execute (Already running job gets restarted in case of exception):
     " Needs careful cleanup after exception.
     NeomakeTestsWaitForMessage 'Cleaning jobinfo.'
     NeomakeCancelJobs!
+  endif
+
+Execute (Pending output gets processed in order of jobs (project first)):
+  if NeomakeAsyncTestsSetup()
+  let maker1 = NeomakeTestsCommandMaker('project_maker', 'sleep .1; echo project_maker')
+  let maker2 = NeomakeTestsCommandMaker('file_maker', 'echo file_maker')
+
+  call neomake#Make(0, [maker1])
+  call neomake#Make(1, [maker2])
+  norm! V
+
+  NeomakeTestsWaitForFinishedJobs
+  exe "norm! \<Esc>"
+  doautocmd CursorHold
+  NeomakeTestsWaitForRemovedJobs
+  AssertNeomakeMessage 'Not processing output for mode "V".'
+  AssertNeomakeMessage 'Creating quickfix list.'
+  AssertNeomakeMessage 'Creating location list.'
+
+  AssertEqual map(copy(getloclist(0)), 'v:val.text'), ['file_maker']
+  AssertEqual map(copy(getqflist()), 'v:val.text'), ['project_maker']
+  endif
+
+Execute (Pending output gets processed in order of jobs (file mode first)):
+  if NeomakeAsyncTestsSetup()
+  let maker1 = NeomakeTestsCommandMaker('project_maker', 'sleep .1; echo project_maker')
+  let maker2 = NeomakeTestsCommandMaker('file_maker', 'echo file_maker')
+
+  call neomake#Make(1, [maker2])
+  call neomake#Make(0, [maker1])
+  norm! V
+
+  NeomakeTestsWaitForFinishedJobs
+  exe "norm! \<Esc>"
+  doautocmd CursorHold
+  NeomakeTestsWaitForRemovedJobs
+  AssertNeomakeMessage 'Not processing output for mode "V".'
+  AssertNeomakeMessage 'Creating location list.'
+  AssertNeomakeMessage 'Creating quickfix list.'
+
+  AssertEqual map(copy(getloclist(0)), 'v:val.text'), ['file_maker']
+  AssertEqual map(copy(getqflist()), 'v:val.text'), ['project_maker']
   endif


### PR DESCRIPTION
- pending job output is not stored in the window anymore
- file mode jobs get processed in another window (for the buffer), if
  the original window is gone
- autocommands are setup only when there is pending output