### PR TITLE
minor: add doc headers to improve coverage

### DIFF
--- a/autoload/neomake/config.vim
+++ b/autoload/neomake/config.vim
@@ -1,3 +1,5 @@
+" Config API.
+
 let g:neomake#config#undefined = {}
 lockvar! g:neomake#config#undefined
 

--- a/autoload/neomake/debug.vim
+++ b/autoload/neomake/debug.vim
@@ -1,3 +1,5 @@
+" Debug/feedback helpers.
+
 function! neomake#debug#validate_maker(maker) abort
     let issues = {'errors': [], 'warnings': []}
 


### PR DESCRIPTION
Vim's :profile ignores the first line, so having documentation there
helps.

Ref: https://github.com/vim/vim/issues/2103