### PR TITLE
Add '-shell-escape' argument to pdflatex maker.

### DIFF
--- a/autoload/neomake/makers/ft/tex.vim
+++ b/autoload/neomake/makers/ft/tex.vim
@@ -59,7 +59,7 @@ endfunction
 function! neomake#makers#ft#tex#pdflatex() abort
     return {
                 \ 'exe': 'pdflatex',
-                \ 'args': ['-file-line-error', '-interaction', 'nonstopmode'],
+                \ 'args': ['-shell-escape', '-file-line-error', '-interaction', 'nonstopmode'],
                 \ 'errorformat': '%E%f:%l: %m'
                 \ }
 endfunction


### PR DESCRIPTION
The '-shell-escape' argument is needed by some latex packages (e.g. minted).
Without it, pdflatex will notify the user about errors that aren't actually
present in the document.