### PR TITLE
postprocess: use g:neomake_postprocess_context

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -1060,7 +1060,7 @@ function! s:AddExprCallback(jobinfo, prev_index) abort
             call neomake#utils#DebugMessage(printf('WARN: entry.bufnr (%d) is different from jobinfo.bufnr (%d) (current buffer %d): %s.', entry.bufnr, a:jobinfo.bufnr, bufnr('%'), string(entry)))
         endif
         if !empty(s:postprocessors)
-            let g:neomake_hook_context = {'jobinfo': a:jobinfo}
+            let g:neomake_postprocess_context = {'jobinfo': a:jobinfo}
             try
                 for s:f in s:postprocessors
                     if type(s:f) == type({})
@@ -1071,7 +1071,7 @@ function! s:AddExprCallback(jobinfo, prev_index) abort
                     unlet! s:f  " vim73
                 endfor
             finally
-                unlet! g:neomake_hook_context  " Might be unset already with sleep in postprocess.
+                unlet! g:neomake_postprocess_context  " Might be unset already with sleep in postprocess.
             endtry
         endif
         if entry != before

--- a/tests/postprocess.vader
+++ b/tests/postprocess.vader
@@ -56,7 +56,7 @@ Execute (Postprocess: called with dict+maker as self for list):
 
   let g:neomake_test_called = []
   function! NeomakeTestPostprocess(entry) abort dict
-    call add(g:neomake_test_called, [self, g:neomake_hook_context])
+    call add(g:neomake_test_called, [self, g:neomake_postprocess_context])
   endfunction
 
   let maker = {
@@ -118,7 +118,7 @@ Execute (Postprocess: called with dict+maker as self for non-list):
   \ '_maker_marker': 1,
   \ }
   function! maker.postprocess(entry) abort dict
-    call add(g:neomake_test_called, [self, g:neomake_hook_context])
+    call add(g:neomake_test_called, [self, g:neomake_postprocess_context])
   endfunction
 
   new
@@ -155,7 +155,7 @@ Execute (Postprocess: removes entries with valid -1):
   \ '_maker_marker': 1,
   \ }
   function! maker.postprocess(entry) abort dict
-    call add(g:neomake_test_called, [self, g:neomake_hook_context])
+    call add(g:neomake_test_called, [self, g:neomake_postprocess_context])
     if a:entry.text ==# 'check: bar!'
       let a:entry.valid = -1
     endif
@@ -218,7 +218,7 @@ Execute (maker.postprocess interface for obj):
     AssertEqual self.property, 1
     AssertEqual sort(keys(self)), ['fn', 'property']
     let self.called = 1
-    AssertEqual ['jobinfo'], keys(g:neomake_hook_context)
+    AssertEqual ['jobinfo'], keys(g:neomake_postprocess_context)
   endfunction
 
   let maker = neomake#makers#ft#neomake_tests#echo_maker()
@@ -240,7 +240,7 @@ Execute (maker.postprocess interface for maker):
     catch
       call add(g:neomake_test_called, v:exception)
     endtry
-    AssertEqual g:neomake_hook_context.jobinfo.maker, self
+    AssertEqual g:neomake_postprocess_context.jobinfo.maker, self
   endfunction
 
   call neomake#Make(0, [maker])
@@ -373,4 +373,4 @@ Execute (Hook context gets cleaned on error in postprocess):
   call neomake#Make({'enabled_makers': [maker]})
   NeomakeTestsWaitForFinishedJobs
   AssertNeomakeMessage 'Error during output processing for success-maker: error from postprocess.', 0
-  Assert !exists('g:neomake_hook_context'), 'Hook context was cleaned.'
+  Assert !exists('g:neomake_postprocess_context'), 'Hook context was cleaned.'


### PR DESCRIPTION
Otherwise it might interfere with `neomake#utils#hook`.

Still not documented, and better to replace it with a function arg after
all.