### PR TITLE
loclist/qflist: use number of entries for window height

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -875,7 +875,7 @@ function! s:restore_prev_windows() abort
 endfunction
 
 let s:ignore_automake_events = 0
-function! s:HandleLoclistQflistDisplay(jobinfo) abort
+function! s:HandleLoclistQflistDisplay(jobinfo, loc_or_qflist) abort
     let open_val = get(g:, 'neomake_open_list', 0)
     if !open_val
         return
@@ -884,6 +884,7 @@ function! s:HandleLoclistQflistDisplay(jobinfo) abort
     if !height
         return
     endif
+    let height = min([len(a:loc_or_qflist), height])
     if a:jobinfo.file_mode
         call neomake#utils#DebugMessage('Handling location list: executing lwindow.', a:jobinfo)
         let cmd = 'lwindow'
@@ -1656,6 +1657,7 @@ function! s:ProcessEntries(jobinfo, entries, ...) abort
     if a:0 > 1
         " Via errorformat processing, where the list has been set already.
         let prev_list = a:1
+        let new_list = file_mode ? getloclist(0) : getqflist()
     else
         " Fix entries with get_list_entries/process_output.
         call map(a:entries, 'extend(v:val, {'
@@ -1679,13 +1681,13 @@ function! s:ProcessEntries(jobinfo, entries, ...) abort
         try
             if file_mode
                 if s:needs_to_replace_qf_for_lwindow
-                    call setloclist(0, getloclist(0) + a:entries, 'r')
+                    call setloclist(0, prev_list + a:entries, 'r')
                 else
                     call setloclist(0, a:entries, 'a')
                 endif
             else
                 if s:needs_to_replace_qf_for_lwindow
-                    call setqflist(getqflist() + a:entries, 'r')
+                    call setqflist(prev_list + a:entries, 'r')
                 else
                     call setqflist(a:entries, 'a')
                 endif
@@ -1695,11 +1697,8 @@ function! s:ProcessEntries(jobinfo, entries, ...) abort
                 exe cd_back_cmd
             endif
         endtry
-        if file_mode
-            let parsed_entries = getloclist(0)[len(prev_list):]
-        else
-            let parsed_entries = getqflist()[len(prev_list):]
-        endif
+        let new_list = file_mode ? getloclist(0) : getqflist()
+        let parsed_entries = new_list[len(prev_list):]
         let idx = 0
         for e in parsed_entries
             if a:entries[idx].bufnr != e.bufnr
@@ -1774,14 +1773,13 @@ function! s:ProcessEntries(jobinfo, entries, ...) abort
     endif
 
     if !counts_changed
-        let counts_changed = (file_mode ? getloclist(0) : getqflist()) != prev_list
-        " Assert !counts_changed, string([file_mode, prev_list, getloclist(0)])
+        let counts_changed = new_list != prev_list
     endif
     if counts_changed
         call neomake#utils#hook('NeomakeCountsChanged', {'reset': 0, 'jobinfo': a:jobinfo})
     endif
 
-    call s:HandleLoclistQflistDisplay(a:jobinfo)
+    call s:HandleLoclistQflistDisplay(a:jobinfo, new_list)
     call neomake#highlights#ShowHighlights()
     return 1
 endfunction

--- a/doc/neomake.txt
+++ b/doc/neomake.txt
@@ -463,7 +463,8 @@ preserve the cursor position when the |location-list| or |quickfix| window is
 opened. Defaults to 0.
 
 *g:neomake_list_height*
-The height of the |location-list| or |quickfix| list opened by Neomake.
+The maximum height of the |location-list| or |quickfix| list opened by Neomake.
+If there are fewer entries than that it will use this for the height.
 Defaults to 10.
 
 *g:neomake_echo_current_error*

--- a/tests/lists.vader
+++ b/tests/lists.vader
@@ -359,6 +359,7 @@ Execute (open_list=1 with job: just opens location window):
 
   Assert !exists('#neomake_event_queue#WinEnter'), 'autocmd was not setup'
   AssertNeomakeMessage 'Handling location list: executing lwindow.'
+  AssertEqual winheight(winnr()), 1
 
   AssertEqual winnr(), winnr('$'), 'In location window.'
   wincmd p
@@ -400,6 +401,56 @@ Execute (open_list=1 with height=0: does not open location window):
   NeomakeTestsWaitForFinishedJobs
   AssertEqual map(getloclist(0), '[v:val.text, v:val.type]'), [['error', 'E']]
   AssertEqual wincount, winnr('$'), 'Location list has not appeared'
+
+  Assert !exists('#neomake_event_queue#WinEnter'), 'autocmd was not setup'
+  Assert !exists('#neomake_event_queue'), 'augroup does not exist'
+  bwipe
+
+Execute (open_list=2 uses minimum from list_height and entries):
+  Save g:neomake_open_list, g:neomake_list_height
+  let g:neomake_open_list = 1
+  let g:neomake_list_height = 3
+  new
+  let wincount = winnr('$')
+
+  let entry_maker = {}
+  function entry_maker.get_list_entries(...)
+    let buf = bufnr('%')
+    return [
+    \ {'text': '1', 'bufnr': buf, 'lnum': 1},
+    \ {'text': '2', 'bufnr': buf, 'lnum': 1},
+    \ {'text': '3', 'bufnr': buf, 'lnum': 1},
+    \ {'text': '4', 'bufnr': buf, 'lnum': 1},
+    \ ]
+  endfunction
+  call neomake#Make(1, [entry_maker])
+  AssertEqual map(getloclist(0), 'v:val.text'), ['1', '2', '3', '4']
+  AssertEqual winheight(winnr()), 3
+
+  " Does not change already open window.
+  function! entry_maker.get_list_entries(...)
+    let buf = bufnr('%')
+    return [
+    \ {'text': '1', 'bufnr': buf, 'lnum': 1},
+    \ {'text': '2', 'bufnr': buf, 'lnum': 1},
+    \ ]
+  endfunction
+  call neomake#Make(1, [entry_maker])
+  AssertEqual map(getloclist(0), 'v:val.text'), ['1', '2']
+  AssertEqual winheight(winnr()), 3
+
+  lclose
+  function! entry_maker.get_list_entries(...)
+    let buf = bufnr('%')
+    return [
+    \ {'text': '1', 'bufnr': buf, 'lnum': 1},
+    \ {'text': '2', 'bufnr': buf, 'lnum': 1},
+    \ ]
+  endfunction
+  call neomake#Make(1, [entry_maker])
+  AssertEqual map(getloclist(0), 'v:val.text'), ['1', '2']
+  AssertEqual winheight(winnr()), 2
+  lclose
 
   Assert !exists('#neomake_event_queue#WinEnter'), 'autocmd was not setup'
   Assert !exists('#neomake_event_queue'), 'augroup does not exist'


### PR DESCRIPTION
This will take into account the number of list entries (e.g. 3) when
creating a location list or quickfix window, and uses the minimum of
`g:neomake_list_height` and that.

Therefore with only 3 entries it will use 3 instead of 10 now by
default.

It is still a good idea to use something like
https://github.com/blueyed/vim-qf_resize in general, but this improves
the default behavior.