### PR TITLE
tslint: do not append file twice, use --project

### DIFF
--- a/autoload/neomake/makers/ft/typescript.vim
+++ b/autoload/neomake/makers/ft/typescript.vim
@@ -29,6 +29,7 @@ function! neomake#makers#ft#typescript#tslint() abort
     let config = neomake#utils#FindGlobFile('tsconfig.json')
     if !empty(config)
         let maker.args = ['--project', config]
+        let maker.cwd = fnamemodify(config, ':h')
     endif
     return maker
 endfunction

--- a/autoload/neomake/makers/ft/typescript.vim
+++ b/autoload/neomake/makers/ft/typescript.vim
@@ -19,7 +19,6 @@ endfunction
 
 function! neomake#makers#ft#typescript#tslint() abort
     return {
-         \ 'args': ['%:p'],
          \ 'errorformat': '%EERROR: %f[%l\, %c]: %m,%E%f[%l\, %c]: %m'
          \ }
 endfunction

--- a/autoload/neomake/makers/ft/typescript.vim
+++ b/autoload/neomake/makers/ft/typescript.vim
@@ -19,6 +19,7 @@ endfunction
 
 function! neomake#makers#ft#typescript#tslint() abort
     return {
-         \ 'errorformat': '%EERROR: %f[%l\, %c]: %m,%E%f[%l\, %c]: %m'
-         \ }
+        \ 'args': ['--project', neomake#utils#FindGlobFile('tsconfig.json')],
+        \ 'errorformat': '%EERROR: %f[%l\, %c]: %m,%E%f[%l\, %c]: %m',
+        \ }
 endfunction

--- a/autoload/neomake/makers/ft/typescript.vim
+++ b/autoload/neomake/makers/ft/typescript.vim
@@ -6,8 +6,8 @@ endfunction
 
 function! neomake#makers#ft#typescript#tsc() abort
     " tsc should not be passed a single file.
-    return {
-        \ 'args': ['--project', neomake#utils#FindGlobFile('tsconfig.json'), '--noEmit', '--watch', 'false'],
+    let maker = {
+        \ 'args': ['--noEmit', '--watch', 'false'],
         \ 'append_file': 0,
         \ 'errorformat':
             \ '%E%f %#(%l\,%c): error %m,' .
@@ -15,11 +15,20 @@ function! neomake#makers#ft#typescript#tsc() abort
             \ '%Eerror %m,' .
             \ '%C%\s%\+%m'
         \ }
+    let config = neomake#utils#FindGlobFile('tsconfig.json')
+    if !empty(config)
+        let maker.args += ['--project', config]
+    endif
+    return maker
 endfunction
 
 function! neomake#makers#ft#typescript#tslint() abort
-    return {
-        \ 'args': ['--project', neomake#utils#FindGlobFile('tsconfig.json')],
+    let maker = {
         \ 'errorformat': '%EERROR: %f[%l\, %c]: %m,%E%f[%l\, %c]: %m',
         \ }
+    let config = neomake#utils#FindGlobFile('tsconfig.json')
+    if !empty(config)
+        let maker.args = ['--project', config]
+    endif
+    return maker
 endfunction


### PR DESCRIPTION
Using --project would allow to use `--type-check` now, but only if a `tsconfig.json` file is found.