### PR TITLE
filename for elm maker output item

### DIFF
--- a/autoload/neomake/makers/ft/elm.vim
+++ b/autoload/neomake/makers/ft/elm.vim
@@ -30,6 +30,7 @@ function! neomake#makers#ft#elm#ElmMakeProcessOutput(context) abort
 
                 let l:compiler_error = item['tag']
                 let l:message = item['overview']
+                let l:filename = item['file']
                 let l:region_start = item['region']['start']
                 let l:region_end = item['region']['end']
                 let l:row = l:region_start['line']
@@ -42,6 +43,7 @@ function! neomake#makers#ft#elm#ElmMakeProcessOutput(context) abort
                             \ 'lnum': l:row,
                             \ 'col': l:col,
                             \ 'length': l:length,
+                            \ 'filename': l:filename,
                             \ }
                 call add(l:errors, l:error)
             endfor

--- a/tests/ft_elm.vader
+++ b/tests/ft_elm.vader
@@ -17,6 +17,7 @@ Execute (elmMake parses error message):
     \ 'lnum': 6,
     \ 'col': 1,
     \ 'length': 4,
+    \ 'filename': 'Bingo.elm',
     \ 'text': 'BAD MAIN TYPE : The `main` value has an unsupported type.'}], result
 
 Execute (elmMake parses warning message):
@@ -29,4 +30,5 @@ Execute (elmMake parses warning message):
     \ 'lnum': 3,
     \ 'col': 1,
     \ 'length': 11,
+    \ 'filename': 'Bingo.elm',
     \ 'text': 'unused import : Module `Html` is unused.'}], result


### PR DESCRIPTION
Neomake complains about missing `bufnr` property in elm maker output. This request adds `bufnr` to error dictionary