### PR TITLE
mypy: Remove '--follow-imports=skip' fixes #1528

### DIFF
--- a/autoload/neomake/makers/ft/python.vim
+++ b/autoload/neomake/makers/ft/python.vim
@@ -280,10 +280,10 @@ function! neomake#makers#ft#python#vulture() abort
 endfunction
 
 " --fast-parser: adds experimental support for async/await syntax
-" --silent-imports: replaced by --ignore-missing-imports --follow-imports=skip
+" --silent-imports: replaced by --ignore-missing-imports
 function! neomake#makers#ft#python#mypy() abort
     return {
-        \ 'args': ['--check-untyped-defs', '--ignore-missing-imports', '--follow-imports=skip'],
+        \ 'args': ['--check-untyped-defs', '--ignore-missing-imports'],
         \ 'errorformat':
             \ '%E%f:%l: error: %m,' .
             \ '%W%f:%l: warning: %m,' .


### PR DESCRIPTION
The '--ignore-missing-imports' switch is enough to ignore missing
imports, adding the skip breaks all annotations using imported types,
which isn't desireable in most use cases.

This is also more in line with the comment on replacing the old
--silent-imports with the new flags.

I have been testing this change with large Python code bases since
I opened the issue and have found mypy to work great.