### PR TITLE
Fix stack command line options

### DIFF
--- a/autoload/neomake/makers/ft/haskell.vim
+++ b/autoload/neomake/makers/ft/haskell.vim
@@ -73,7 +73,7 @@ function! neomake#makers#ft#haskell#hdevtools() abort
     if !exists('s:uses_cabal')
         let s:uses_cabal = 0
         if executable('stack')
-            let output = neomake#compat#systemlist(['stack', '--verbosity silent', 'path', '--project-root'])
+            let output = neomake#compat#systemlist(['stack', '--verbosity', 'silent', 'path', '--project-root'])
             if !empty(output)
                 let rootdir = output[0]
                 if !empty(glob(rootdir . '/*.cabal'))


### PR DESCRIPTION
This fix treats "--verbosity" and "silent" as independent tokens on the command line. 

The problem seems to have been introduced with https://github.com/neomake/neomake/commit/958b3c6f036a69a6cca71f198ae2565a6fcc9482 

@blueyed is probably the best person to review this.

Thanks!