### PR TITLE
README: use CircleCI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # [![Neomake](https://cloud.githubusercontent.com/assets/111942/22717189/9e3e1760-ed67-11e6-94c5-e8955869d6d0.png)](#neomake)
 
-[![Build Status](https://travis-ci.org/neomake/neomake.svg?branch=master)](https://travis-ci.org/neomake/neomake)
+[![Build Status](https://circleci.com/gh/neomake/neomake.png?style=shield)](https://circleci.com/gh/neomake/neomake)
 [![codecov](https://codecov.io/gh/neomake/neomake/branch/master/graph/badge.svg)](https://codecov.io/gh/neomake/neomake)
 
 Neomake is a plugin for [Vim]/[Neovim] to asynchronously run programs.


### PR DESCRIPTION
The TravisCI badge seems outdated. Now we have the choice between:

![badge](https://circleci.com/gh/neomake/neomake.png)

and

![badge](https://circleci.com/gh/neomake/neomake.png?style=shield)

The PR uses the latter, since it better fits with other badges out there. 