### PR TITLE
do not highlight when line is 0

### DIFF
--- a/autoload/neomake/highlights.vim
+++ b/autoload/neomake/highlights.vim
@@ -57,18 +57,20 @@ else
 endif
 
 function! neomake#highlights#AddHighlight(entry, type) abort
+    " some makers use line 0 for file warnings
+    " (e.g. cpplint with no copyright warnings)
+    " these cannot be highlighted since the line does not exist
+    if a:entry.lnum == 0
+        return
+    endif
+
     if !has_key(s:highlights[a:type], a:entry.bufnr)
         call s:InitBufHighlights(a:type, a:entry.bufnr)
     endif
     let l:hi = get(s:highlight_types, toupper(a:entry.type), 'NeomakeError')
     if get(g:, 'neomake_highlight_lines', 0)
         if s:nvim_api
-            " some makers use line 0 for file warnings
-            " (e.g. cpplint with no copyright warnings)
-            " these cannot be highlighted since the line does not exist
-            if a:entry.lnum > 0
-                call nvim_buf_add_highlight(a:entry.bufnr, s:highlights[a:type][a:entry.bufnr], l:hi, a:entry.lnum - 1, 0, -1)
-            endif
+            call nvim_buf_add_highlight(a:entry.bufnr, s:highlights[a:type][a:entry.bufnr], l:hi, a:entry.lnum - 1, 0, -1)
         else
             call add(s:highlights[a:type][a:entry.bufnr][l:hi], a:entry.lnum)
         endif

--- a/autoload/neomake/highlights.vim
+++ b/autoload/neomake/highlights.vim
@@ -63,7 +63,12 @@ function! neomake#highlights#AddHighlight(entry, type) abort
     let l:hi = get(s:highlight_types, toupper(a:entry.type), 'NeomakeError')
     if get(g:, 'neomake_highlight_lines', 0)
         if s:nvim_api
-            call nvim_buf_add_highlight(a:entry.bufnr, s:highlights[a:type][a:entry.bufnr], l:hi, a:entry.lnum - 1, 0, -1)
+            " some makers use line 0 for file warnings
+            " (e.g. cpplint with no copyright warnings)
+            " these cannot be highlighted since the line does not exist
+            if a:entry.lnum > 0
+                call nvim_buf_add_highlight(a:entry.bufnr, s:highlights[a:type][a:entry.bufnr], l:hi, a:entry.lnum - 1, 0, -1)
+            endif
         else
             call add(s:highlights[a:type][a:entry.bufnr][l:hi], a:entry.lnum)
         endif

--- a/tests/highlights.vader
+++ b/tests/highlights.vader
@@ -66,8 +66,27 @@ Execute (neomake#highlights#AddHighlight with off-columns):
   if !has('nvim')
     AssertEqual highlights['NeomakeError'], [[1, 1, 4]]
   endif
-
   bwipe!
+
+Execute (neomake#highlights#AddHighlight handles entries with line=0, col=0):
+  Save g:neomake_highlight_lines
+  let entry = {'bufnr': bufnr('%'), 'type': 'E', 'lnum': 0, 'col': 0}
+  lockvar entry
+
+  let g:neomake_highlight_lines = 0
+  call neomake#highlights#AddHighlight(entry, 'file')
+  let g:neomake_highlight_lines = 1
+  call neomake#highlights#AddHighlight(entry, 'file')
+
+Execute (neomake#highlights#AddHighlight handles entries with line=0, col=1):
+  Save g:neomake_highlight_lines
+  let entry = {'bufnr': bufnr('%'), 'type': 'E', 'lnum': 0, 'col': 1}
+  lockvar entry
+
+  let g:neomake_highlight_lines = 0
+  call neomake#highlights#AddHighlight(entry, 'file')
+  let g:neomake_highlight_lines = 1
+  call neomake#highlights#AddHighlight(entry, 'file')
 
 Execute (Highlights get (re-)defined on ColorScheme event):
   if exists('g:colors_name')


### PR DESCRIPTION
Prior to this pull request, when let `g:neomake_highlight_lines=1` and the problem line was 0 (e.g., with cpplint and a no copyright warning), neomake would generate the following error:

```Neomake: [1.1:1:1] Error during output processing for cpplint: Vim(call):Line number outside range.```

This pull request excludes line highlighting when the line number is less than 0. An example output of cpplint for this type of error is:

```path/to/file:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]```

