### PR TITLE
Fix go makers: do not use mapexpr

### DIFF
--- a/autoload/neomake/makers/ft/go.vim
+++ b/autoload/neomake/makers/ft/go.vim
@@ -10,10 +10,6 @@ function! neomake#makers#ft#go#EnabledMakers() abort
     return makers
 endfunction
 
-" The mapexprs in these are needed because cwd will make the command print out
-" the wrong path (it will just be ./%:h in the output), so the mapexpr turns
-" that back into the relative path
-
 function! neomake#makers#ft#go#go() abort
     return {
         \ 'args': [
@@ -24,7 +20,6 @@ function! neomake#makers#ft#go#go() abort
         \ 'cwd': '%:h',
         \ 'serialize': 1,
         \ 'serialize_abort_on_error': 1,
-        \ 'mapexpr': 'neomake_bufdir . "/" . v:val',
         \ 'errorformat':
             \ '%W%f:%l: warning: %m,' .
             \ '%E%f:%l:%c:%m,' .
@@ -49,7 +44,6 @@ function! neomake#makers#ft#go#govet() abort
         \ 'args': ['vet'],
         \ 'append_file': 0,
         \ 'cwd': '%:h',
-        \ 'mapexpr': 'neomake_bufdir . "/" . v:val',
         \ 'errorformat':
             \ '%Evet: %.%\+: %f:%l:%c: %m,' .
             \ '%W%f:%l: %m,' .
@@ -66,7 +60,6 @@ function! neomake#makers#ft#go#gometalinter() abort
         \ 'args': ['--disable-all', '--enable=errcheck', '--enable=gosimple', '--enable=staticcheck', '--enable=unused'],
         \ 'append_file': 0,
         \ 'cwd': '%:h',
-        \ 'mapexpr': 'neomake_bufdir . "/" . v:val',
         \ 'errorformat': '%f:%l:%c:%t%*[^:]: %m',
         \ }
 endfunction

--- a/tests/ft_go.vader
+++ b/tests/ft_go.vader
@@ -1,0 +1,28 @@
+Include: include/setup.vader
+
+Execute (go: go):
+  new
+  set ft=go
+  file build/proxier.go
+
+  let maker = neomake#makers#ft#go#go()
+  let maker.remove_invalid_entries = 0
+  " to work on an unreadable file.
+  let maker.append_file = 0
+  let maker.exe = 'printf'
+  let maker.args = ['%s\n',
+  \'proxier.go:24:2: cannot find package "bytes" in any of:',
+  \'	/home/user/bin/go1.x/src/bytes (from $GOROOT)',
+  \'	/home/user/go/src/bytes (from $GOPATH)']
+  CallNeomake 1, [maker]
+
+  AssertNeomakeMessage printf('cwd: %s/build (changed).', getcwd())
+  AssertNeomakeMessage 'unnamed_maker: processing 3 lines of output.'
+  AssertNeomakeMessage 'Processing 1 entries.'
+  AssertEqual getloclist(0), [
+  \ {'lnum': 24, 'bufnr': bufnr('%'), 'col': 2, 'valid': 1, 'vcol': 0,
+  \  'nr': -1, 'type': 'E', 'pattern': '',
+  \  'text': 'cannot find package "bytes" in any of: '
+  \  .'/home/user/bin/go1.x/src/bytes (from $GOROOT) '
+  \  .'/home/user/go/src/bytes (from $GOPATH)'}]
+  bwipe

--- a/tests/include/init.vim
+++ b/tests/include/init.vim
@@ -90,6 +90,8 @@ command! -nargs=* RunNeomake Neomake <args>
   \ | NeomakeTestsWaitForFinishedJobs
 command! -nargs=* RunNeomakeProject NeomakeProject <args>
   \ | NeomakeTestsWaitForFinishedJobs
+command! -nargs=* CallNeomake call neomake#Make(<args>)
+  \ | NeomakeTestsWaitForFinishedJobs
 
 " NOTE: NeomakeSh does not use '-bar'.
 command! -nargs=* RunNeomakeSh call RunNeomakeSh(<q-args>)

--- a/tests/neomake.vader
+++ b/tests/neomake.vader
@@ -50,6 +50,7 @@ Include (Pandoc): ft_pandoc.vader
 Include (TypeScript): ft_typescript.vader
 Include (JavaScript): ft_javascript.vader
 Include (PureScript): ft_purescript.vader
+Include (Go): ft_go.vader
 
 * Old/unorganized tests
 Include: include/setup.vader


### PR DESCRIPTION
This was quite broken since a while at least already, and should not be
necessary anymore, at least since the 'errorformat' is evaluated in the
`cwd` (which picks up the names correctly).

Fixes https://github.com/neomake/neomake/issues/1306.