### PR TITLE
contrib/highlight-log: suppress output for --compact also

### DIFF
--- a/contrib/highlight-log
+++ b/contrib/highlight-log
@@ -36,7 +36,7 @@ if [ "$1" = vader ]; then
     spinner_current=0
   fi
 
-  quiet_started=$((!quiet))
+  quiet_started=$(( !(quiet || compact) ))
   if ((compact || quiet)); then
     # Do not display output for successful tests (i.e. the log statements).
     last_start_match=
@@ -47,7 +47,7 @@ if [ "$1" = vader ]; then
         echo "$REPLY"
         continue
       fi
-      # quiet: suppress output until "Starting Vader:".
+      # quiet/compact: suppress output until "Starting Vader:".
       if ! ((quiet_started)); then
         if [[ "$REPLY" == 'Starting Vader:'* ]]; then
           printf "\r" >&2


### PR DESCRIPTION
This avoids having the messages being displayed with Neovim.