### PR TITLE
Add neomake#compat#get_argv to fix .cmd lookup on Windows

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -624,39 +624,7 @@ function! s:command_maker_base._get_argv(jobinfo) abort dict
             endif
         endif
     endif
-
-    if has('nvim')
-        if args_is_list
-            let argv = [exe] + args
-        else
-            let argv = exe . (!empty(args) ? ' ' . args : '')
-        endif
-    elseif s:async
-        " Vim jobs, need special treatment on Windows..
-        if neomake#utils#IsRunningWindows()
-            " Windows needs a subshell to handle PATH/%PATHEXT% etc.
-            if args_is_list
-                let argv = join(map(copy([exe] + args), 'neomake#utils#shellescape(v:val)'))
-            else
-                let argv = exe.' '.args
-            endif
-            let argv = &shell.' '.&shellcmdflag.' '.argv
-
-        elseif !args_is_list
-            " Use a shell to handle argv properly (Vim splits at spaces).
-            let argv = [&shell, &shellcmdflag, exe.' '.args]
-        else
-            let argv = [exe] + args
-        endif
-    else
-        " Vim (synchronously), via system().
-        if args_is_list
-            let argv = join(map(copy([exe] + args), 'neomake#utils#shellescape(v:val)'))
-        else
-            let argv = exe.' '.args
-        endif
-    endif
-    return argv
+    return neomake#compat#get_argv(exe, args, args_is_list)
 endfunction
 
 function! neomake#GetMaker(name_or_maker, ...) abort

--- a/autoload/neomake/compat.vim
+++ b/autoload/neomake/compat.vim
@@ -151,14 +151,14 @@ if has('nvim')
                 " but not worth it probably (and more fragile in the end?!).
                 return join(map(copy([a:exe] + a:args), 'neomake#utils#shellescape(v:val)'))
             endif
-            return a:exe . (!empty(a:args) ? ' ' . a:args : '')
+            return a:exe . (empty(a:args) ? '' : ' '.a:args)
         endfunction
     else
         function! neomake#compat#get_argv(exe, args, args_is_list) abort
             if a:args_is_list
                 return [a:exe] + a:args
             endif
-            return a:exe . (!empty(a:args) ? ' ' . a:args : '')
+            return a:exe . (empty(a:args) ? '' : ' '.a:args)
         endfunction
     endif
 elseif neomake#has_async_support()  " Vim-async.
@@ -168,7 +168,7 @@ elseif neomake#has_async_support()  " Vim-async.
             if a:args_is_list
                 let argv = join(map(copy([a:exe] + a:args), 'neomake#utils#shellescape(v:val)'))
             else
-                let argv = a:exe.' '.a:args
+                let argv = a:exe . (empty(a:args) ? '' : ' '.a:args)
             endif
             return &shell.' '.&shellcmdflag.' '.argv
         endfunction
@@ -178,7 +178,8 @@ elseif neomake#has_async_support()  " Vim-async.
                 return [a:exe] + a:args
             endif
             " Use a shell to handle argv properly (Vim splits at spaces).
-            return [&shell, &shellcmdflag, a:exe.' '.a:args]
+            let argv = a:exe . (empty(a:args) ? '' : ' '.a:args)
+            return [&shell, &shellcmdflag, argv]
         endfunction
     endif
 else
@@ -187,6 +188,6 @@ else
         if a:args_is_list
             return join(map(copy([a:exe] + a:args), 'neomake#utils#shellescape(v:val)'))
         endif
-        return a:exe . (!empty(a:args) ? ' ' . a:args : '')
+        return a:exe . (empty(a:args) ? '' : ' '.a:args)
     endfunction
 endif


### PR DESCRIPTION
Fixes https://github.com/neomake/neomake/issues/1476.

TODO:
 - [x] confirmation to fix the issue with Neovim on Windows, and not regress otherwise.