### PR TITLE
Add support for Styled Components in JavaScript and JSX

### DIFF
--- a/autoload/neomake/makers/ft/javascript.vim
+++ b/autoload/neomake/makers/ft/javascript.vim
@@ -97,11 +97,6 @@ function! neomake#makers#ft#javascript#xo() abort
 endfunction
 
 function! neomake#makers#ft#javascript#stylelint() abort
-    return {
-          \ 'errorformat':
-          \   '%+P%f,'.
-          \   '%*\s%l:%c  %t  %m,'.
-          \   '%-Q'
-          \ }
+    return neomake#makers#ft#css#stylelint()
 endfunction
 

--- a/autoload/neomake/makers/ft/javascript.vim
+++ b/autoload/neomake/makers/ft/javascript.vim
@@ -95,3 +95,13 @@ function! neomake#makers#ft#javascript#xo() abort
         \ '%W%f: line %l\, col %c\, Warning - %m',
         \ }
 endfunction
+
+function! neomake#makers#ft#javascript#stylelint() abort
+    return {
+          \ 'errorformat':
+          \   '%+P%f,'.
+          \   '%*\s%l:%c  %t  %m,'.
+          \   '%-Q'
+          \ }
+endfunction
+

--- a/autoload/neomake/makers/ft/jsx.vim
+++ b/autoload/neomake/makers/ft/jsx.vim
@@ -11,7 +11,7 @@ function! neomake#makers#ft#jsx#jsxhint() abort
 endfunction
 
 function! neomake#makers#ft#jsx#stylelint() abort
-    return neomake#makers#ft#javascript#stylelint()
+    return neomake#makers#ft#css#stylelint()
 endfunction
 
 " vim: ts=4 sw=4 et

--- a/autoload/neomake/makers/ft/jsx.vim
+++ b/autoload/neomake/makers/ft/jsx.vim
@@ -10,4 +10,8 @@ function! neomake#makers#ft#jsx#jsxhint() abort
     return neomake#makers#ft#javascript#jshint()
 endfunction
 
+function! neomake#makers#ft#jsx#stylelint() abort
+    return neomake#makers#ft#javascript#stylelint()
+endfunction
+
 " vim: ts=4 sw=4 et


### PR DESCRIPTION
[Styled Components](https://github.com/styled-components/styled-components) is getting traction.

The community built a pre-processor which allows linting of Styled Components trough StyleLint: https://github.com/styled-components/stylelint-processor-styled-components

This PR adds support of stylelint to JavaScrit and JSX files. I manually configured it in my vimrc and it works perfectly.