### PR TITLE
Add commands to toggle/disable/enable Neomake per buffer/tab/global

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -907,6 +907,16 @@ function! s:process_action_queue(event) abort
 endfunction
 
 function! s:Make(options) abort
+    let is_automake = !empty(expand('<abuf>'))
+    if is_automake
+        let disabled = neomake#config#get_with_source('disabled', 0)
+        if disabled[0]
+            call neomake#utils#DebugMessage(printf(
+                        \ 'Disabled via %s.', disabled[1]))
+            return []
+        endif
+    endif
+
     let s:make_id += 1
     let make_id = s:make_id
     let options = copy(a:options)

--- a/doc/neomake.txt
+++ b/doc/neomake.txt
@@ -73,6 +73,30 @@ fantastic Vim plugins such as syntastic and dispatch.
                         Terminate all jobs.
 
 ==============================================================================
+2.1. Toggle commands                                          *neomake-toggle*
+
+The following commands enable, disable or toggle Neomake globally, per tab or
+per buffer by changing the `disabled` setting, which is checked when Neomake
+is called via autocommands. Calling |:Neomake| manually will not use this
+setting.
+In verbose mode (e.g. when called with |:verbose|) the new status gets
+displayed.
+
+*:NeomakeToggle* toggles Neomake globally.
+*:NeomakeToggleBuffer* toggles Neomake for the current buffer.
+*:NeomakeToggleTab* toggles Neomake for the current tab.
+                                                             *neomake-disable*
+*:NeomakeDisable* disables Neomake globally.
+*:NeomakeDisableBuffer* disables Neomake for the current buffer.
+*:NeomakeDisableTab* disables Neomake for the current tab.
+                                                              *neomake-enable*
+*:NeomakeEnable* enables Neomake globally.
+*:NeomakeEnableBuffer* enables Neomake for the current buffer.
+*:NeomakeEnableTab* enables Neomake for the current tab.
+
+*:NeomakeStatus* displays the current status.
+
+==============================================================================
 3. Configuration                                       *neomake-configuration*
 
 If you just want an easy way to run |:make| asynchronously, you're all set.

--- a/plugin/neomake.vim
+++ b/plugin/neomake.vim
@@ -21,6 +21,45 @@ command! -bang NeomakeCancelJobs call neomake#CancelJobs(<bang>0)
 
 command! -bar NeomakeInfo call neomake#DisplayInfo()
 
+" Enable/disable/toggle commands.  {{{
+function! s:toggle(scope) abort
+    let new = !get(get(a:scope, 'neomake', {}), 'disabled', 0)
+    if new
+        call neomake#config#set_dict(a:scope, 'neomake.disabled', new)
+    else
+        call neomake#config#unset_dict(a:scope, 'neomake.disabled')
+    endif
+    if &verbose
+        call s:display_status()
+    endif
+endfunction
+function! s:disable(scope, disabled) abort
+    call neomake#config#set_dict(a:scope, 'neomake.disabled', a:disabled)
+    if &verbose
+        call s:display_status()
+    endif
+endfunction
+function! s:display_status() abort
+    let [disabled, source] = neomake#config#get_with_source('disabled', 0)
+    let msg = 'Neomake is ' . (disabled ? 'disabled' : 'enabled')
+    if source !=# 'default'
+        let msg .= ' ('.source.')'
+    endif
+    echom msg.'.'
+endfunction
+command! NeomakeToggle call s:toggle(g:)
+command! NeomakeToggleBuffer call s:toggle(b:)
+command! NeomakeToggleTab call s:toggle(t:)
+command! NeomakeDisable call s:disable(g:, 1)
+command! NeomakeDisableBuffer call s:disable(b:, 1)
+command! NeomakeDisableTab call s:disable(t:, 1)
+command! NeomakeEnable call s:disable(g:, 0)
+command! NeomakeEnableBuffer call s:disable(b:, 0)
+command! NeomakeEnableTab call s:disable(t:, 0)
+
+command! NeomakeStatus call s:display_status()
+" }}}
+
 augroup neomake
   au!
   if !exists('*nvim_buf_add_highlight')

--- a/tests/neomake.vader
+++ b/tests/neomake.vader
@@ -27,6 +27,7 @@ Include (Serialize): serialize.vader
 Include (Signs): signs.vader
 Include (Statusline): statusline.vader
 Include (Temporary files): tempfiles.vader
+Include (Toggling): toggle.vader
 Include (Utils): utils.vader
 Include (Verbosity): verbosity.vader
 

--- a/tests/toggle.vader
+++ b/tests/toggle.vader
@@ -1,0 +1,137 @@
+Include: include/setup.vader
+
+Execute (Toggle commands):
+  Save g:neomake, &verbose
+
+  for verbose in [0, 1]
+    tabnew
+    let &verbose = verbose
+
+    NeomakeToggle
+    AssertEqual g:neomake, {'disabled': 1}
+    AssertEqual neomake#config#get_with_source('disabled'), [1, 'global']
+
+    NeomakeToggleTab
+    AssertEqual g:neomake, {'disabled': 1}
+    AssertEqual t:neomake, {'disabled': 1}
+    AssertEqual neomake#config#get_with_source('disabled'), [1, 'tab']
+
+    NeomakeToggleBuffer
+    AssertEqual g:neomake, {'disabled': 1}
+    AssertEqual t:neomake, {'disabled': 1}
+    AssertEqual b:neomake, {'disabled': 1}
+    AssertEqual neomake#config#get_with_source('disabled'), [1, 'buffer']
+
+    NeomakeEnableBuffer
+    AssertEqual g:neomake, {'disabled': 1}
+    AssertEqual t:neomake, {'disabled': 1}
+    AssertEqual b:neomake, {'disabled': 0}
+    AssertEqual neomake#config#get_with_source('disabled'), [0, 'buffer']
+
+    NeomakeToggleBuffer
+    AssertEqual g:neomake, {'disabled': 1}
+    AssertEqual t:neomake, {'disabled': 1}
+    AssertEqual b:neomake, {'disabled': 1}
+    AssertEqual neomake#config#get_with_source('disabled'), [1, 'buffer']
+
+    NeomakeToggleBuffer
+    AssertEqual g:neomake, {'disabled': 1}
+    AssertEqual t:neomake, {'disabled': 1}
+    AssertEqual b:neomake, {}
+    AssertEqual neomake#config#get_with_source('disabled'), [1, 'tab']
+
+    NeomakeEnableTab
+    AssertEqual g:neomake, {'disabled': 1}
+    AssertEqual t:neomake, {'disabled': 0}
+    AssertEqual b:neomake, {}
+    AssertEqual neomake#config#get_with_source('disabled'), [0, 'tab']
+
+    NeomakeToggleTab
+    AssertEqual g:neomake, {'disabled': 1}
+    AssertEqual t:neomake, {'disabled': 1}
+    AssertEqual b:neomake, {}
+    AssertEqual neomake#config#get_with_source('disabled'), [1, 'tab']
+
+    NeomakeToggleTab
+    AssertEqual g:neomake, {'disabled': 1}
+    AssertEqual t:neomake, {}
+    AssertEqual b:neomake, {}
+    AssertEqual neomake#config#get_with_source('disabled'), [1, 'global']
+
+    NeomakeEnable
+    AssertEqual g:neomake, {'disabled': 0}
+    AssertEqual t:neomake, {}
+    AssertEqual b:neomake, {}
+    AssertEqual neomake#config#get_with_source('disabled'), [0, 'global']
+
+    NeomakeToggle
+    AssertEqual g:neomake, {'disabled': 1}
+    AssertEqual t:neomake, {}
+    AssertEqual b:neomake, {}
+    AssertEqual neomake#config#get_with_source('disabled'), [1, 'global']
+
+    NeomakeToggle
+    AssertEqual g:neomake, {}
+    AssertEqual t:neomake, {}
+    AssertEqual b:neomake, {}
+    AssertEqual neomake#config#get_with_source('disabled'),
+    \ [g:neomake#config#undefined, 'default']
+    bwipe
+
+    if verbose
+      redir => messages_output
+        silent messages
+      redir END
+      AssertEqual split(messages_output, "\n")[-12:], [
+        \ 'Neomake is disabled (global).',
+        \ 'Neomake is disabled (tab).',
+        \ 'Neomake is disabled (buffer).',
+        \ 'Neomake is enabled (buffer).',
+        \ 'Neomake is disabled (buffer).',
+        \ 'Neomake is disabled (tab).',
+        \ 'Neomake is enabled (tab).',
+        \ 'Neomake is disabled (tab).',
+        \ 'Neomake is disabled (global).',
+        \ 'Neomake is enabled (global).',
+        \ 'Neomake is disabled (global).',
+        \ 'Neomake is enabled.']
+    endif
+  endfor
+
+Execute (NeomakeStatus with disabling commands):
+  tabnew
+  echom 'init_msg'
+  NeomakeStatus
+
+  NeomakeDisable
+  NeomakeStatus
+
+  NeomakeDisableTab
+  NeomakeStatus
+
+  NeomakeDisableBuffer
+  NeomakeStatus
+
+  redir => messages_output
+    silent messages
+  redir END
+  AssertEqual split(messages_output, "\n")[-5:], [
+  \ 'init_msg',
+  \ 'Neomake is enabled.',
+  \ 'Neomake is disabled (global).',
+  \ 'Neomake is disabled (tab).',
+  \ 'Neomake is disabled (buffer).']
+  bwipe
+
+Execute (Neomake via autocommand uses 'disabled' setting):
+  new
+  NeomakeDisableBuffer
+
+  augroup neomake_test_user_setup
+    au!
+    autocmd BufWritePost * Neomake
+  augroup END
+  doautocmd BufWritePost
+  AssertNeomakeMessage 'Disabled via buffer.', 3
+  bwipe
+  augroup! neomake_test_user_setup


### PR DESCRIPTION
This is taken out of the "automake" branch, and `s:Make` uses
`expand('<abuf>')` to detect if it is invoked automatically (via an
autocommand), where the "disabled" setting is checked then.