### PR TITLE
[php.phpstan] Disable progress output

### DIFF
--- a/autoload/neomake/makers/ft/php.vim
+++ b/autoload/neomake/makers/ft/php.vim
@@ -43,7 +43,7 @@ endfunction
 
 function! neomake#makers#ft#php#phpstan() abort
     return {
-        \ 'args': ['analyse', '--errorFormat', 'raw'],
+        \ 'args': ['analyse', '--errorFormat', 'raw', '--no-progress'],
         \ 'errorformat': '%E%f:%l:%m',
         \ }
 endfunction


### PR DESCRIPTION
Disables phpstan's progress output to not pollute the location list.