### PR TITLE
Do not process output/lists in operator-pending mode (Vim)

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -1488,7 +1488,7 @@ function! s:handle_locqf_list_for_finished_jobs(make_info) abort
                             \ [a:make_info] + a:000])
             endif
 
-            let mode = mode(1)
+            let mode = neomake#compat#get_mode()
             if index(['n', 'i'], mode) == -1
                 call neomake#utils#DebugMessage(printf(
                             \ 'Postponing final location list handling for mode "%s".', mode),
@@ -1542,7 +1542,7 @@ endfunction
 function! s:CanProcessJobOutput() abort
     " We can only process output (change the location/quickfix list) in
     " certain modes, otherwise e.g. the visual selection gets lost.
-    let mode = mode(1)
+    let mode = neomake#compat#get_mode()
     if index(['n', 'i'], mode) == -1
         call neomake#utils#DebugMessage('Not processing output for mode "'.mode.'".')
     elseif exists('*getcmdwintype') && getcmdwintype() !=# ''

--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -1488,7 +1488,7 @@ function! s:handle_locqf_list_for_finished_jobs(make_info) abort
                             \ [a:make_info] + a:000])
             endif
 
-            let mode = mode()
+            let mode = mode(1)
             if index(['n', 'i'], mode) == -1
                 call neomake#utils#DebugMessage(printf(
                             \ 'Postponing final location list handling for mode "%s".', mode),
@@ -1542,8 +1542,9 @@ endfunction
 function! s:CanProcessJobOutput() abort
     " We can only process output (change the location/quickfix list) in
     " certain modes, otherwise e.g. the visual selection gets lost.
-    if index(['n', 'i'], mode()) == -1
-        call neomake#utils#DebugMessage('Not processing output for mode "'.mode().'".')
+    let mode = mode(1)
+    if index(['n', 'i'], mode) == -1
+        call neomake#utils#DebugMessage('Not processing output for mode "'.mode.'".')
     elseif exists('*getcmdwintype') && getcmdwintype() !=# ''
         call neomake#utils#DebugMessage('Not processing output from command-line window "'.getcmdwintype().'".')
     else

--- a/autoload/neomake/compat.vim
+++ b/autoload/neomake/compat.vim
@@ -235,3 +235,13 @@ else
         return r
     endfunction
 endif
+
+" Not really necessary for now, but allows to overwriting and extending.
+function! neomake#compat#get_mode() abort
+    if exists('*nvim_get_mode')
+        let mode = nvim_get_mode()
+        return mode.mode
+    else
+        return mode(1)
+    endif
+endfunction

--- a/autoload/neomake/configure.vim
+++ b/autoload/neomake/configure.vim
@@ -87,7 +87,7 @@ function! s:neomake_do_automake(context) abort
         let timer = timer_start(a:context.delay, function('s:automake_delayed_cb'))
         let s:timer_info[timer] = a:context
         if !has_key(a:context, 'pos')
-            let s:timer_info[timer].pos = [getpos('.'), mode()]
+            let s:timer_info[timer].pos = [getpos('.'), mode(1)]
         endif
         let s:timer_by_bufnr[a:context.bufnr] = timer
         call s:debug_log(printf('started timer (%dms): %d', a:context.delay, timer),
@@ -158,13 +158,14 @@ function! s:automake_delayed_cb(timer) abort
     "       BufWritePost/BufWinEnter?!
     " if timer_info.event !=# 'BufWritePost'
     if !empty(timer_info.pos)
-        let current_context = [getpos('.'), mode()]
+        let mode = mode(1)
+        let current_context = [getpos('.'), mode]
         if current_context != timer_info.pos
             call s:debug_log(printf('context/position changed: %s => %s',
                         \ string(timer_info.pos), string(current_context)))
             " Restart timer.
             if !empty(timer_info.pos)
-                let timer_info.pos = [getpos('.'), mode()]
+                let timer_info.pos = [getpos('.'), mode]
             endif
             call s:neomake_do_automake(timer_info)
             return

--- a/autoload/neomake/configure.vim
+++ b/autoload/neomake/configure.vim
@@ -87,7 +87,7 @@ function! s:neomake_do_automake(context) abort
         let timer = timer_start(a:context.delay, function('s:automake_delayed_cb'))
         let s:timer_info[timer] = a:context
         if !has_key(a:context, 'pos')
-            let s:timer_info[timer].pos = [getpos('.'), mode(1)]
+            let s:timer_info[timer].pos = [getpos('.'), neomake#compat#get_mode()]
         endif
         let s:timer_by_bufnr[a:context.bufnr] = timer
         call s:debug_log(printf('started timer (%dms): %d', a:context.delay, timer),
@@ -158,7 +158,7 @@ function! s:automake_delayed_cb(timer) abort
     "       BufWritePost/BufWinEnter?!
     " if timer_info.event !=# 'BufWritePost'
     if !empty(timer_info.pos)
-        let mode = mode(1)
+        let mode = neomake#compat#get_mode()
         let current_context = [getpos('.'), mode]
         if current_context != timer_info.pos
             call s:debug_log(printf('context/position changed: %s => %s',

--- a/tests/compat.vader
+++ b/tests/compat.vader
@@ -37,3 +37,31 @@ Execute (neomake#compat#systemlist with empty args):
 
 Execute (neomake#compat#json_decode):
   AssertEqual neomake#compat#json_decode(''), g:neomake#compat#json_none
+
+Execute (neomake#compat#get_mode):
+  AssertEqual neomake#compat#get_mode(), 'n'
+
+  norm! V
+  AssertEqual neomake#compat#get_mode(), 'V'
+  exe "norm! \<Esc>"
+  AssertEqual neomake#compat#get_mode(), 'n'
+
+  if has('nvim')
+    let nvim_exe = '/proc/'.getpid().'/exe'
+    let nvim = jobstart([nvim_exe, '-u', 'tests/vim/vimrc', '--embed'], {'rpc': v:true})
+    call rpcrequest(nvim, 'nvim_call_function', 'feedkeys', ['d', '!'])
+    call rpcrequest(nvim, 'nvim_eval', 'assert_equal(neomake#compat#get_mode(), "no")')
+    let rpc_errors = rpcrequest(nvim, 'nvim_eval', 'v:errors')
+    AssertEqual rpc_errors, []
+    call jobstop(nvim)
+  elseif exists('*timer_start')
+    let b:mode_in_cb = ''
+    function s:CB(...)
+        let b:mode_in_cb = neomake#compat#get_mode()
+        call feedkeys("\<Esc>")
+    endfunction
+    call timer_start(10, 's:CB')
+    call feedkeys('da', 'x!')
+    AssertEqual b:mode_in_cb, 'no'
+    AssertEqual neomake#compat#get_mode(), 'n'
+  endif

--- a/tests/processing.vader
+++ b/tests/processing.vader
@@ -53,28 +53,22 @@ Execute (Output is only processed in normal/insert mode (qflist)):
   endif
 
 Execute (Output is not processed in operator-pending mode (Vim)):
-  if has('nvim')
-    NeomakeTestsSkip 'only for Vim'
-  elseif NeomakeAsyncTestsSetup()
+  if NeomakeAsyncTestsSetup()
     new
     file file_sleep_efm
+
+    " Simulate operator-pending mode ('no').
+    NeomakeTestsMonkeyPatch 'neomake#compat#get_mode'
+    function! neomake#compat#get_mode()
+      return 'no'
+    endfunction
+
     call neomake#Make(0, [g:sleep_efm_maker])[0]
     let jobinfo = neomake#GetJobs()[-1]
-
-    " Trigger operator-pending mode ('no').
-    let b:cb_called = 0
-    function! s:callback_in_operator_pending_mode(...)
-      let b:cb_called = mode(1)
-      call feedkeys("\<Esc>")
-    endfunction
-    call timer_start(100, 's:callback_in_operator_pending_mode')
-    call feedkeys('da', 'x!')
-
     NeomakeTestsWaitForFinishedJobs
     AssertNeomakeMessage 'Not processing output for mode "no".', 3
     AssertNeomakeMessage 'sleep_efm_maker: completed with exit code 0.'
     AssertEqual getqflist(), [], 'Quickfix list has not been updated'
-    AssertEqual b:cb_called, 'no'
     doautocmd CursorHold
     AssertNeomakeMessage 'sleep_efm_maker: processing 3 lines of output.'
     AssertNeomakeMessage 'Processed pending output.', 3, jobinfo
@@ -83,6 +77,9 @@ Execute (Output is not processed in operator-pending mode (Vim)):
     call neomake#signs#ResetProject()
     call neomake#signs#CleanAllOldSigns('project')
     bwipe
+
+    NeomakeTestsMonkeyPatchUndo
+    AssertEqual neomake#compat#get_mode(), 'n'
   endif
 
 Execute (Location list is only cleared in normal/insert mode on success):

--- a/tests/processing.vader
+++ b/tests/processing.vader
@@ -11,6 +11,7 @@ Execute (Output is only processed in normal/insert mode (loclist)):
     AssertEqual map(copy(getloclist(0)), 'v:val.text'), ['init'], 'Location list has not been updated'
     " with Vim
     " AssertNeomakeMessage 'exit (delayed): sleep_efm_maker: 0'
+    AssertNeomakeMessage 'Not processing output for mode "V".'
     AssertNeomakeMessage 'sleep_efm_maker: completed with exit code 0.'
     AssertEqual mode(), 'V'
     exe "norm! \<Esc>"
@@ -51,6 +52,39 @@ Execute (Output is only processed in normal/insert mode (qflist)):
     bwipe
   endif
 
+Execute (Output is not processed in operator-pending mode (Vim)):
+  if has('nvim')
+    NeomakeTestsSkip 'only for Vim'
+  elseif NeomakeAsyncTestsSetup()
+    new
+    file file_sleep_efm
+    call neomake#Make(0, [g:sleep_efm_maker])[0]
+    let jobinfo = neomake#GetJobs()[-1]
+
+    " Trigger operator-pending mode ('no').
+    let b:cb_called = 0
+    function! s:callback_in_operator_pending_mode(...)
+      let b:cb_called = mode(1)
+      call feedkeys("\<Esc>")
+    endfunction
+    call timer_start(10, 's:callback_in_operator_pending_mode')
+    call feedkeys('da', 'x!')
+
+    NeomakeTestsWaitForFinishedJobs
+    AssertNeomakeMessage 'Not processing output for mode "no".', 3
+    AssertNeomakeMessage 'sleep_efm_maker: completed with exit code 0.'
+    AssertEqual getqflist(), [], 'Quickfix list has not been updated'
+    AssertEqual b:cb_called, 'no'
+    doautocmd CursorHold
+    AssertNeomakeMessage 'sleep_efm_maker: processing 3 lines of output.'
+    AssertNeomakeMessage 'Processed pending output.', 3, jobinfo
+    AssertEqual map(getqflist(), 'v:val.text'), ['error message', 'warning', 'error2']
+    NeomakeTestsWaitForRemovedJobs
+    call neomake#signs#ResetProject()
+    call neomake#signs#CleanAllOldSigns('project')
+    bwipe
+  endif
+
 Execute (Location list is only cleared in normal/insert mode on success):
   if NeomakeAsyncTestsSetup()
     new
@@ -74,6 +108,51 @@ Execute (Location list is only cleared in normal/insert mode on success):
     AssertEqual mode(), 'V'
     exe "norm! \<Esc>"
     AssertEqual mode(), 'n'
+    AssertEqual len(g:neomake_test_countschanged), 0
+    AssertEqual len(g:neomake_test_finished), 0
+    doautocmd WinEnter
+    AssertEqual len(g:neomake_test_finished), 0
+    AssertNeomakeMessage 'Retrying Timer event in 10ms.'
+    sleep 10m
+    AssertEqual len(g:neomake_test_countschanged), 0
+    AssertEqual len(g:neomake_test_finished), 1
+    AssertNeomakeMessage 'Cleaning location list.', 3
+    AssertEqual map(getloclist(0), 'v:val.text'), []
+    bwipe
+  endif
+
+Execute (Location list is not cleared in operator-pending mode (Vim)):
+  if has('nvim')
+    NeomakeTestsSkip 'only for Vim'
+  elseif NeomakeAsyncTestsSetup()
+    new
+    lgetexpr 'init'
+    file file_sleep_efm
+    let maker = NeomakeTestsCommandMaker('silent-sleep-success', 'sleep .01')
+    call neomake#Make(1, [maker])
+
+    " Trigger operator-pending mode ('no').
+    let b:cb_called = 0
+    function! s:callback_in_operator_pending_mode(...)
+      let b:cb_called = mode(1)
+      call feedkeys("\<Esc>")
+    endfunction
+    call timer_start(10, 's:callback_in_operator_pending_mode')
+    call feedkeys('da', 'x!')
+
+    NeomakeTestsWaitForFinishedJobs
+    AssertEqual map(getloclist(0), 'v:val.text'), ['init'], 'Location list has not been updated'
+
+    AssertEqual len(g:neomake_test_countschanged), 0
+    AssertEqual len(g:neomake_test_jobfinished), 1
+    AssertEqual len(g:neomake_test_finished), 0
+
+    AssertNeomakeMessage 'Cleaning jobinfo.', 3
+    AssertNeomakeMessage 'File-level errors cleaned.', 3
+    AssertNeomakeMessage 'Postponing final location list handling for mode "no".'
+    AssertEqual b:cb_called, 'no'
+    AssertNeomakeMessage 'Queueing action: s:handle_locqf_list_for_finished_jobs for Timer.'
+
     AssertEqual len(g:neomake_test_countschanged), 0
     AssertEqual len(g:neomake_test_finished), 0
     doautocmd WinEnter

--- a/tests/processing.vader
+++ b/tests/processing.vader
@@ -67,7 +67,7 @@ Execute (Output is not processed in operator-pending mode (Vim)):
       let b:cb_called = mode(1)
       call feedkeys("\<Esc>")
     endfunction
-    call timer_start(10, 's:callback_in_operator_pending_mode')
+    call timer_start(100, 's:callback_in_operator_pending_mode')
     call feedkeys('da', 'x!')
 
     NeomakeTestsWaitForFinishedJobs
@@ -137,7 +137,7 @@ Execute (Location list is not cleared in operator-pending mode (Vim)):
       let b:cb_called = mode(1)
       call feedkeys("\<Esc>")
     endfunction
-    call timer_start(10, 's:callback_in_operator_pending_mode')
+    call timer_start(100, 's:callback_in_operator_pending_mode')
     call feedkeys('da', 'x!')
 
     NeomakeTestsWaitForFinishedJobs


### PR DESCRIPTION
This is only relevant for Vim, and cannot be tested in Neovim even.
Ref: https://github.com/neovim/neovim/issues/7350