### PR TITLE
Fix sign handling across file/project mode

### DIFF
--- a/autoload/neomake/signs.vim
+++ b/autoload/neomake/signs.vim
@@ -20,7 +20,7 @@ let s:neomake_sign_id = {
     \ 'file': {}
     \ }
 
-let s:base_sign_id = {'file': 5000, 'project': 7000}
+let s:base_sign_id = 5000
 
 let s:signs_for_entries = {}
 
@@ -49,9 +49,15 @@ function! neomake#signs#Reset(bufnr, type) abort
     endif
 endfunction
 
-let s:sign_order = {'neomake_err': 0, 'neomake_warn': 1,
-                 \  'neomake_info': 2, 'neomake_msg': 3}
+let s:sign_order = {'neomake_file_err': 0, 'neomake_file_warn': 1,
+                 \  'neomake_file_info': 2, 'neomake_file_msg': 3,
+                 \  'neomake_project_err': 4, 'neomake_project_warn': 5,
+                 \  'neomake_project_info': 6, 'neomake_project_msg': 7}
 
+" Get the defined signs for a:bufnr.
+" It returns a dictionary with line numbers as keys.
+" If there are multiple entries for a line only the first (visible) entry is
+" returned.
 function! neomake#signs#by_lnum(bufnr) abort
     if !bufexists(a:bufnr + 0)
         return {}
@@ -70,7 +76,7 @@ function! neomake#signs#by_lnum(bufnr) abort
     let d = {}
     for line in signs_output
         let m = matchlist(line, pattern)
-        if !empty(m)
+        if !empty(m) && !has_key(d, m[1])
             " let l[m[2]] = l[m[1]] + 0
             let d[m[1]] = [m[2] + 0, m[3]]
         endif
@@ -99,14 +105,15 @@ function! neomake#signs#PlaceSigns(bufnr, entries, type) abort
                 continue
             endif
             if entry.type ==? 'W'
-                let sign_type = 'neomake_warn'
+                let sign_type = 'warn'
             elseif entry.type ==? 'I'
-                let sign_type = 'neomake_info'
+                let sign_type = 'info'
             elseif entry.type ==? 'M'
-                let sign_type = 'neomake_msg'
+                let sign_type = 'msg'
             else
-                let sign_type = 'neomake_err'
+                let sign_type = 'err'
             endif
+            let sign_type = 'neomake_'.a:type.'_'.sign_type
 
             if ! exists('entries_by_linenr[entry.lnum]')
                         \ || s:sign_order[entries_by_linenr[entry.lnum][1]]
@@ -126,20 +133,20 @@ function! neomake#signs#PlaceSigns(bufnr, entries, type) abort
             endif
 
             let existing_sign = get(placed_signs, entry.lnum, [])
-            if !empty(existing_sign)
-                if existing_sign[1] == sign_type
-                    call neomake#utils#DebugMessage(printf(
-                                \ 'Reusing sign: id=%d, type=%s, lnum=%d.',
-                                \ existing_sign[0], existing_sign[1], lnum))
-                else
-                    let cmd = 'sign place '.existing_sign[0].' name='.sign_type.' buffer='.bufnr
-                    call neomake#utils#DebugMessage('Upgrading sign for lnum='.lnum.': '.cmd.'.')
-                    exe cmd
-                endif
-                call add(kept_signs, existing_sign[0])
+            if empty(existing_sign) || existing_sign[1] !~# '^neomake_'.a:type.'_'
+                call add(place_new, [lnum, sign_type])
                 continue
             endif
-            call add(place_new, [lnum, sign_type])
+            if existing_sign[1] == sign_type
+                call neomake#utils#DebugMessage(printf(
+                            \ 'Reusing sign: id=%d, type=%s, lnum=%d.',
+                            \ existing_sign[0], existing_sign[1], lnum))
+            else
+                let cmd = 'sign place '.existing_sign[0].' name='.sign_type.' buffer='.bufnr
+                call neomake#utils#DebugMessage('Upgrading sign for lnum='.lnum.': '.cmd.'.')
+                exe cmd
+            endif
+            call add(kept_signs, existing_sign[0])
         endfor
 
         for [lnum, sign_type] in place_new
@@ -147,7 +154,7 @@ function! neomake#signs#PlaceSigns(bufnr, entries, type) abort
                 if !empty(placed_signs)
                     let next_sign_id = max(map(values(copy(placed_signs)), 'v:val[0]')) + 1
                 else
-                    let next_sign_id = s:base_sign_id[a:type]
+                    let next_sign_id = s:base_sign_id
                 endif
             else
                 let next_sign_id += 1
@@ -214,7 +221,8 @@ function! neomake#signs#RedefineErrorSign(...) abort
         call extend(opts, g:neomake_error_sign)
     endif
     call extend(opts, default_opts, 'keep')
-    call neomake#signs#RedefineSign('neomake_err', opts)
+    call neomake#signs#RedefineSign('neomake_file_err', opts)
+    call neomake#signs#RedefineSign('neomake_project_err', opts)
 endfunction
 
 function! neomake#signs#RedefineWarningSign(...) abort
@@ -226,7 +234,8 @@ function! neomake#signs#RedefineWarningSign(...) abort
         call extend(opts, g:neomake_warning_sign)
     endif
     call extend(opts, default_opts, 'keep')
-    call neomake#signs#RedefineSign('neomake_warn', opts)
+    call neomake#signs#RedefineSign('neomake_file_warn', opts)
+    call neomake#signs#RedefineSign('neomake_project_warn', opts)
 endfunction
 
 function! neomake#signs#RedefineMessageSign(...) abort
@@ -238,7 +247,8 @@ function! neomake#signs#RedefineMessageSign(...) abort
         call extend(opts, g:neomake_message_sign)
     endif
     call extend(opts, default_opts, 'keep')
-    call neomake#signs#RedefineSign('neomake_msg', opts)
+    call neomake#signs#RedefineSign('neomake_file_msg', opts)
+    call neomake#signs#RedefineSign('neomake_project_msg', opts)
 endfunction
 
 function! neomake#signs#RedefineInfoSign(...) abort
@@ -250,7 +260,8 @@ function! neomake#signs#RedefineInfoSign(...) abort
         call extend(opts, g:neomake_info_sign)
     endif
     call extend(opts, default_opts, 'keep')
-    call neomake#signs#RedefineSign('neomake_info', opts)
+    call neomake#signs#RedefineSign('neomake_file_info', opts)
+    call neomake#signs#RedefineSign('neomake_project_info', opts)
 endfunction
 
 function! neomake#signs#HlexistsAndIsNotCleared(group) abort

--- a/tests/cwd.vader
+++ b/tests/cwd.vader
@@ -407,7 +407,7 @@ Execute (legacy errorformat maker: filename with cwd (error: removed)):
   endif
   bwipe
 
-  AssertNeomakeMessage 'Placing sign: sign place 5000 line=23 name=neomake_err buffer='.expected_bufnr.'.'
+  AssertNeomakeMessage 'Placing sign: sign place 5000 line=23 name=neomake_file_err buffer='.expected_bufnr.'.'
 
 Execute (legacy errorformat maker: filename with cwd (error: maker rmdir)):
   let tempdir = tempname()

--- a/tests/integration.vader
+++ b/tests/integration.vader
@@ -27,12 +27,12 @@ Execute (Test Neomake on errors.sh with one maker):
   endfor
 
   " Basic verification that signs are placed.
-  AssertNeomakeMessage 'Placing sign: sign place 5000 line=5 name=neomake_err buffer='.bufnr.'.', 3, {}
-  AssertNeomakeMessage 'Reusing sign: id=5000, type=neomake_err, lnum=5.', 3, {}
+  AssertNeomakeMessage 'Placing sign: sign place 5000 line=5 name=neomake_file_err buffer='.bufnr.'.', 3, {}
+  AssertNeomakeMessage 'Reusing sign: id=5000, type=neomake_file_err, lnum=5.', 3, {}
 
   AssertEqual NeomakeTestsGetSigns(), [
     \ 'Signs for tests/fixtures/errors.sh:',
-    \ 'line=5  id=5000  name=neomake_err']
+    \ 'line=5  id=5000  name=neomake_file_err']
   bwipe
 
 Execute (Test Neomake on errors.sh with two makers):

--- a/tests/signs.vader
+++ b/tests/signs.vader
@@ -25,7 +25,7 @@ Execute (neomake#signs#RedefineErrorSign):
 
   call neomake#Make(1, [maker])
   NeomakeTestsWaitForFinishedJobs
-  AssertNeomakeMessage 'Placing sign: sign place 5000 line=2 name=neomake_warn buffer='.bufnr('%').'.'
+  AssertNeomakeMessage 'Placing sign: sign place 5000 line=2 name=neomake_file_warn buffer='.bufnr('%').'.'
 
   AssertNeomakeMessage printf("Could not place signs for 1 entries without line number: %s.",
   \ string([{'lnum': 0, 'bufnr': bufnr, 'col': 0, 'valid': 1, 'vcol': 0,
@@ -34,25 +34,25 @@ Execute (neomake#signs#RedefineErrorSign):
 
   " Test #736.
   call neomake#signs#RedefineErrorSign({'text': 'X', 'texthl': 'ErrorMsg'})
-  let sign = substitute(neomake#utils#redir('sign list neomake_err'), '\v^[\n]*', '', '')
-  AssertEqual sign, 'sign neomake_err text=X  texthl=ErrorMsg'
-  AssertEqual neomake#signs#by_lnum(bufnr('%')), {'2': [5000, 'neomake_warn']}
+  let sign = substitute(neomake#utils#redir('sign list neomake_file_err'), '\v^[\n]*', '', '')
+  AssertEqual sign, 'sign neomake_file_err text=X  texthl=ErrorMsg'
+  AssertEqual neomake#signs#by_lnum(bufnr('%')), {'2': [5000, 'neomake_file_warn']}
 
 "   call neomake#signs#RedefineErrorSign({'text': 'W', 'texthl': 'MyWarningSign'})
-"   AssertEqual neomake#signs#by_lnum(bufnr('%')), {'2': [5000, 'neomake_warn']}
+"   AssertEqual neomake#signs#by_lnum(bufnr('%')), {'2': [5000, 'neomake_file_warn']}
 
   call neomake#Make(1, [maker])
   NeomakeTestsWaitForFinishedJobs
-  AssertNeomakeMessage 'Reusing sign: id=5000, type=neomake_warn, lnum=2.'
+  AssertNeomakeMessage 'Reusing sign: id=5000, type=neomake_file_warn, lnum=2.'
   AssertNeomakeMessage 'Cleaning old signs in buffer '.bufnr.': {}.'
 
 "   AssertNeomakeMessage 'Cleaning old signs in buffer '.bufnr.':
-"   \ {'.bufnr.': {2: [5000, neomake_warn]}}', 3, {}
+"   \ {'.bufnr.': {2: [5000, neomake_file_warn]}}', 3, {}
 
   call neomake#signs#Reset(bufnr, 'file')
   call neomake#signs#CleanAllOldSigns('file')
   AssertNeomakeMessage 'Removing signs: {file: {'.bufnr.': '
-  \ .'{2: [5000, neomake_warn]}}, project: {}}.'
+  \ .'{2: [5000, neomake_file_warn]}}, project: {}}.'
   bwipe
 
 Execute (Placing signs in project mode):
@@ -67,14 +67,33 @@ Execute (Placing signs in project mode):
   let bufnr = bufnr('%')
   call neomake#Make(0, [maker])
   NeomakeTestsWaitForFinishedJobs
-  AssertNeomakeMessage 'Placing sign: sign place 7000 line=1 name=neomake_warn buffer='.bufnr.'.'
+  AssertNeomakeMessage 'Placing sign: sign place 5000 line=1 name=neomake_project_warn buffer='.bufnr.'.'
   bd
 
   call neomake#signs#Reset(bufnr, 'project')
   call neomake#signs#CleanAllOldSigns('project')
-  AssertNeomakeMessage 'Cleaning old signs in buffer '.bufnr.': {1: [7000, neomake_warn]}.', 3, {}
-  AssertNeomakeMessage 'Unplacing sign: sign unplace 7000 buffer='.bufnr.'.'
+  AssertNeomakeMessage 'Cleaning old signs in buffer '.bufnr.': {1: [5000, neomake_project_warn]}.', 3, {}
+  AssertNeomakeMessage 'Unplacing sign: sign unplace 5000 buffer='.bufnr.'.'
   exe 'bwipe' bufnr
+
+Execute (Signs are not re-used / wiped across modes):
+  new
+  let bufnr = bufnr('%')
+  call neomake#signs#PlaceSigns(bufnr('%'),
+  \ [{'type': 'E', 'bufnr': bufnr('%'), 'lnum': 1}], 'file')
+  call neomake#signs#PlaceSigns(bufnr('%'),
+  \ [{'type': 'W', 'bufnr': bufnr('%'), 'lnum': 1}], 'project')
+
+  AssertNeomakeMessage 'Placing sign: sign place 5000 line=1 name=neomake_file_err buffer='.bufnr.'.'
+  AssertNeomakeMessage 'Placing sign: sign place 5001 line=1 name=neomake_project_warn buffer='.bufnr.'.'
+  call neomake#signs#ResetProject()
+  call neomake#signs#CleanAllOldSigns('project')
+  AssertNeomakeMessage 'Removing signs: {file: {}, project: {'.bufnr.': {1: [5001, neomake_project_warn]}}}.'
+
+  AssertEqual neomake#signs#by_lnum(bufnr), {'1': [5000, 'neomake_file_err']}
+  call neomake#signs#RedefineSign('neomake_file_warn', {})
+
+  bwipe
 
 Execute (Signs are wiped when buffer gets wiped):
   new
@@ -82,7 +101,7 @@ Execute (Signs are wiped when buffer gets wiped):
   \ [{'type': 'E', 'bufnr': bufnr('%'), 'lnum': 1}], 'file')
   bwipe
   " Should not cause 'E158: Invalid buffer name'
-  call neomake#signs#RedefineSign('neomake_err', {})
+  call neomake#signs#RedefineSign('neomake_file_err', {})
 
 Execute (Signs are not wiped when buffer gets wiped with removed augroup):
   new
@@ -90,7 +109,7 @@ Execute (Signs are not wiped when buffer gets wiped with removed augroup):
   call neomake#signs#PlaceSigns(bufnr('%'),
   \ [{'type': 'E', 'bufnr': bufnr('%'), 'lnum': 1}], 'file')
   bwipe
-  AssertThrows call neomake#signs#RedefineSign('neomake_err', {})
+  AssertThrows call neomake#signs#RedefineSign('neomake_file_err', {})
   AssertEqual g:vader_exception, 'Vim(sign):E158: Invalid buffer name: '
   runtime autoload/neomake/signs.vim
 
@@ -98,12 +117,12 @@ Execute (neomake#signs#by_lnum):
   new
   let bufnr = bufnr('%')
 
-  exe 'sign place 5000 name=neomake_err line=1 buffer='.bufnr
-  exe 'sign place 5001 name=neomake_warn line=2 buffer='.bufnr
-  exe 'sign place 5002 name=neomake_info line=3 buffer='.bufnr
+  exe 'sign place 5000 name=neomake_file_err line=1 buffer='.bufnr
+  exe 'sign place 5001 name=neomake_file_warn line=2 buffer='.bufnr
+  exe 'sign place 5002 name=neomake_file_info line=3 buffer='.bufnr
 
   AssertEqual neomake#signs#by_lnum(bufnr('%')), {
-  \ '1': [5000, 'neomake_err'], '2': [5001, 'neomake_warn'], '3': [5002, 'neomake_info']}
+  \ '1': [5000, 'neomake_file_err'], '2': [5001, 'neomake_file_warn'], '3': [5002, 'neomake_file_info']}
   bwipe
 
 Execute (neomake#signs#by_lnum for invalid bufnr):
@@ -124,9 +143,9 @@ Execute (neomake#signs#PlaceSigns):
   call neomake#signs#PlaceSigns(bufnr, entries, 'file')
 
   AssertEqual neomake#signs#by_lnum(bufnr('%')), {
-  \ '1': [5000, 'neomake_err'],
-  \ '2': [5001, 'neomake_warn'],
-  \ '3': [5002, 'neomake_info']}
+  \ '1': [5000, 'neomake_file_err'],
+  \ '2': [5001, 'neomake_file_warn'],
+  \ '3': [5002, 'neomake_file_info']}
 
   let entries = [
   \ {'lnum': 1, 'type': 'E', 'bufnr': bufnr},
@@ -137,9 +156,9 @@ Execute (neomake#signs#PlaceSigns):
   call neomake#signs#PlaceSigns(bufnr, entries, 'file')
 
   AssertEqual neomake#signs#by_lnum(bufnr), {
-  \ '1': [5000, 'neomake_err'],
-  \ '2': [5001, 'neomake_warn'],
-  \ '3': [5002, 'neomake_err']}
+  \ '1': [5000, 'neomake_file_err'],
+  \ '2': [5001, 'neomake_file_warn'],
+  \ '3': [5002, 'neomake_file_err']}
 
   let entries = [
   \ {'lnum': 2, 'type': 'E', 'bufnr': bufnr},
@@ -149,10 +168,10 @@ Execute (neomake#signs#PlaceSigns):
   \ ]
   call neomake#signs#PlaceSigns(bufnr, entries, 'file')
   AssertEqual neomake#signs#by_lnum(bufnr), {
-  \ '1': [5000, 'neomake_err'],
-  \ '2': [5001, 'neomake_err'],
-  \ '3': [5002, 'neomake_warn'],
-  \ '4': [5003, 'neomake_err']}
+  \ '1': [5000, 'neomake_file_err'],
+  \ '2': [5001, 'neomake_file_err'],
+  \ '3': [5002, 'neomake_file_warn'],
+  \ '4': [5003, 'neomake_file_err']}
 
   call neomake#signs#Reset(bufnr, 'file')
   call neomake#signs#CleanOldSigns(bufnr, 'file')
@@ -161,9 +180,9 @@ Execute (neomake#signs#PlaceSigns):
 "   call neomake#signs#ResetFile(bufnr)
 
   AssertEqual neomake#signs#by_lnum(bufnr), {
-  \ '2': [5000, 'neomake_err'],
-  \ '3': [5001, 'neomake_warn'],
-  \ '4': [5002, 'neomake_err']}
+  \ '2': [5000, 'neomake_file_err'],
+  \ '3': [5001, 'neomake_file_warn'],
+  \ '4': [5002, 'neomake_file_err']}
 
   let entries = [
   \ {'lnum': 4, 'type': 'E', 'bufnr': bufnr},
@@ -174,9 +193,9 @@ Execute (neomake#signs#PlaceSigns):
   call neomake#signs#PlaceSigns(bufnr, entries, 'file')
 
   AssertEqual neomake#signs#by_lnum(bufnr), {
-  \ '2': [5000, 'neomake_err'],
-  \ '3': [5001, 'neomake_warn'],
-  \ '4': [5002, 'neomake_err']}
+  \ '2': [5000, 'neomake_file_err'],
+  \ '3': [5001, 'neomake_file_warn'],
+  \ '4': [5002, 'neomake_file_err']}
 
 
   let entries = [
@@ -188,10 +207,10 @@ Execute (neomake#signs#PlaceSigns):
   call neomake#signs#PlaceSigns(bufnr, entries, 'file')
 
   AssertEqual neomake#signs#by_lnum(bufnr), {
-  \ '2': [5000, 'neomake_err'],
-  \ '3': [5001, 'neomake_warn'],
-  \ '4': [5002, 'neomake_err'],
-  \ '5': [5003, 'neomake_info']}
+  \ '2': [5000, 'neomake_file_err'],
+  \ '3': [5001, 'neomake_file_warn'],
+  \ '4': [5002, 'neomake_file_err'],
+  \ '5': [5003, 'neomake_file_info']}
 
   call neomake#signs#Reset(bufnr, 'file')
   call neomake#signs#CleanOldSigns(bufnr, 'file')
@@ -213,9 +232,9 @@ Execute (neomake#signs#PlaceSigns with E and I):
   call neomake#signs#PlaceSigns(bufnr, entries, 'file')
 
   AssertEqual neomake#signs#by_lnum(bufnr('%')), {
-  \ '1': [5000, 'neomake_err'],
-  \ '2': [5001, 'neomake_warn'],
-  \ '3': [5002, 'neomake_err']}
+  \ '1': [5000, 'neomake_file_err'],
+  \ '2': [5001, 'neomake_file_warn'],
+  \ '3': [5002, 'neomake_file_err']}
   bwipe
 
 Execute (Signs get handled across multiple get_list_entries jobs):
@@ -238,31 +257,31 @@ Execute (Signs get handled across multiple get_list_entries jobs):
 
   call neomake#Make(1, [maker1])
   AssertEqual neomake#signs#by_lnum(bufnr), {
-  \ '1': [5000, 'neomake_err'],
+  \ '1': [5000, 'neomake_file_err'],
   \ }
 
   call neomake#Make(1, [maker1, maker2])
   AssertEqual neomake#signs#by_lnum(bufnr), {
-  \ '1': [5000, 'neomake_err'],
-  \ '2': [5001, 'neomake_warn'],
+  \ '1': [5000, 'neomake_file_err'],
+  \ '2': [5001, 'neomake_file_warn'],
   \ }
 
   call neomake#Make(1, [maker1])
   AssertEqual neomake#signs#by_lnum(bufnr), {
-  \ '1': [5000, 'neomake_err'],
+  \ '1': [5000, 'neomake_file_err'],
   \ }
   bwipe
 
 Execute (next sign_id based on max):
   new
   let bufnr = bufnr('%')
-  exe 'sign place 5002 line=1 name=neomake_warn buffer='.bufnr
-  exe 'sign place 5001 line=2 name=neomake_warn buffer='.bufnr
+  exe 'sign place 5002 line=1 name=neomake_file_warn buffer='.bufnr
+  exe 'sign place 5001 line=2 name=neomake_file_warn buffer='.bufnr
   call neomake#signs#PlaceSigns(bufnr, [{'lnum': 3, 'type': 'W'}], 'file')
   AssertEqual neomake#signs#by_lnum(bufnr), {
-  \ '1': [5002, 'neomake_warn'],
-  \ '2': [5001, 'neomake_warn'],
-  \ '3': [5003, 'neomake_warn']}
+  \ '1': [5002, 'neomake_file_warn'],
+  \ '2': [5001, 'neomake_file_warn'],
+  \ '3': [5003, 'neomake_file_warn']}
   bwipe
 
 Execute (file mode signs get placed when job finishes):
@@ -280,14 +299,14 @@ Execute (file mode signs get placed when job finishes):
     NeomakeTestsWaitForNextFinishedJob
 
     AssertEqual neomake#signs#by_lnum(bufnr), {
-    \ '1': [5000, 'neomake_info'],
-    \ '3': [5001, 'neomake_warn'],
+    \ '1': [5000, 'neomake_file_info'],
+    \ '3': [5001, 'neomake_file_warn'],
     \ }
     NeomakeTestsWaitForFinishedJobs
     AssertEqual neomake#signs#by_lnum(bufnr), {
-    \ '1': [5000, 'neomake_warn'],
-    \ '2': [5002, 'neomake_err'],
-    \ '3': [5001, 'neomake_warn'],
+    \ '1': [5000, 'neomake_file_warn'],
+    \ '2': [5002, 'neomake_file_err'],
+    \ '3': [5001, 'neomake_file_warn'],
     \ }
     bwipe
   endif
@@ -311,19 +330,36 @@ Execute (project mode signs get placed when job finishes):
     NeomakeTestsWaitForNextFinishedJob
 
     AssertEqual neomake#signs#by_lnum(bufnr1), {
-    \ '1': [7000, 'neomake_info'],
+    \ '1': [5000, 'neomake_project_info'],
     \ }
     AssertEqual neomake#signs#by_lnum(bufnr2), {
-    \ '3': [7000, 'neomake_warn'],
+    \ '3': [5000, 'neomake_project_warn'],
     \ }
     NeomakeTestsWaitForFinishedJobs
     AssertEqual neomake#signs#by_lnum(bufnr1), {
-    \ '1': [7000, 'neomake_warn'],
+    \ '1': [5000, 'neomake_project_warn'],
     \ }
     AssertEqual neomake#signs#by_lnum(bufnr2), {
-    \ '2': [7001, 'neomake_err'],
-    \ '3': [7000, 'neomake_warn'],
+    \ '2': [5001, 'neomake_project_err'],
+    \ '3': [5000, 'neomake_project_warn'],
     \ }
+
+    " Verify sign handling with a file mode maker on top.
+    let maker = {'_bufnr': bufnr1}
+    function maker.get_list_entries(...)
+      return [{'bufnr': self._bufnr, 'lnum': 1}]
+    endfunction
+    CallNeomake {'file_mode': 1, 'enabled_makers': [maker]}
+    AssertNeomakeMessage 'Placing sign: sign place 5001 line=1 name=neomake_file_err buffer='.bufnr1.'.'
+    AssertEqual neomake#signs#by_lnum(bufnr1), {
+    \ '1': [5001, 'neomake_file_err'],
+    \ }
+    call neomake#signs#ResetFile(bufnr1)
+    call neomake#signs#CleanAllOldSigns('file')
+    AssertEqual neomake#signs#by_lnum(bufnr1), {
+    \ '1': [5000, 'neomake_project_warn'],
+    \ }
+
     bwipe
     bwipe
   endif


### PR DESCRIPTION
- Use separate sign names ('neomake_file_err' and 'neomake_project_err',
  instead of only 'neomake_err').
- Use just a single base sign_id.