### PR TITLE
Use latest supported version of C++ standard by default for cpp maker

### DIFF
--- a/autoload/neomake/makers/ft/cpp.vim
+++ b/autoload/neomake/makers/ft/cpp.vim
@@ -9,12 +9,14 @@ endfunction
 function! neomake#makers#ft#cpp#clang() abort
     let maker = neomake#makers#ft#c#clang()
     let maker.exe = 'clang++'
+    let maker.args = makers.args + ['-std=c++1z']
     return maker
 endfunction
 
 function! neomake#makers#ft#cpp#gcc() abort
     let maker = neomake#makers#ft#c#gcc()
     let maker.exe = 'g++'
+    let maker.args = makers.args + ['-std=c++1z']
     return maker
 endfunction
 

--- a/autoload/neomake/makers/ft/cpp.vim
+++ b/autoload/neomake/makers/ft/cpp.vim
@@ -9,14 +9,14 @@ endfunction
 function! neomake#makers#ft#cpp#clang() abort
     let maker = neomake#makers#ft#c#clang()
     let maker.exe = 'clang++'
-    let maker.args = makers.args + ['-std=c++1z']
+    let maker.args += ['-std=c++1z']
     return maker
 endfunction
 
 function! neomake#makers#ft#cpp#gcc() abort
     let maker = neomake#makers#ft#c#gcc()
     let maker.exe = 'g++'
-    let maker.args = makers.args + ['-std=c++1z']
+    let maker.args += ['-std=c++1z']
     return maker
 endfunction
 


### PR DESCRIPTION
By default, gcc and clang default to the 2003 C++ version. Regardless of project make settings, I think it's a safe assumption for the default standard that neomake checks syntax against to be the latest supported standard (currently C++1z)