### PR TITLE
Add maker.output_streams and report errors from unexpected streams

### DIFF
--- a/autoload/neomake/makers/ft/python.vim
+++ b/autoload/neomake/makers/ft/python.vim
@@ -246,6 +246,7 @@ function! neomake#makers#ft#python#python() abort
         \ 'errorformat': '%E%f:%l:%c: %m',
         \ 'serialize': 1,
         \ 'serialize_abort_on_error': 1,
+        \ 'output_stream': 'stdout',
         \ }
 endfunction
 

--- a/autoload/neomake/makers/ft/ruby.vim
+++ b/autoload/neomake/makers/ft/ruby.vim
@@ -43,7 +43,8 @@ function! neomake#makers#ft#ruby#mri() abort
     return {
         \ 'exe': 'ruby',
         \ 'args': ['-c', '-T1', '-w'],
-        \ 'errorformat': errorformat
+        \ 'errorformat': errorformat,
+        \ 'output_stream': 'stderr',
         \ }
 endfunction
 

--- a/autoload/neomake/makers/ft/sh.vim
+++ b/autoload/neomake/makers/ft/sh.vim
@@ -65,7 +65,8 @@ function! neomake#makers#ft#sh#sh() abort
         \ 'args': args,
         \ 'errorformat':
             \ '%E%f: line %l: %m,' .
-            \ '%E%f: %l: %m'
+            \ '%E%f: %l: %m',
+        \ 'output_streams': ['stderr'],
         \}
 endfunction
 

--- a/autoload/neomake/makers/ft/sh.vim
+++ b/autoload/neomake/makers/ft/sh.vim
@@ -66,7 +66,7 @@ function! neomake#makers#ft#sh#sh() abort
         \ 'errorformat':
             \ '%E%f: line %l: %m,' .
             \ '%E%f: %l: %m',
-        \ 'output_streams': ['stderr'],
+        \ 'output_stream': 'stderr',
         \}
 endfunction
 

--- a/autoload/neomake/makers/ft/vim.vim
+++ b/autoload/neomake/makers/ft/vim.vim
@@ -15,6 +15,7 @@ function! neomake#makers#ft#vim#vint() abort
     return {
         \ 'args': l:args,
         \ 'errorformat': '%I%f:%l:%c:style_problem:%m,%f:%l:%c:%t%*[^:]:%m',
+        \ 'output_stream': 'stdout',
         \ 'postprocess': {
         \   'fn': function('neomake#postprocess#GenericLengthPostprocess'),
         \   'pattern': '\vUndefined variable: \zs([^ ]+)',
@@ -27,6 +28,7 @@ function! neomake#makers#ft#vim#vimlint() abort
         \ 'errorformat': '%f:%l:%c:%trror: EVL%n: %m,'
         \   . '%f:%l:%c:%tarning: EVL%n: %m',
         \ 'postprocess': function('neomake#makers#ft#vim#PostprocessVimlint'),
+        \ 'output_stream': 'stdout',
         \ }
 endfunction
 

--- a/doc/neomake.txt
+++ b/doc/neomake.txt
@@ -309,6 +309,12 @@ but disable it for some maker only: >
         let g:neomake_tempfile_enabled = 1
         let g:neomake_<ft>_<name>_tempfile_enabled = 0
 <
+                                                *neomake-makers-output_stream*
+Default: "both" ("stdout", "stderr", "both")
+The `output_stream` setting specifies what stream gets used for output from
+the maker.
+Any output from a maker on a stream not configured here gets reported as
+unexpected output.
 
 Global Options                                               *neomake-options*
 

--- a/tests/maker_errors.vader
+++ b/tests/maker_errors.vader
@@ -1,0 +1,13 @@
+Include: include/setup.vader
+
+Execute (Handles unexpected output on stderr from maker):
+  let maker = NeomakeTestsCommandMaker('stderr_maker', 'echo failed to run >&2; echo because something bad happened >&2')
+  let maker.output_stream = 'stdout'
+
+  CallNeomake 1, [maker]
+  AssertNeomakeMessage 'stderr_maker: unexpected output. See :messages for more information.', 0
+
+  redir => messages_output
+    silent messages
+  redir END
+  AssertEqual split(messages_output, "\n")[-1], 'Neomake: stderr_maker: unexpected output on stderr: failed to run^@because something bad happened'

--- a/tests/mapexpr.vader
+++ b/tests/mapexpr.vader
@@ -3,6 +3,7 @@ Include: include/setup.vader
 Execute (mapexpr: output source in mapexpr):
   let maker = neomake#utils#MakerFromCommand('echo on_stdout; echo on_stderr>&2')
   let maker.mapexpr = "printf('[%s] %s', neomake_output_source, v:val)"
+  let maker.output_stream = 'both'
   call neomake#Make(0, [maker])
   NeomakeTestsWaitForFinishedJobs
 

--- a/tests/neomake.vader
+++ b/tests/neomake.vader
@@ -18,6 +18,7 @@ Include (JSON): json.vader
 Include (Lists): lists.vader
 Include (Maker args): args.vader
 Include (Makers): makers.vader
+Include (Maker errors): maker_errors.vader
 Include (Mapexpr): mapexpr.vader
 Include (Postprocess): postprocess.vader
 Include (Processing): processing.vader


### PR DESCRIPTION
TODO:
- [x] use just 'both', 'stderr', 'stdout' ?

Fixes https://github.com/neomake/neomake/issues/850.