### PR TITLE
javascript: standard: use stdout output_stream (#1506)

### DIFF
--- a/autoload/neomake/makers/ft/javascript.vim
+++ b/autoload/neomake/makers/ft/javascript.vim
@@ -48,7 +48,8 @@ endfunction
 
 function! neomake#makers#ft#javascript#standard() abort
     return {
-        \ 'errorformat': '%W  %f:%l:%c: %m'
+        \ 'errorformat': '%W  %f:%l:%c: %m',
+        \ 'output_stream': 'stdout'
         \ }
 endfunction
 


### PR DESCRIPTION
Standard prints its tagline and `--fix` notice to stderr. Lint output
goes to stdout.

Closes #1506.