### PR TITLE
Feature/vimwiki filetype

### DIFF
--- a/autoload/neomake/makers/ft/vimwiki.vim
+++ b/autoload/neomake/makers/ft/vimwiki.vim
@@ -1,0 +1,9 @@
+function! neomake#makers#ft#vimwiki#SupersetOf() abort
+    return 'markdown'
+endfunction
+
+function! neomake#makers#ft#vimwiki#EnabledMakers() abort
+    return neomake#makers#ft#markdown#EnabledMakers()
+endfunction
+
+" vim: ts=4 sw=4 et

--- a/autoload/neomake/makers/ft/vimwiki.vim
+++ b/autoload/neomake/makers/ft/vimwiki.vim
@@ -1,9 +1,21 @@
 function! neomake#makers#ft#vimwiki#SupersetOf() abort
-    return 'markdown'
+    return 'text'
 endfunction
 
 function! neomake#makers#ft#vimwiki#EnabledMakers() abort
-    return neomake#makers#ft#markdown#EnabledMakers()
+    let makers = ['proselint', 'writegood'] + neomake#makers#ft#text#EnabledMakers()
+    if expand('%:e') ==? 'md'
+      let makers = executable('mdl') ? ['mdl'] : ['markdownlint'] + makers
+    endif
+    return makers
+  endfunction
+
+function! neomake#makers#ft#vimwiki#mdl() abort
+  return neomake#makers#ft#markdown#mdl()
+endfunction
+
+function! neomake#makers#ft#vimwiki#markdownlint() abort
+  return neomake#makers#ft#markdown#markdownlint()
 endfunction
 
 " vim: ts=4 sw=4 et


### PR DESCRIPTION
My attempt at adding makers for [vimwiki](https://github.com/vimwiki/vimwiki/blob/dev/doc/vimwiki.txt) filetypes. I use markdown for my vimwiki syntax, but as I was about to submit a PR with just the first commit I realized markdown isn't even the default syntax.

This implementation defaults to turning on 'proselint' and 'writegood' and then depending on the extension other syntax makers can be added. I initially only added markdown, but obviously (and probably better than how I set it up) it can be extended to include any vimwiki syntax desired. 

First time doing anything in vim script, thankfully it seemed pretty basic. Was a little unsure on adding to a list using the + operator versus cal add() or whatever the alternative was, but overall seemed straight forward. 