### PR TITLE
Echo current error when all jobs finished (forced)

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -1142,6 +1142,7 @@ function! s:CleanJobinfo(jobinfo) abort
         endif
 
         call s:HandleLoclistQflistDisplay(a:jobinfo)
+        call neomake#EchoCurrentError(1)
 
         call neomake#utils#hook('NeomakeFinished', {'jobinfo': a:jobinfo})
     endif
@@ -1432,7 +1433,6 @@ function! s:ProcessEntries(jobinfo, entries, ...) abort
 
     call s:HandleLoclistQflistDisplay(a:jobinfo)
     call neomake#highlights#ShowHighlights()
-    call neomake#EchoCurrentError()
     return 1
 endfunction
 


### PR DESCRIPTION
This makes it show up after typing/using `:Neomake` would have cleared
the cmdline, without having to trigger CursorMoved first.