### PR TITLE
Maker for matlab linter mlint

### DIFF
--- a/autoload/neomake/makers/ft/mlint.vim
+++ b/autoload/neomake/makers/ft/mlint.vim
@@ -1,6 +1,6 @@
 " vim: ts=4 sw=4 et
 
-function! neomake#makers#ft#mlint#mlint() abort 
+function! neomake#makers#ft#mlint#mlint() abort
     return {
         \ 'exe': 'mlint',
         \ 'args': ['-id'],

--- a/autoload/neomake/makers/ft/mlint.vim
+++ b/autoload/neomake/makers/ft/mlint.vim
@@ -1,5 +1,9 @@
 " vim: ts=4 sw=4 et
 
+function! neomake#makers#ft#mlint#EnabledMakers() abort
+    return ['mlint']
+endfunction
+
 function! neomake#makers#ft#mlint#mlint() abort
     return {
         \ 'exe': 'mlint',

--- a/autoload/neomake/makers/ft/mlint.vim
+++ b/autoload/neomake/makers/ft/mlint.vim
@@ -1,6 +1,6 @@
 " vim: ts=4 sw=4 et
 
-function! neomake#maker#mlint#mlint() abort 
+function! neomake#makers#ft#mlint#mlint() abort 
     return {
         \ 'exe': 'mlint',
         \ 'args': ['-id'],

--- a/autoload/neomake/makers/mlint.vim
+++ b/autoload/neomake/makers/mlint.vim
@@ -1,0 +1,12 @@
+" vim: ts=4 sw=4 et
+
+function! neomake#maker#mlint#mlint() abort 
+    return {
+        \ 'exe': 'mlint',
+        \ 'args': ['-id'],
+        \ 'mapexpr': "neomake_bufname.':'.v:val",
+        \ 'errorformat':
+        \ '%f:L %l (C %c): %m,' .
+        \ '%f:L %l (C %c-%*[0-9]): %m,',
+        \ }
+endfunction


### PR DESCRIPTION
By default mlint doesn't output filename when linting a single file.
Workaround is to paste current buffer name to the begining of each line of the linter output. 
This is achieved via
```
'mapexpr': "neomake_bufname.':'.v:val"
```
in maker configuration as suggested by @blueyed.