### PR TITLE
rst: use 'text' as superset

### DIFF
--- a/autoload/neomake/makers/ft/rst.vim
+++ b/autoload/neomake/makers/ft/rst.vim
@@ -1,5 +1,9 @@
 " vim: ts=4 sw=4 et
 
+function! neomake#makers#ft#rst#SupersetOf() abort
+    return 'text'
+endfunction
+
 function! neomake#makers#ft#rst#EnabledMakers() abort
     return ['rstlint', 'rstcheck']
 endfunction


### PR DESCRIPTION
This allows to use e.g. `writegood` in ReST files after all.

For the real fix see https://github.com/neomake/neomake/issues/1314.