### PR TITLE
Mypy: check untyped defs

### DIFF
--- a/autoload/neomake/makers/ft/python.vim
+++ b/autoload/neomake/makers/ft/python.vim
@@ -283,7 +283,7 @@ endfunction
 " --silent-imports: replaced by --ignore-missing-imports --follow-imports=skip
 function! neomake#makers#ft#python#mypy() abort
     return {
-        \ 'args': ['--ignore-missing-imports', '--follow-imports=skip'],
+        \ 'args': ['--check-untyped-defs', '--ignore-missing-imports', '--follow-imports=skip'],
         \ 'errorformat':
             \ '%E%f:%l: error: %m,' .
             \ '%W%f:%l: warning: %m,' .


### PR DESCRIPTION
This flag makes mypy behave less surprisingly. A core part of mypy is
that it infers types and performs checks based on these inferences. With
this flag set, more code is covered.

>`--check-untyped-defs` is less severe than the previous option – it
> type checks the body of every function, regardless of whether it has
> type annotations. (By default the bodies of functions without
> annotations are not type checked.) It will assume all arguments have
> type Any and always infer Any as the return type.

http://mypy.readthedocs.io/en/latest/command_line.html