### PR TITLE
Allow use of .chktexrc for chktex

### DIFF
--- a/autoload/neomake/makers/ft/tex.vim
+++ b/autoload/neomake/makers/ft/tex.vim
@@ -5,8 +5,8 @@ function! neomake#makers#ft#tex#EnabledMakers() abort
 endfunction
 
 function! neomake#makers#ft#tex#chktex() abort
-    return {
-                \ 'args': ['-l', '.chktexrc'],
+    let maker = {
+                \ 'args': [],
                 \ 'errorformat':
                 \ '%EError %n in %f line %l: %m,' .
                 \ '%WWarning %n in %f line %l: %m,' .
@@ -14,6 +14,11 @@ function! neomake#makers#ft#tex#chktex() abort
                 \ '%Z%p^,' .
                 \ '%-G%.%#'
                 \ }
+    let rcfile = neomake#utils#FindGlobFile('.chktexrc')
+    if !empty(rcfile)
+        let maker.args += ['-l', fnamemodify(rcfile, ':h')]
+    endif
+    return maker
 endfunction
 
 function! neomake#makers#ft#tex#lacheck() abort

--- a/autoload/neomake/makers/ft/tex.vim
+++ b/autoload/neomake/makers/ft/tex.vim
@@ -6,6 +6,7 @@ endfunction
 
 function! neomake#makers#ft#tex#chktex() abort
     return {
+                \ 'args': ['-l', '.chktexrc'],
                 \ 'errorformat':
                 \ '%EError %n in %f line %l: %m,' .
                 \ '%WWarning %n in %f line %l: %m,' .


### PR DESCRIPTION
This just adds `-l .chktexrc` to the chktex command line so that it's possible to specify some local configuration options.
The file is ignored if it doesn't exist.
This warning is not caught by the parser, so if the file doesn't exist, the behaviour should be just as it is now.