### PR TITLE
tests: simplify sleep in postprocess test

### DIFF
--- a/tests/processing.vader
+++ b/tests/processing.vader
@@ -153,8 +153,6 @@ Execute (Sleep in postprocess gets handled correctly):
   " Reproduces flakiness with https://github.com/neomake/neomake/issues/899.
   call neomake#statusline#ResetCounts()
   if NeomakeAsyncTestsSetup()
-    " Vim needs longer sleep to process the output line by line.
-    let s:sleep = has('nvim') ? '0.01' : '0.1'
     Save g:neomake_test_postprocess_count
     let g:neomake_test_postprocess_count = 0
     function! s:postprocess(entry) dict
@@ -166,7 +164,7 @@ Execute (Sleep in postprocess gets handled correctly):
     endfunction
 
     let maker = extend(neomake#utils#MakerFromCommand(
-      \ 'echo out-1; sleep '.s:sleep.'; echo out-22; sleep '.s:sleep.'; echo out-333'), {
+      \ 'echo out-1; sleep 0.1; echo out-22; sleep 0.1; echo out-333'), {
       \ 'buffer_output': 0, 'errorformat': '%m',
       \ 'append_file': 0,
       \ 'postprocess': function('s:postprocess')})

--- a/tests/processing.vader
+++ b/tests/processing.vader
@@ -158,8 +158,7 @@ Execute (Sleep in postprocess gets handled correctly):
     function! s:postprocess(entry) dict
       let g:neomake_test_postprocess_count += 1
       if g:neomake_test_postprocess_count == 1
-        let sleep = has('nvim') ? 200 : 400
-        exe 'sleep '.sleep.'m'
+        exe 'sleep 200m'
       endif
     endfunction
 

--- a/tests/processing.vader
+++ b/tests/processing.vader
@@ -158,7 +158,7 @@ Execute (Sleep in postprocess gets handled correctly):
     function! s:postprocess(entry) dict
       let g:neomake_test_postprocess_count += 1
       if g:neomake_test_postprocess_count == 1
-        let sleep = has('nvim') ? 50 : 400
+        let sleep = has('nvim') ? 200 : 400
         exe 'sleep '.sleep.'m'
       endif
     endfunction


### PR DESCRIPTION
NVIM v0.2.1-642-g36a91c790 might also need more sleep (on Travis, see
https://travis-ci.org/neomake/neomake/jobs/261314821).