### PR TITLE
[WIP] s:clean_make_info: remove detection of queued jobs/makes

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -1350,28 +1350,6 @@ function! s:clean_make_info(make_id, ...) abort
                     \ len(make_info.active_jobs)), {'make_id': a:make_id})
         return
     endif
-    let queued_jobs = []
-    for q in values(s:action_queue)
-        for v in q
-            if has_key(v[1][0], 'make_id')
-                let jobinfo = v[1][0]
-                if jobinfo.make_id == a:make_id && v[0] !=# 's:CleanJobinfo'
-                    let queued_jobs += [jobinfo.id]
-                endif
-            else
-                let make_id = v[1][0].options.make_id
-                if make_id == a:make_id
-                    call add(queued_jobs, s:make_info.queued_jobs)
-                endif
-            endif
-        endfor
-    endfor
-    if !empty(queued_jobs)
-        call neomake#utils#DebugMessage(printf(
-                    \ 'Skipping cleaning of make info because of queued jobs: %s.',
-                    \ join(queued_jobs, ', ')), {'make_id': a:make_id})
-        return
-    endif
 
     if !empty(make_info.finished_jobs)
         " Clean old signs after all jobs have finished, so that they can be

--- a/tests/include/init.vim
+++ b/tests/include/init.vim
@@ -300,8 +300,7 @@ function! NeomakeTestsFakeJobinfo() abort
   let make_info[-42] = {
         \ 'verbosity': get(g:, 'neomake_verbose', 1),
         \ 'active_jobs': [],
-        \ 'finished_jobs': [],
-        \ 'queued_jobs': []}
+        \ 'finished_jobs': []}
   return {'file_mode': 1, 'bufnr': bufnr('%'), 'ft': '', 'make_id': -42}
 endfunction
 


### PR DESCRIPTION
The code for queued makes is broken, and it is not triggered (or at
least covered) in any way.