### PR TITLE
makers: markdown: do not use proselint by default

### DIFF
--- a/autoload/neomake/makers/ft/markdown.vim
+++ b/autoload/neomake/makers/ft/markdown.vim
@@ -3,7 +3,7 @@ function! neomake#makers#ft#markdown#SupersetOf() abort
 endfunction
 function! neomake#makers#ft#markdown#EnabledMakers() abort
     let makers = executable('mdl') ? ['mdl'] : ['markdownlint']
-    return makers + ['proselint', 'writegood'] + neomake#makers#ft#text#EnabledMakers()
+    return makers + ['writegood'] + neomake#makers#ft#text#EnabledMakers()
 endfunction
 
 function! neomake#makers#ft#markdown#mdl() abort


### PR DESCRIPTION
Followup to eac942fb - cutting down proselint usage, which is not easy
to configure and chokes on fenced code blocks etc.