### PR TITLE
Revert "Makefile: _docker_test: do not push down VADER_ARGS forcefully (#1609)"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ $(_TESTS_REL_AND_ABS):
 	make $(FILE_TEST_TARGET) VADER_ARGS='$@'
 .PHONY: $(_TESTS_REL_AND_ABS)
 
-testcoverage: VADER_ARGS:=tests/main.vader $(wildcard tests/isolated/*.vader)
+testcoverage: COVERAGE_VADER_ARGS:=tests/main.vader $(wildcard tests/isolated/*.vader)
 testcoverage:
 	@ret=0; \
 	cov_dir=$(NEOMAKE_TEST_PROFILE_DIR); \
@@ -130,7 +130,7 @@ testcoverage:
 	  fi; \
 	fi; \
 	echo "Generating profile output in $$cov_dir"; \
-	for testfile in $(VADER_ARGS); do \
+	for testfile in $(COVERAGE_VADER_ARGS); do \
 	  make test VADER_ARGS=$$testfile \
 	    NEOMAKE_COVERAGE_FILE=$$cov_dir/$$(basename $$testfile).profile || (( ++ret )); \
 	done; \
@@ -200,7 +200,7 @@ $(_DOCKER_VIM_TARGETS):
 _docker_test: DOCKER_VIM:=vim-master
 _docker_test: DOCKER_MAKE_TARGET=$(DOCKER_MAKE_TEST_TARGET) \
   TEST_VIM='/vim-build/bin/$(DOCKER_VIM)' \
-  VADER_OPTIONS="$(VADER_OPTIONS)"
+  VADER_OPTIONS="$(VADER_OPTIONS)" VADER_ARGS="$(VADER_ARGS)"
 _docker_test: docker_make
 docker_test: DOCKER_MAKE_TEST_TARGET:=test
 docker_test: DOCKER_STREAMS:=-t

--- a/tests/vim/vimrc
+++ b/tests/vim/vimrc
@@ -36,9 +36,21 @@ let &runtimepath .= ','.plugin_dir
 let coverage_file = $NEOMAKE_COVERAGE_FILE
 if !empty(coverage_file) && has('profile')
   if filereadable(coverage_file)
-    echoerr 'DO_COVERAGE: file exists, not overwriting: '.coverage_file
-    " Use cquit here to cause a non-zero exit code.
-    cquit
+    function! s:print_stderr(output)
+      let lines = split(a:output, '\n')
+      if !empty($VADER_OUTPUT_FILE)
+        call writefile(lines, $VADER_OUTPUT_FILE, 'a')
+      else
+        let tmp = tempname()
+        call writefile(lines, tmp)
+        execute 'silent !cat '.tmp.' 1>&2'
+        call delete(tmp)
+      endif
+    endfunction
+
+    let error = 'Error: NEOMAKE_COVERAGE_FILE: file exists, not overwriting: '.coverage_file
+    call s:print_stderr(error)
+    cquit  " exit non-zero.
   else
     exec 'profile start '.coverage_file
     exe 'profile! file plugin/*.vim'


### PR DESCRIPTION
This reverts commit 3086c9704ec50bce1a0366a92a6a0d1ff88f7095.

It breaks e.g.

> make docker_test TEST_VIM=vim73 VADER_ARGS=tests/signs.vader VADER_OPTIONS=-x