### PR TITLE
Travis: language: generic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 dist: trusty
 sudo: false
 
-language: none
+language: generic
 branches:
   only:
     - master


### PR DESCRIPTION
Using "none" still appears to (conditionally) call "bundle install"
(install.bundler step).