### PR TITLE
typescript: tsc: add '--watch false' to args

### DIFF
--- a/autoload/neomake/makers/ft/typescript.vim
+++ b/autoload/neomake/makers/ft/typescript.vim
@@ -7,7 +7,7 @@ endfunction
 function! neomake#makers#ft#typescript#tsc() abort
     " tsc should not be passed a single file.
     return {
-        \ 'args': ['--project', neomake#utils#FindGlobFile('tsconfig.json'), '--noEmit'],
+        \ 'args': ['--project', neomake#utils#FindGlobFile('tsconfig.json'), '--noEmit', '--watch', 'false'],
         \ 'append_file': 0,
         \ 'errorformat':
             \ '%E%f %#(%l\,%c): error %m,' .


### PR DESCRIPTION
This will override the (not recommended) `watch: true` from the config.

Ref: https://github.com/neomake/neomake/issues/1203#issuecomment-301489908.