### PR TITLE
_get_argv: drop support for handling dynamic exe

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -639,15 +639,6 @@ function! s:command_maker_base._bind_args() abort dict
 endfunction
 
 function! s:command_maker_base._get_argv(jobinfo) abort dict
-    " Resolve exe, which might be a function or dictionary.
-    if type(self.exe) == type(function('tr'))
-        let exe = call(self.exe, [])
-    elseif type(self.exe) == type({})
-        let exe = call(self.exe.fn, [], self.exe)
-    else
-        let exe = self.exe
-    endif
-
     let args = copy(self.args)
     let args_is_list = type(args) == type([])
 
@@ -665,7 +656,7 @@ function! s:command_maker_base._get_argv(jobinfo) abort dict
             endif
         endif
     endif
-    return neomake#compat#get_argv(exe, args, args_is_list)
+    return neomake#compat#get_argv(self.exe, args, args_is_list)
 endfunction
 
 function! s:GetMakerForFiletype(ft, maker_name) abort


### PR DESCRIPTION
This was never really working recently anyway.  It should get done
through other methods if you need this.