### PR TITLE
Don't conditionally disable fast-parser for python mypy

### DIFF
--- a/autoload/neomake/makers/ft/python.vim
+++ b/autoload/neomake/makers/ft/python.vim
@@ -271,12 +271,8 @@ endfunction
 " --fast-parser: adds experimental support for async/await syntax
 " --silent-imports: replaced by --ignore-missing-imports --follow-imports=skip
 function! neomake#makers#ft#python#mypy() abort
-    let args = ['--ignore-missing-imports', '--follow-imports=skip']
-    if !neomake#utils#IsRunningWindows()
-        let args += ['--fast-parser']
-    endif
     return {
-        \ 'args': args,
+        \ 'args': ['--ignore-missing-imports', '--follow-imports=skip'],
         \ 'errorformat':
             \ '%E%f:%l: error: %m,' .
             \ '%W%f:%l: warning: %m,' .


### PR DESCRIPTION
Since mypy 0.510 there is no point to conditionally enable fast-parser - it is the only one available. Windows is supported by mypy.

```
λ mypy --no-fast-parser
Warning: --no-fast-parser no longer has any effect.  The fast parser is now mypy's default and only parser.
```