### PR TITLE
C and C++ maker improvements

### DIFF
--- a/autoload/neomake/makers/ft/c.vim
+++ b/autoload/neomake/makers/ft/c.vim
@@ -66,6 +66,7 @@ endfunction
 function! neomake#makers#ft#c#clangtidy() abort
     return {
         \ 'exe': 'clang-tidy',
+        \ 'args': ['%:p'],
         \ 'errorformat':
             \ '%E%f:%l:%c: fatal error: %m,' .
             \ '%E%f:%l:%c: error: %m,' .

--- a/autoload/neomake/makers/ft/c.vim
+++ b/autoload/neomake/makers/ft/c.vim
@@ -8,8 +8,10 @@ function! neomake#makers#ft#c#EnabledMakers() abort
 endfunction
 
 function! neomake#makers#ft#c#clang() abort
+    " as a single-file maker, include the current directory in the default
+    " search path
     return {
-        \ 'args': ['-fsyntax-only', '-Wall', '-Wextra'],
+        \ 'args': ['-fsyntax-only', '-Wall', '-Wextra', '-I./'],
         \ 'errorformat':
             \ '%-G%f:%s:,' .
             \ '%f:%l:%c: %trror: %m,' .
@@ -41,8 +43,10 @@ function! neomake#makers#ft#c#clangcheck() abort
 endfunction
 
 function! neomake#makers#ft#c#gcc() abort
+    " as a single-file maker, include the current directory in the default
+    " search path
     return {
-        \ 'args': ['-fsyntax-only', '-Wall', '-Wextra'],
+        \ 'args': ['-fsyntax-only', '-Wall', '-Wextra', '-I./'],
         \ 'errorformat':
             \ '%-G%f:%s:,' .
             \ '%-G%f:%l: %#error: %#(Each undeclared identifier is reported only%.%#,' .

--- a/autoload/neomake/makers/ft/cpp.vim
+++ b/autoload/neomake/makers/ft/cpp.vim
@@ -21,11 +21,20 @@ function! neomake#makers#ft#cpp#gcc() abort
 endfunction
 
 function! neomake#makers#ft#cpp#clangtidy() abort
-    return neomake#makers#ft#c#clangtidy()
+    let maker = neomake#makers#ft#c#clangtidy()
+    " clang-tidy invokes clang, and that needs to be configured
+    " clang arguments are passed to clang-tidy after a literal "--"
+    let maker.args += ['--']
+    let maker.args += neomake#makers#ft#cpp#clang().args
+    return maker
 endfunction
 
 function! neomake#makers#ft#cpp#clangcheck() abort
-    return neomake#makers#ft#c#clangcheck()
+    " clang-check invokes clang, and that needs to be configured
+    " clang arguments are passed to clang-check after a literal "--"
+    let maker.args += ['--']
+    let maker.args += neomake#makers#ft#cpp#clang().args
+    return maker
 endfunction
 
 function! neomake#makers#ft#cpp#cppcheck() abort

--- a/autoload/neomake/makers/ft/cpp.vim
+++ b/autoload/neomake/makers/ft/cpp.vim
@@ -10,9 +10,6 @@ function! neomake#makers#ft#cpp#clang() abort
     let maker = neomake#makers#ft#c#clang()
     let maker.exe = 'clang++'
     let maker.args += ['-std=c++1z']
-    " as a single-file maker, include the current directory in the default
-    " search path
-    let maker.args += ['-I./']
     return maker
 endfunction
 
@@ -20,9 +17,6 @@ function! neomake#makers#ft#cpp#gcc() abort
     let maker = neomake#makers#ft#c#gcc()
     let maker.exe = 'g++'
     let maker.args += ['-std=c++1z']
-    " as a single-file maker, include the current directory in the default
-    " search path
-    let maker.args += ['-I./']
     return maker
 endfunction
 

--- a/autoload/neomake/makers/ft/cpp.vim
+++ b/autoload/neomake/makers/ft/cpp.vim
@@ -22,18 +22,16 @@ endfunction
 
 function! neomake#makers#ft#cpp#clangtidy() abort
     let maker = neomake#makers#ft#c#clangtidy()
-    " clang-tidy invokes clang, and that needs to be configured
     " clang arguments are passed to clang-tidy after a literal "--"
-    let maker.args += ['--']
+    let maker.args += ['--', '-std=c++1z', '-I./']
     let maker.args += neomake#makers#ft#cpp#clang().args
     return maker
 endfunction
 
 function! neomake#makers#ft#cpp#clangcheck() abort
     let maker = neomake#makers#ft#c#clangcheck()
-    " clang-check invokes clang, and that needs to be configured
     " clang arguments are passed to clang-check after a literal "--"
-    let maker.args += ['--']
+    let maker.args += ['--', '-std=c++1z', '-I./']
     let maker.args += neomake#makers#ft#cpp#clang().args
     return maker
 endfunction

--- a/autoload/neomake/makers/ft/cpp.vim
+++ b/autoload/neomake/makers/ft/cpp.vim
@@ -10,6 +10,9 @@ function! neomake#makers#ft#cpp#clang() abort
     let maker = neomake#makers#ft#c#clang()
     let maker.exe = 'clang++'
     let maker.args += ['-std=c++1z']
+    " as a single-file maker, include the current directory in the default
+    " search path
+    let maker.args += ['-I./']
     return maker
 endfunction
 
@@ -17,6 +20,9 @@ function! neomake#makers#ft#cpp#gcc() abort
     let maker = neomake#makers#ft#c#gcc()
     let maker.exe = 'g++'
     let maker.args += ['-std=c++1z']
+    " as a single-file maker, include the current directory in the default
+    " search path
+    let maker.args += ['-I./']
     return maker
 endfunction
 

--- a/autoload/neomake/makers/ft/cpp.vim
+++ b/autoload/neomake/makers/ft/cpp.vim
@@ -30,6 +30,7 @@ function! neomake#makers#ft#cpp#clangtidy() abort
 endfunction
 
 function! neomake#makers#ft#cpp#clangcheck() abort
+    let maker = neomake#makers#ft#c#clangcheck()
     " clang-check invokes clang, and that needs to be configured
     " clang arguments are passed to clang-check after a literal "--"
     let maker.args += ['--']

--- a/autoload/neomake/makers/ft/cpp.vim
+++ b/autoload/neomake/makers/ft/cpp.vim
@@ -23,16 +23,16 @@ endfunction
 function! neomake#makers#ft#cpp#clangtidy() abort
     let maker = neomake#makers#ft#c#clangtidy()
     " clang arguments are passed to clang-tidy after a literal "--"
+    " clang arguments like -fsyntax-only break clang-tidy
     let maker.args += ['--', '-std=c++1z', '-I./']
-    let maker.args += neomake#makers#ft#cpp#clang().args
     return maker
 endfunction
 
 function! neomake#makers#ft#cpp#clangcheck() abort
     let maker = neomake#makers#ft#c#clangcheck()
     " clang arguments are passed to clang-check after a literal "--"
+    " clang arguments like -fsyntax-only break clang-check
     let maker.args += ['--', '-std=c++1z', '-I./']
-    let maker.args += neomake#makers#ft#cpp#clang().args
     return maker
 endfunction
 


### PR DESCRIPTION
I've made some improvements to the C and C++ makers that should be safe to apply for everyone for single-file makers. The most important improvement is include -I./ in the arguments to the single-file makers for C/C++ for clang and gcc to include the current project directory in the header file search path. A lot of build systems generate a top-level config.h that is placed in that directory, regardless of where the rest of the source code actually lives.

Also, the clang-check and clang-tidy makers were broken for a couple of reasons. First, the clang arguments do not go directly to the clang-{check,tidy} tool, they have to be separated by a literal `--`, otherwise they are interpreted as arguments to the tool and not the compiler. Second, for some reason clang-check and clang-tidy were refusing to recognize clang arguments when `-fsyntax-only` (from the default clang c/cpp maker args) was included in the argument list.

Additionally, the file path was being included for these tools via the clang arguments, but the file path needs to go before the `--` and not after. 

All-in-all, it was way saner and much less fragile to just specify the parameters for these tools separately rather than have them inherit from the clang maker.