### PR TITLE
Verilog fixes

### DIFF
--- a/autoload/neomake/makers/ft/verilog.vim
+++ b/autoload/neomake/makers/ft/verilog.vim
@@ -4,7 +4,7 @@ endfunction
 
 function! neomake#makers#ft#verilog#iverilog() abort
     return {
-                \ 'args' : ['-t null', '-Wall'],
+                \ 'args' : ['-tnull', '-Wall'],
                 \ 'errorformat' : '%f:%l: %trror: %m,' .
                 \ '%f:%l: %tarning: %m,' .
                 \ '%E%f:%l:      : %m,' .

--- a/autoload/neomake/makers/ft/verilog.vim
+++ b/autoload/neomake/makers/ft/verilog.vim
@@ -4,7 +4,8 @@ endfunction
 
 function! neomake#makers#ft#verilog#iverilog() abort
     return {
-                \ 'args' : ['-tnull', '-Wall'],
+                \ 'args' : ['-tnull', '-Wall', '-y./'],
+                \ 'cwd' : '%:h',
                 \ 'errorformat' : '%f:%l: %trror: %m,' .
                 \ '%f:%l: %tarning: %m,' .
                 \ '%E%f:%l:      : %m,' .


### PR DESCRIPTION
Fix an error caused by an extra space and make it possible to build files with locally defined external modules