### PR TITLE
Makefile: vimlint: ignore _ as unused var by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,10 +133,11 @@ build/vimlint: | build
 	git clone --depth=1 https://github.com/syngan/vim-vimlint $@
 build/vimlparser: | build
 	git clone --depth=1 https://github.com/ynkdir/vim-vimlparser $@
+VIMLINT_OPTIONS=-u -e EVL102.l:_=1
 vimlint: build/vimlint build/vimlparser
-	build/vimlint/bin/vimlint.sh -u -l build/vimlint -p build/vimlparser $(LINT_ARGS)
+	build/vimlint/bin/vimlint.sh $(VIMLINT_OPTIONS) -l build/vimlint -p build/vimlparser $(LINT_ARGS)
 vimlint-errors: build/vimlint build/vimlparser
-	build/vimlint/bin/vimlint.sh -u -E -l build/vimlint -p build/vimlparser $(LINT_ARGS)
+	build/vimlint/bin/vimlint.sh $(VIMLINT_OPTIONS) -E -l build/vimlint -p build/vimlparser $(LINT_ARGS)
 
 build build/neovim-test-home:
 	mkdir $@


### PR DESCRIPTION
Ref: https://github.com/syngan/vim-vimlint/issues/82#issuecomment-303883064.