### PR TITLE
Getting CLASSPATH from Apache Ant build file.

### DIFF
--- a/autoload/neomake/makers/ft/java.vim
+++ b/autoload/neomake/makers/ft/java.vim
@@ -370,7 +370,6 @@ function! s:GetAntClasspath() abort
     if s:has_ant && filereadable(ant)
         if !has_key(g:neomake_java_javac_ant_ftime, ant) || g:neomake_java_javac_ant_ftime[ant] != getftime(ant)
             try
-                let f = tempname()
                 let ant_cmd = 'ant classpath -f build.xml -S -q'
                 let cp = system(ant_cmd)
                 if v:shell_error != 0

--- a/autoload/neomake/makers/ft/java.vim
+++ b/autoload/neomake/makers/ft/java.vim
@@ -39,6 +39,9 @@ let g:neomake_java_maven_executable =
 let g:neomake_java_gradle_executable =
             \ get(g:, 'neomake_java_gradle_executable', s:is_windows? '.\gradlew.bat' : './gradlew')
 
+let g:neomake_java_ant_executable =
+            \ get(g:, 'neomake_java_ant_executable', 'ant')
+
 let g:neomake_java_checkstyle_executable =
             \ get(g:, 'neomake_java_checkstyle_executable', 'checkstyle')
 
@@ -66,6 +69,9 @@ let g:neomake_java_javac_autoload_maven_classpath =
 let g:neomake_java_javac_autoload_gradle_classpath =
             \ get(g:, 'neomake_java_javac_autoload_gradle_classpath', 1)
 
+let g:neomake_java_javac_autoload_ant_classpath =
+            \ get(g:, 'neomake_java_javac_autoload_ant_classpath', 1)
+
 let g:neomake_java_javac_autoload_eclipse_classpath =
             \ get(g:, 'neomake_java_javac_autoload_eclipse_classpath', 1)
 
@@ -81,9 +87,16 @@ let g:neomake_java_javac_gradle_ftime =
 let g:neomake_java_javac_gradle_classpath =
             \ get(g:, 'neomake_java_javac_gradle_classpath', {})
 
+let g:neomake_java_javac_ant_ftime =
+            \ get(g:, 'neomake_java_javac_ant_ftime', {})
+
+let g:neomake_java_javac_ant_classpath =
+            \ get(g:, 'neomake_java_javac_ant_classpath', {})
+
 
 let s:has_maven = executable(expand(g:neomake_java_maven_executable, 1))
 let s:has_gradle = executable(expand(g:neomake_java_gradle_executable, 1))
+let s:has_ant = executable(expand(g:neomake_java_ant_executable, 1))
 
 function! s:tmpdir() abort
     let tempdir = tempname()
@@ -157,6 +170,10 @@ function! neomake#makers#ft#java#javac() abort
             let javac_opts = extend(javac_opts, ['-d', s:shescape(s:GradleOutputDirectory())])
         endif
         let javac_classpath = s:AddToClasspath(javac_classpath, s:GetGradleClasspath())
+    endif
+
+    if s:has_ant && g:neomake_java_javac_autoload_ant_classpath && empty(javac_classpath)
+        let javac_classpath = s:AddToClasspath(javac_classpath, s:GetAntClasspath())
     endif
 
     if (has('python') || has('python3')) && empty(javac_classpath)
@@ -344,6 +361,27 @@ function! s:GetGradleClasspath() abort
             let g:neomake_java_javac_gradle_classpath[gradle] = cp
         endif
         return g:neomake_java_javac_gradle_classpath[gradle]
+    endif
+    return ''
+endf
+
+function! s:GetAntClasspath() abort
+    let ant = s:findFileInParent('build.xml', expand('%:p:h', 1))
+    if s:has_ant && filereadable(ant)
+        if !has_key(g:neomake_java_javac_ant_ftime, ant) || g:neomake_java_javac_ant_ftime[ant] != getftime(ant)
+            try
+                let f = tempname()
+                let ant_cmd = 'ant classpath -f build.xml -S -q'
+                let cp = system(ant_cmd)
+                if v:shell_error != 0
+                    let cp = ''
+                endif
+            catch
+            endtry
+            let g:neomake_java_javac_ant_ftime[ant] = getftime(ant)
+            let g:neomake_java_javac_ant_classpath[ant] = cp
+        endif
+        return g:neomake_java_javac_ant_classpath[ant]
     endif
     return ''
 endf


### PR DESCRIPTION
To make this works, we just need a task called `classpath` on the Ant
build.xml file, that returns the classpath needed to compile the current
file on Vim. It can be a fixed string or a command that returns a
combination of paths, like:

```
<?xml version="1.0"?>
<project name="neomake" default="build" basedir=".">
   <path id="compile.path">
      <pathelement location="a.jar"/>
      <pathelement location="b.jar"/>
      <pathelement location="c.jar"/>
   </path>

   <target name="classpath">
      <echo message="${toString:compile.path}"/>
   </target>
</project>
```

which will print:

```
$ ant classpath -f build.xml -S -q
/tmp/a.jar:/tmp/b.jar:/tmp/c.jar
```
that can be used on Neomake.