### PR TITLE
tests: add tests/isolated/modes.vader

### DIFF
--- a/tests/include/init.vim
+++ b/tests/include/init.vim
@@ -377,27 +377,6 @@ function! NeomakeTestsGetVimMessages()
   return reverse(msgs[0 : idx-1])
 endfunction
 
-" Helpers for monkeypatching a function temporarily.
-" This avoids having to put them into separate files when using profiling,
-" where :runtime would overwrite the functions.
-let s:monkeypatched = []
-function! s:monkeypatch(fname)
-    let orig_f = neomake#utils#redir('fun neomake#compat#get_mode')
-    let restore_f = map(split(orig_f, '\n'), 'v:val[3:]')
-    call add(s:monkeypatched, restore_f)
-endfunction
-function! s:undo_monkeypatch()
-    let tmpfile = tempname()
-    for f in s:monkeypatched
-        let f[0] = substitute(f[0], '^function ', 'function!', '')
-        call writefile(f, tmpfile)
-        exe 'source '.tmpfile
-    endfor
-    let s:monkeypatched = []
-endfunction
-command! -nargs=1 NeomakeTestsMonkeyPatch call s:monkeypatch(<f-args>)
-command! NeomakeTestsMonkeyPatchUndo call s:undo_monkeypatch(<f-args>)
-
 function! s:After()
   if exists('#neomake_automake')
     au! neomake_automake

--- a/tests/isolated.vader
+++ b/tests/isolated.vader
@@ -4,3 +4,4 @@ Include: isolated/utils-DebugMessage-handles-missing-make-options.vader
 Include: isolated/highlights.vader
 Include: isolated/ft_help.vader
 Include: isolated/tempfiles-cleanup.vader
+Include: isolated/modes.vader

--- a/tests/isolated/modes.vader
+++ b/tests/isolated/modes.vader
@@ -1,0 +1,30 @@
+Include: ../include/setup.vader
+
+Execute (Output is not processed in operator-pending mode (Vim)):
+  if NeomakeAsyncTestsSetup()
+    new
+    file file_sleep_efm
+
+    " Simulate operator-pending mode ('no').
+    function! neomake#compat#get_mode()
+      return 'no'
+    endfunction
+
+    call neomake#Make(0, [g:sleep_efm_maker])[0]
+    let jobinfo = neomake#GetJobs()[-1]
+    NeomakeTestsWaitForFinishedJobs
+    AssertNeomakeMessage 'Not processing output for mode "no".', 3
+    AssertNeomakeMessage 'sleep_efm_maker: completed with exit code 0.'
+    AssertEqual getqflist(), [], 'Quickfix list has not been updated'
+    doautocmd CursorHold
+    AssertNeomakeMessage 'sleep_efm_maker: processing 3 lines of output.'
+    AssertNeomakeMessage 'Processed pending output.', 3, jobinfo
+    AssertEqual map(getqflist(), 'v:val.text'), ['error message', 'warning', 'error2']
+    NeomakeTestsWaitForRemovedJobs
+    call neomake#signs#ResetProject()
+    call neomake#signs#CleanAllOldSigns('project')
+    bwipe
+
+    runtime autoload/neomake/compat.vim
+    AssertEqual neomake#compat#get_mode(), 'n'
+  endif

--- a/tests/processing.vader
+++ b/tests/processing.vader
@@ -52,36 +52,6 @@ Execute (Output is only processed in normal/insert mode (qflist)):
     bwipe
   endif
 
-Execute (Output is not processed in operator-pending mode (Vim)):
-  if NeomakeAsyncTestsSetup()
-    new
-    file file_sleep_efm
-
-    " Simulate operator-pending mode ('no').
-    NeomakeTestsMonkeyPatch 'neomake#compat#get_mode'
-    function! neomake#compat#get_mode()
-      return 'no'
-    endfunction
-
-    call neomake#Make(0, [g:sleep_efm_maker])[0]
-    let jobinfo = neomake#GetJobs()[-1]
-    NeomakeTestsWaitForFinishedJobs
-    AssertNeomakeMessage 'Not processing output for mode "no".', 3
-    AssertNeomakeMessage 'sleep_efm_maker: completed with exit code 0.'
-    AssertEqual getqflist(), [], 'Quickfix list has not been updated'
-    doautocmd CursorHold
-    AssertNeomakeMessage 'sleep_efm_maker: processing 3 lines of output.'
-    AssertNeomakeMessage 'Processed pending output.', 3, jobinfo
-    AssertEqual map(getqflist(), 'v:val.text'), ['error message', 'warning', 'error2']
-    NeomakeTestsWaitForRemovedJobs
-    call neomake#signs#ResetProject()
-    call neomake#signs#CleanAllOldSigns('project')
-    bwipe
-
-    NeomakeTestsMonkeyPatchUndo
-    AssertEqual neomake#compat#get_mode(), 'n'
-  endif
-
 Execute (Location list is only cleared in normal/insert mode on success):
   if NeomakeAsyncTestsSetup()
     new


### PR DESCRIPTION
The new monkeypatch method (NeomakeTestsMonkeyPatch) does not work
really: where re-sourcing the function through the temporary file, it
does not appear in the :profile output at all anymore.