### PR TITLE
GetSetting/GetMaker: handle maker-only settings

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -604,7 +604,7 @@ function! neomake#GetMaker(name_or_maker, ...) abort
             \ 'errorformat': &errorformat,
             \ })
         for [key, default] in items(defaults)
-            let maker[key] = neomake#utils#GetSetting(key, maker, default, ft, bufnr)
+            let maker[key] = neomake#utils#GetSetting(key, maker, default, ft, bufnr, 1)
             unlet default  " for Vim without patch-7.4.1546
         endfor
     endif

--- a/tests/utils.vader
+++ b/tests/utils.vader
@@ -61,6 +61,9 @@ Execute (neomake#utils#GetSetting serialize):
 
   let g:neomake_serialize = 7
   AssertEqual GetSetting(), 7
+  " maker-only should return default.
+  AssertEqual neomake#utils#GetSetting('serialize', g:maker, 'default',
+                                \ 'myft', bufnr('%'), 1), 'default'
   let g:neomake_serialize = 0
   AssertEqual GetSetting(), 0
   let g:neomake_serialize = 99
@@ -114,6 +117,18 @@ Execute (neomake#utils#GetSetting serialize):
   AssertEqual GetSetting(), 98
   let g:maker = {}
   AssertEqual GetSetting(), 98
+  bwipe
+
+Execute (neomake#utils#GetSetting handles maker-only settings):
+  new
+  set filetype=myft
+  AssertEqual 'default', neomake#utils#GetSetting('exe', {}, 'default', 'myft', bufnr('%'))
+  let b:neomake_exe = 'buffer_exe'
+  AssertEqual 'buffer_exe', neomake#utils#GetSetting('exe', {}, 'default', 'myft', bufnr('%'))
+  AssertEqual 'default', neomake#utils#GetSetting('exe', {}, 'default', 'myft', bufnr('%'), 1)
+
+  let b:neomake_myft_mymaker_maker = {}
+  AssertEqual neomake#GetMaker('mymaker', 'myft').exe, 'mymaker'
   bwipe
 
 Execute (neomake#utils#GetSetting for multiple fts):


### PR DESCRIPTION
`b:neomake_exe` should not get picked up for maker settings.