### PR TITLE
Work around vim-qf messing via QuickFixCmdPost

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -1395,6 +1395,19 @@ function! s:ProcessJobOutput(jobinfo, lines, source) abort
 
         let olderrformat = &errorformat
         let &errorformat = maker.errorformat
+        if exists('g:loaded_qf')
+            if file_mode
+                if exists('g:qf_auto_open_loclist')
+                    let restore = {'qf_auto_open_loclist': g:qf_auto_open_loclist}
+                endif
+                let g:qf_auto_open_loclist = 0
+            else
+                if exists('g:qf_auto_open_quickfix')
+                    let restore = {'qf_auto_open_quickfix': g:qf_auto_open_quickfix}
+                endif
+                let g:qf_auto_open_quickfix = 0
+            endif
+        endif
         try
             if file_mode
                 laddexpr a:lines
@@ -1405,6 +1418,11 @@ function! s:ProcessJobOutput(jobinfo, lines, source) abort
             let &errorformat = olderrformat
             if empty(cd_error)
                 exe cd_back_cmd
+            endif
+            if exists('restore')
+                for [k, v] in restore
+                    let g:[k] = v
+                endfor
             endif
         endtry
 

--- a/tests/lists.vader
+++ b/tests/lists.vader
@@ -93,7 +93,7 @@ Execute (Goes back to original window after opening list):
   lclose
   bwipe
 
-Execute (Stays in location window with :lwindow in QuickFixCmdPost (vim-qf)):
+Execute (Stays in location window with :lwindow in QuickFixCmdPost (like vim-qf)):
   if !has('patch-7.4.2299')
     NeomakeTestsSkip 'Only for 7.4.2299 (vim-qf issue)'
   else
@@ -119,6 +119,49 @@ Execute (Stays in location window with :lwindow in QuickFixCmdPost (vim-qf)):
     AssertNotEqual winnr, winnr()
     exe winnr.'wincmd w'
     lclose
+    bwipe
+  endif
+
+Execute (Goes back to original window with vim-qf):
+  if !has('patch-7.4.2299')
+    NeomakeTestsSkip 'Only for 7.4.2299 (vim-qf issue)'
+  else
+    Save g:neomake_open_list
+    let g:neomake_open_list = 2
+
+    Save g:loaded_qf, g:qf_auto_open_quickfix, g:qf_auto_open_loclist
+    " Simulate vim-qf being used.
+    let g:loaded_qf = 1
+
+    new
+    let winnr = winnr()
+    let wincount = winnr('$')
+
+    augroup neomake_tests
+      autocmd QuickFixCmdPost laddexpr AssertEqual g:qf_auto_open_loclist, 0
+      autocmd QuickFixCmdPost caddexpr AssertEqual g:qf_auto_open_quickfix, 0
+    augroup END
+
+    " Location list.
+    call neomake#Make(1, [g:error_maker])
+    NeomakeTestsWaitForFinishedJobs
+    AssertEqual map(copy(getloclist(0)), '[v:val.text, v:val.type]'), [['error', 'E']]
+
+    AssertEqual wincount + 1, winnr('$'), 'Location list appeared'
+    AssertEqual winnr, winnr()
+    exe winnr.'wincmd w'
+    lclose
+    AssertEqual wincount, winnr('$')
+
+    " Quickfix list.
+    call neomake#Make(0, [g:error_maker])
+    NeomakeTestsWaitForFinishedJobs
+    AssertEqual map(copy(getloclist(0)), '[v:val.text, v:val.type]'), [['error', 'E']]
+
+    AssertEqual wincount + 1, winnr('$'), 'Location list appeared'
+    AssertEqual winnr, winnr()
+    exe winnr.'wincmd w'
+    cclose
     bwipe
   endif
 


### PR DESCRIPTION
Fixes https://github.com/neomake/neomake/issues/1097.

vim-qf's author said to have no bandwidth to merge / look at my PR (https://github.com/romainl/vim-qf/pull/48), so here is a workaround.