### PR TITLE
makers: help: do not use proselint by default

### DIFF
--- a/autoload/neomake/makers/ft/help.vim
+++ b/autoload/neomake/makers/ft/help.vim
@@ -1,5 +1,5 @@
 function! neomake#makers#ft#help#EnabledMakers() abort
-    let makers = ['proselint', 'writegood']
+    let makers = ['writegood']
     if executable('vim')
         call insert(makers, 'vimhelplint')
     endif

--- a/tests/ft_help.vader
+++ b/tests/ft_help.vader
@@ -21,7 +21,7 @@ Execute (vimhelplint reports errors):
   endif
 
 Execute (neomake#makers#ft#help#EnabledMakers):
-  let expected = ['proselint', 'writegood']
+  let expected = ['writegood']
   if executable('vim')
     call insert(expected, 'vimhelplint')
   endif


### PR DESCRIPTION
It is really more meant for prose and not easy to configure regarding
its ignore lists etc.