### PR TITLE
neomake#utils#MakerFromCommand: set exe/args; support list

### DIFF
--- a/tests/ft_text.vader
+++ b/tests/ft_text.vader
@@ -55,9 +55,8 @@ Execute (proselint):
 
   let maker = neomake#GetMaker('proselint', 'text')
   let maker.append_file = 0
-  call extend(maker, neomake#utils#MakerFromCommand(
-  \ "echo \"file.txt:1:1: typography.symbols.ellipsis '...' is an approximation, use the ellipsis symbol '…'.\""),
-  \ 'keep')
+  let maker.exe = 'echo'
+  let maker.args = ["file.txt:1:1: typography.symbols.ellipsis '...' is an approximation, use the ellipsis symbol '…'."]
   call neomake#Make(1, [maker])
   NeomakeTestsWaitForFinishedJobs
   AssertEqual g:neomake_test_highlights_called, [[

--- a/tests/signs.vader
+++ b/tests/signs.vader
@@ -286,11 +286,14 @@ Execute (next sign_id based on max):
 
 Execute (file mode signs get placed when job finishes):
   if NeomakeAsyncTestsSetup()
+    let options = {
+    \ 'errorformat': '%f:%l:%t:%m',
+    \ 'mapexpr': "bufname('%').':'.v:val"}
     let maker1 = NeomakeTestsCommandMaker('maker1', 'echo 1:I:msg1; echo 3:W:msg2')
-    let maker1.errorformat = '%f:%l:%t:%m'
-    let maker1.mapexpr = "bufname('%').':'.v:val"
+    call extend(maker1, options)
+    let maker2 = NeomakeTestsCommandMaker('maker2', 'sleep .1; echo 1:W:msg3; echo 2:E:msg4')
+    call extend(maker2, options)
 
-    let maker2 = extend(copy(maker1), {'__command': 'sleep .1; echo 1:W:msg3; echo 2:E:msg4'})
     new
     file signs.test
     let bufnr = bufnr('%')
@@ -316,8 +319,9 @@ Execute (project mode signs get placed when job finishes):
     let maker1 = NeomakeTestsCommandMaker('maker1',
     \ 'echo signs1.test:1:I:msg1; echo signs2.test:3:W:msg2')
     let maker1.errorformat = '%f:%l:%t:%m'
-    let maker2 = extend(copy(maker1), {
-    \ '__command': 'sleep .1; echo signs1.test:1:W:msg3; echo signs2.test:2:E:msg4'})
+    let maker2 = NeomakeTestsCommandMaker('maker2',
+    \ 'sleep .1; echo signs1.test:1:W:msg3; echo signs2.test:2:E:msg4')
+    let maker2.errorformat = '%f:%l:%t:%m'
 
     new
     file signs1.test

--- a/tests/utils.vader
+++ b/tests/utils.vader
@@ -381,12 +381,12 @@ Execute (neomake#utils#MakerFromCommand splits shell/shellcmdflag):
   let bound_maker = neomake#GetMaker(maker).fn(jobinfo)
   AssertEqual bound_maker._get_argv(jobinfo), expected_argv
 
-Execute (neomake#utils#MakerFromCommand appends args for file_mode):
+Execute (neomake#utils#MakerFromCommand appends args for file_mode (string)):
   let maker = neomake#utils#MakerFromCommand('echo')
   let jobinfo = {'file_mode': 0, 'bufnr': 0}
 
   AssertEqual maker.fn(jobinfo), {
-  \ 'args': [&shellcmdflag, 'echo'], 'exe': &shell, 'remove_invalid_entries': 0}
+  \ 'args': [&shellcmdflag, 'echo'], 'exe': &shell, 'remove_invalid_entries': 0, '_wrapped_in_shell': 1}
 
   new
   edit tests/fixtures/a\ filename\ with\ spaces
@@ -397,6 +397,25 @@ Execute (neomake#utils#MakerFromCommand appends args for file_mode):
   AssertEqual bound_maker.args, [&shellcmdflag, 'echo '.fname]
   AssertEqual bound_maker.append_file, 0
   AssertEqual bound_maker.exe, &shell
+  AssertEqual bound_maker.remove_invalid_entries, 0
+  bwipe
+
+Execute (neomake#utils#MakerFromCommand appends args for file_mode (list)):
+  let maker = neomake#utils#MakerFromCommand(['echo', '1'])
+  let jobinfo = {'file_mode': 0, 'bufnr': 0}
+
+  AssertEqual maker.fn(jobinfo), {
+  \ 'args': ['1'], 'exe': 'echo', 'remove_invalid_entries': 0, '_wrapped_in_shell': 0}
+
+  new
+  edit tests/fixtures/a\ filename\ with\ spaces
+  let fname = expand('%:p')
+  let jobinfo = NeomakeTestsFakeJobinfo()
+  let jobinfo.maker = maker
+  let bound_maker = neomake#GetMaker(maker).fn(jobinfo)
+  AssertEqual bound_maker.args, ['1', fname]
+  AssertEqual bound_maker.append_file, 0
+  AssertEqual bound_maker.exe, 'echo'
   AssertEqual bound_maker.remove_invalid_entries, 0
   bwipe
 

--- a/tests/utils.vader
+++ b/tests/utils.vader
@@ -382,30 +382,37 @@ Execute (neomake#utils#MakerFromCommand splits shell/shellcmdflag):
   AssertEqual bound_maker._get_argv(jobinfo), expected_argv
 
 Execute (neomake#utils#MakerFromCommand appends args for file_mode (string)):
-  let maker = neomake#utils#MakerFromCommand('echo')
-  let jobinfo = {'file_mode': 0, 'bufnr': 0}
-
-  AssertEqual maker.fn(jobinfo), {
-  \ 'args': [&shellcmdflag, 'echo'], 'exe': &shell, 'remove_invalid_entries': 0, '_wrapped_in_shell': 1}
+  let maker = neomake#utils#MakerFromCommand('echo "%" 1')
 
   new
   edit tests/fixtures/a\ filename\ with\ spaces
+
+  let jobinfo = {'file_mode': 0, 'bufnr': bufnr('%')}
+  AssertEqual maker.fn(jobinfo), {
+  \ 'args': [&shellcmdflag, 'echo "%" 1'], 'exe': &shell, 'remove_invalid_entries': 0, '_exe_wrapped_in_shell': 'echo'}
+
   let fname = expand('%:p')
   let jobinfo = NeomakeTestsFakeJobinfo()
   let jobinfo.maker = maker
   let bound_maker = neomake#GetMaker(maker).fn(jobinfo)
-  AssertEqual bound_maker.args, [&shellcmdflag, 'echo '.fname]
+  AssertEqual bound_maker.args, [&shellcmdflag, 'echo "%" 1 '.fname]
   AssertEqual bound_maker.append_file, 0
   AssertEqual bound_maker.exe, &shell
   AssertEqual bound_maker.remove_invalid_entries, 0
+
+  call bound_maker._bind_args()
+  AssertEqual bound_maker.args, [&shellcmdflag, 'echo "'.bufname('%').'" 1 '.fname]
+
+  CallNeomake 0, [maker]
+  AssertEqual getqflist()[0].text, 'tests/fixtures/a filename with spaces 1'
   bwipe
 
 Execute (neomake#utils#MakerFromCommand appends args for file_mode (list)):
-  let maker = neomake#utils#MakerFromCommand(['echo', '1'])
+  let maker = neomake#utils#MakerFromCommand(['echo', '%', '1'])
   let jobinfo = {'file_mode': 0, 'bufnr': 0}
 
   AssertEqual maker.fn(jobinfo), {
-  \ 'args': ['1'], 'exe': 'echo', 'remove_invalid_entries': 0, '_wrapped_in_shell': 0}
+  \ 'args': ['%', '1'], 'exe': 'echo', 'remove_invalid_entries': 0, '_exe_wrapped_in_shell': ''}
 
   new
   edit tests/fixtures/a\ filename\ with\ spaces
@@ -413,10 +420,16 @@ Execute (neomake#utils#MakerFromCommand appends args for file_mode (list)):
   let jobinfo = NeomakeTestsFakeJobinfo()
   let jobinfo.maker = maker
   let bound_maker = neomake#GetMaker(maker).fn(jobinfo)
-  AssertEqual bound_maker.args, ['1', fname]
+  AssertEqual bound_maker.args, ['%', '1', fname]
   AssertEqual bound_maker.append_file, 0
   AssertEqual bound_maker.exe, 'echo'
   AssertEqual bound_maker.remove_invalid_entries, 0
+
+  call bound_maker._bind_args()
+  AssertEqual bound_maker.args, [bufname('%'), '1', fname]
+
+  CallNeomake 0, [maker]
+  AssertEqual getqflist()[0].text, 'tests/fixtures/a filename with spaces 1'
   bwipe
 
 Execute (neomake#utils#Stringify):


### PR DESCRIPTION
Passing a list will not wrap it in a shell.