### PR TITLE
megacheck runs staticcheck, gosimple and unused

### DIFF
--- a/autoload/neomake/makers/ft/go.vim
+++ b/autoload/neomake/makers/ft/go.vim
@@ -57,7 +57,7 @@ function! neomake#makers#ft#go#gometalinter() abort
     "
     " All linters are only warnings, the go compiler will report errors
     return {
-        \ 'args': ['--disable-all', '--enable=errcheck', '--enable=gosimple', '--enable=staticcheck', '--enable=unused'],
+        \ 'args': ['--disable-all', '--enable=errcheck', '--enable=megacheck'],
         \ 'append_file': 0,
         \ 'cwd': '%:h',
         \ 'errorformat': '%f:%l:%c:%t%*[^:]: %m',


### PR DESCRIPTION
Replaces 3 go linters by one. See [megacheck](https://github.com/dominikh/go-tools/tree/master/cmd/megacheck).