### PR TITLE
Fix neomake#compat#get_argv for Windows

### DIFF
--- a/autoload/neomake/compat.vim
+++ b/autoload/neomake/compat.vim
@@ -170,7 +170,11 @@ elseif neomake#has_async_support()  " Vim-async.
             else
                 let argv = a:exe . (empty(a:args) ? '' : ' '.a:args)
             endif
-            return &shell.' '.&shellcmdflag.' '.argv
+            let prefix = &shell.' '.&shellcmdflag.' '
+            if argv[0:len(prefix)-1] == prefix
+                return argv
+            endif
+            return prefix.neomake#utils#shellescape(argv)
         endfunction
     else
         function! neomake#compat#get_argv(exe, args, args_is_list) abort

--- a/tests/compat.vader
+++ b/tests/compat.vader
@@ -51,7 +51,11 @@ Execute (neomake#compat#get_argv on (emulated) Windows):
   if has('nvim')
     AssertEqual out, 'sh -c ''echo 1'''
   else
-    AssertEqual out, '/bin/bash -c ''sh -c ''\''''echo 1''\'''''''
+    if neomake#has_async_support()
+      AssertEqual out, '/bin/bash -c ''sh -c ''\''''echo 1''\'''''''
+    else
+      AssertEqual out, 'sh -c ''echo 1'''
+    endif
 
     " Does not get wrapped in shell twice.
     let &shell = 'sh'

--- a/tests/compat.vader
+++ b/tests/compat.vader
@@ -39,3 +39,26 @@ Execute (neomake#compat#systemlist with empty args):
   AssertEqual neomake#compat#systemlist(''), []
   AssertEqual neomake#compat#systemlist([]), []
   AssertEqual neomake#compat#systemlist('0'), ['/bin/bash: 0: command not found']
+
+Execute (neomake#compat#get_argv on (emulated) Windows):
+  Save &shell, &shellcmdflag
+  function! neomake#utils#IsRunningWindows()
+    return 1
+  endfunction
+  runtime autoload/neomake/compat.vim
+
+  let out = neomake#compat#get_argv('sh', ['-c', 'echo 1'], 1)
+  if has('nvim')
+    AssertEqual out, 'sh -c ''echo 1'''
+  else
+    AssertEqual out, '/bin/bash -c ''sh -c ''\''''echo 1''\'''''''
+
+    " Does not get wrapped in shell twice.
+    let &shell = 'sh'
+    let out = neomake#compat#get_argv('sh', ['-c', 'echo 1'], 1)
+    AssertEqual out, 'sh -c ''echo 1'''
+  endif
+
+  " Undo monkeypatch.
+  runtime autoload/neomake/compat.vim
+  runtime autoload/neomake/utils.vim

--- a/tests/compat.vader
+++ b/tests/compat.vader
@@ -60,5 +60,5 @@ Execute (neomake#compat#get_argv on (emulated) Windows):
   endif
 
   " Undo monkeypatch.
-  runtime autoload/neomake/compat.vim
   runtime autoload/neomake/utils.vim
+  runtime autoload/neomake/compat.vim


### PR DESCRIPTION
- escape argv when wrapping it in a shell
- do not wrap it in a shell twice

Fixes https://github.com/neomake/neomake/issues/1481.