### PR TITLE
tests: only use function name for check in teardown

### DIFF
--- a/tests/include/init.vim
+++ b/tests/include/init.vim
@@ -430,7 +430,8 @@ function! s:After()
   redir => output_func
     silent function /\C^[A-Z]
   redir END
-  let funcs = split(output_func, "\n")
+  let funcs = map(split(output_func, '\n'),
+        \ "substitute(v:val, '\\v^function (.*)\\(.*$', '\\1', '')")
   let new_funcs = filter(copy(funcs), 'index(g:neomake_test_funcs_before, v:val) == -1')
   if !empty(new_funcs)
     call add(errors, 'New global functions (use script-local ones, or :delfunction to clean them): '.string(new_funcs))

--- a/tests/include/setup.vader
+++ b/tests/include/setup.vader
@@ -18,14 +18,15 @@ Before:
     redir => output_func
       silent function /\C^[A-Z]
     redir END
-    let g:neomake_test_funcs_before = split(output_func, "\n")
+    let g:neomake_test_funcs_before = map(split(output_func, '\n'),
+        \ "substitute(v:val, '\\v^function (.*)\\(.*$', '\\1', '')")
 
     call extend(g:neomake_test_funcs_before, [
-    \ 'function GetVimIndent()', 'function GetVimIndentIntern()',
-    \ 'function GetPythonIndent(lnum)',
-    \ 'function GetJavascriptIndent()',
-    \ 'function GetShIndent()',
-    \ ])
+        \ 'GetVimIndent', 'GetVimIndentIntern',
+        \ 'GetPythonIndent',
+        \ 'GetJavascriptIndent',
+        \ 'GetShIndent',
+        \ ])
   endif
 
   let g:neomake_test_messages = []


### PR DESCRIPTION
Vim 7.3 will not include the "abort" attribute there, and the name is
unique anyway.