### PR TITLE
Use eslint error format for sass-lint

### DIFF
--- a/autoload/neomake/makers/ft/scss.vim
+++ b/autoload/neomake/makers/ft/scss.vim
@@ -7,10 +7,8 @@ endfunction
 function! neomake#makers#ft#scss#sasslint() abort
     return {
         \ 'exe': 'sass-lint',
-        \ 'args': ['--no-exit', '--verbose', '--format=compact'],
-        \ 'errorformat':
-            \ '%E%f: line %l\, col %c\, Error - %m,' .
-            \ '%W%f: line %l\, col %c\, Warning - %m',
+        \ 'args': ['--no-exit', '--verbose', '--format', 'compact'],
+        \ 'errorformat': neomake#makers#ft#javascript#eslint()['errorformat']
         \ }
 endfunction
 


### PR DESCRIPTION
sass-lint uses eslint under the hood, thus we can just use the same formatting that is used with js.