### PR TITLE
Pre-create maker_jobs for automaking

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -29,8 +29,6 @@ let s:maker_defaults = {
             \ 'remove_invalid_entries': 0}
 " List of pending outputs by job ID.
 let s:pending_outputs = {}
-" Keep track of for what maker.exe an error was thrown.
-let s:exe_error_thrown = {}
 
 if !has('nvim')
     let s:kill_vim_timers = {}
@@ -1076,30 +1074,30 @@ function! s:Make(options) abort
                     \ 'Calling Make with options %s.',
                     \ string(filter(copy(options), "index(['bufnr', 'make_id'], v:key) == -1"))), {'make_id': make_id, 'bufnr': bufnr})
     endif
-    if has_key(options, 'enabled_makers')
-        let makers = neomake#map_makers(options.enabled_makers, options.ft, 0)
-        unlet options.enabled_makers
+
+    " Use pre-compiled jobs (used with automake).
+    if has_key(options, 'jobs')
+        let jobs = map(copy(options.jobs), "extend(v:val, {'make_id': make_id})")
+        unlet options.jobs
     else
-        let makers = call('neomake#GetEnabledMakers', file_mode ? [options.ft] : [])
-        if empty(makers)
-            if file_mode
-                call neomake#utils#DebugMessage('Nothing to make: no enabled file mode makers (filetype='.options.ft.').', options)
-                call s:clean_make_info(make_info)
-                return []
-            else
-                let makers = [s:get_makeprg_maker()]
+        if has_key(options, 'enabled_makers')
+            let makers = neomake#map_makers(options.enabled_makers, options.ft, 0)
+            unlet options.enabled_makers
+        else
+            let makers = call('neomake#GetEnabledMakers', file_mode ? [options.ft] : [])
+            if empty(makers)
+                if file_mode
+                    call neomake#utils#DebugMessage('Nothing to make: no enabled file mode makers (filetype='.options.ft.').', options)
+                    call s:clean_make_info(make_info)
+                    return []
+                else
+                    let makers = [s:get_makeprg_maker()]
+                endif
             endif
         endif
+        let jobs = neomake#core#create_jobs(options, makers)
     endif
 
-    " Instantiate all makers in the beginning (so expand() gets used in
-    " the current buffer's context).
-    let args = [options, makers]
-    if file_mode
-        let args += [options.ft]
-    endif
-    lockvar options
-    let jobs = call('s:bind_makers_for_job', args)
     if empty(jobs)
         call neomake#utils#DebugMessage('Nothing to make: no valid makers.', options)
         call s:clean_make_info(make_info)
@@ -1594,7 +1592,21 @@ endfunction
 "  - directory changed into (empty if skipped)
 "  - command to change back to the current workding dir (might be empty)
 function! s:cd_to_jobs_cwd(jobinfo) abort
-    let cwd = get(a:jobinfo, 'cwd', s:make_info[a:jobinfo.make_id].cwd)
+    if !has_key(a:jobinfo, 'cwd')
+        let maker = a:jobinfo.maker
+        if has_key(maker, 'cwd')
+            let cwd = maker.cwd
+            if cwd[0:1] ==# '%:'
+                let cwd = neomake#utils#fnamemodify(a:jobinfo.bufnr, cwd[1:])
+            else
+                let cwd = expand(cwd, 1)
+            endif
+            let a:jobinfo.cwd = substitute(fnamemodify(cwd, ':p'), '[\/]$', '', '')
+        else
+            let a:jobinfo.cwd = s:make_info[a:jobinfo.make_id].cwd
+        endif
+    endif
+    let cwd = a:jobinfo.cwd
     if empty(cwd)
         return ['', '', '']
     endif
@@ -2452,73 +2464,6 @@ function! neomake#CompleteJobs(...) abort
     return join(map(neomake#GetJobs(), "v:val.id.': '.v:val.maker.name"), "\n")
 endfunction
 
-" Map/bind a:makers to a list of job options, using a:options.
-function! s:bind_makers_for_job(options, makers, ...) abort
-    let r = []
-    for maker in a:makers
-        let options = copy(a:options)
-        try
-            " Call .fn function in maker object, if any.
-            if has_key(maker, 'fn')
-                " TODO: Allow to throw and/or return 0 to abort/skip?!
-                let returned_maker = call(maker.fn, [options], maker)
-                if returned_maker isnot# 0
-                    " This conditional assignment allows to both return a copy
-                    " (factory), while also can be used as a init method.
-                    let maker = returned_maker
-                endif
-            endif
-
-            if has_key(maker, 'cwd')
-                let cwd = maker.cwd
-                if cwd[0:1] ==# '%:'
-                    let cwd = neomake#utils#fnamemodify(options.bufnr, cwd[1:])
-                else
-                    let cwd = expand(cwd, 1)
-                endif
-                let options.cwd = substitute(fnamemodify(cwd, ':p'), '[\/]$', '', '')
-            endif
-
-            if has_key(maker, '_bind_args')
-                call maker._bind_args()
-                if type(maker.exe) != type('')
-                    let error = printf('Non-string given for executable of maker %s: type %s.',
-                                \ maker.name, type(maker.exe))
-                    if !get(maker, 'auto_enabled', 0)
-                        call neomake#utils#ErrorMessage(error, options)
-                    else
-                        call neomake#utils#DebugMessage(error, options)
-                    endif
-                    continue
-                endif
-                if !executable(maker.exe)
-                    if !get(maker, 'auto_enabled', 0)
-                        let error = printf('Exe (%s) of maker %s is not executable.', maker.exe, maker.name)
-                        if !has_key(s:exe_error_thrown, maker.exe)
-                            let s:exe_error_thrown[maker.exe] = 1
-                            call neomake#utils#ErrorMessage(error, options)
-                        else
-                            call neomake#utils#DebugMessage(error, options)
-                        endif
-                    else
-                        call neomake#utils#DebugMessage(printf(
-                                    \ 'Exe (%s) of auto-configured maker %s is not executable, skipping.', maker.exe, maker.name), options)
-                    endif
-                    continue
-                endif
-            endif
-
-        catch /^Neomake: /
-            let error = substitute(v:exception, '^Neomake: ', '', '').'.'
-            call neomake#utils#ErrorMessage(error, {'make_id': options.make_id})
-            continue
-        endtry
-        let options.maker = maker
-        let r += [options]
-    endfor
-    return r
-endfunction
-
 function! neomake#Make(file_mode_or_options, ...) abort
     if type(a:file_mode_or_options) == type({})
         return s:Make(a:file_mode_or_options)
@@ -2674,7 +2619,6 @@ function! s:display_neomake_info() abort
         echo '```'
     endif
 endfunction
-
 
 function! neomake#map_makers(makers, ft, auto_enabled) abort
     let makers = []

--- a/autoload/neomake/configure.vim
+++ b/autoload/neomake/configure.vim
@@ -77,7 +77,6 @@ function! s:neomake_do_automake(context) abort
             call timer_stop(s:timer_by_bufnr[bufnr])
             unlet s:timer_by_bufnr[bufnr]
         endif
-        " call s:debug_log('context: '.string(context))
         if !s:tick_changed(a:context, 0)
             call s:debug_log('buffer was not changed', {'bufnr': bufnr})
             return
@@ -109,10 +108,10 @@ function! s:neomake_do_automake(context) abort
         call neomake#CancelMake(prev_make_id)
     endif
 
-    call s:debug_log(printf('enabled makers: %s', join(map(copy(a:context.enabled_makers), "type(v:val) == type('') ? v:val : v:val.name"), ', ')))
+    call s:debug_log(printf('enabled makers: %s', join(map(copy(a:context.maker_jobs), 'v:val.maker.name'), ', ')))
     let jobinfos = neomake#Make({
                 \ 'file_mode': 1,
-                \ 'enabled_makers': a:context.enabled_makers,
+                \ 'jobs': a:context.maker_jobs,
                 \ 'ft': ft,
                 \ 'automake': 1})
     let started_jobs = filter(copy(jobinfos), "!get(v:val, 'finished', 0)")
@@ -340,9 +339,11 @@ function! s:configure_buffer(bufnr, ...) abort
             let makers = neomake#map_makers(makers, ft, 0)
         endif
     endif
-    let s:configured_buffers[bufnr].enabled_makers = makers
+    let options = {'file_mode': 1, 'ft': ft, 'bufnr': bufnr, 'automake': 1}
+    let jobs = neomake#core#create_jobs(options, makers)
+    let s:configured_buffers[bufnr].maker_jobs = jobs
     call s:debug_log(printf('configured buffer for ft=%s (%s)',
-                \ ft, empty(makers) ? 'no enabled makers' : join(map(copy(makers), "type(v:val) == type('') ? v:val : v:val.name"), ', ').' ('.source.')'), {'bufnr': bufnr})
+                \ ft, empty(jobs) ? 'no enabled makers' : join(map(copy(jobs), 'v:val.maker.name'), ', ').' ('.source.')'), {'bufnr': bufnr})
 
     if a:0
       " Setup autocommands etc (when called manually)?!
@@ -391,8 +392,8 @@ function! s:neomake_automake(event, bufnr) abort
         " register the buffer, and remember that it's automatic.
         call s:configure_buffer(bufnr)
     endif
-    let enabled_makers = s:configured_buffers[bufnr].enabled_makers
-    if empty(enabled_makers)
+    let maker_jobs = s:configured_buffers[bufnr].maker_jobs
+    if empty(maker_jobs)
         call s:debug_log('no enabled makers', {'bufnr': bufnr})
         return
     endif
@@ -413,7 +414,7 @@ function! s:neomake_automake(event, bufnr) abort
                 \ 'delay': delay,
                 \ 'bufnr': bufnr,
                 \ 'event': a:event,
-                \ 'enabled_makers': enabled_makers,
+                \ 'maker_jobs': maker_jobs,
                 \ }
     if event ==# 'BufWinEnter'
         " Ignore context, so that e.g. with vim-stay restoring the view
@@ -450,7 +451,7 @@ function! neomake#configure#automake(...) abort
     call filter(s:configured_buffers, 'v:val.custom')
     let s:registered_events = keys(get(get(g:neomake, 'automake', {}), 'events', {}))
     for b in keys(s:configured_buffers)
-        if empty(s:configured_buffers[b].enabled_makers)
+        if empty(s:configured_buffers[b].maker_jobs)
             continue
         endif
         let b_cfg = neomake#config#get('b:automake.events', {})

--- a/autoload/neomake/core.vim
+++ b/autoload/neomake/core.vim
@@ -1,0 +1,68 @@
+" Keep track of for what maker.exe an error was thrown.
+let s:exe_error_thrown = {}
+
+function! neomake#core#create_jobs(options, makers) abort
+    let args = [a:options, a:makers]
+    if a:options.file_mode
+        let args += [a:options.ft]
+    endif
+    let jobs = call('s:bind_makers_for_job', args)
+    return jobs
+endfunction
+
+" Map/bind a:makers to a list of job options, using a:options.
+function! s:bind_makers_for_job(options, makers, ...) abort
+    let r = []
+    for maker in a:makers
+        let options = copy(a:options)
+        try
+            " Call .fn function in maker object, if any.
+            if has_key(maker, 'fn')
+                " TODO: Allow to throw and/or return 0 to abort/skip?!
+                let returned_maker = call(maker.fn, [options], maker)
+                if returned_maker isnot# 0
+                    " This conditional assignment allows to both return a copy
+                    " (factory), while also can be used as a init method.
+                    let maker = returned_maker
+                endif
+            endif
+
+            if has_key(maker, '_bind_args')
+                call maker._bind_args()
+                if type(maker.exe) != type('')
+                    let error = printf('Non-string given for executable of maker %s: type %s.',
+                                \ maker.name, type(maker.exe))
+                    if !get(maker, 'auto_enabled', 0)
+                        call neomake#utils#ErrorMessage(error, options)
+                    else
+                        call neomake#utils#DebugMessage(error, options)
+                    endif
+                    continue
+                endif
+                if !executable(maker.exe)
+                    if !get(maker, 'auto_enabled', 0)
+                        let error = printf('Exe (%s) of maker %s is not executable.', maker.exe, maker.name)
+                        if !has_key(s:exe_error_thrown, maker.exe)
+                            let s:exe_error_thrown[maker.exe] = 1
+                            call neomake#utils#ErrorMessage(error, options)
+                        else
+                            call neomake#utils#DebugMessage(error, options)
+                        endif
+                    else
+                        call neomake#utils#DebugMessage(printf(
+                                    \ 'Exe (%s) of auto-configured maker %s is not executable, skipping.', maker.exe, maker.name), options)
+                    endif
+                    continue
+                endif
+            endif
+
+        catch /^Neomake: /
+            let error = substitute(v:exception, '^Neomake: ', '', '').'.'
+            call neomake#utils#ErrorMessage(error, {'make_id': options.make_id})
+            continue
+        endtry
+        let options.maker = maker
+        let r += [options]
+    endfor
+    return r
+endfunction

--- a/tests/automake.vader
+++ b/tests/automake.vader
@@ -197,19 +197,9 @@ Execute (Automake):
   new
   let b:neomake_tempfile_enabled = 1
   setfiletype neomake_tests
-  AssertNeomakeMessage 'automake: configured buffer for ft=neomake_tests (maker_without_exe (default)).'
-  Save g:neomake_test_enabledmakers
-  let g:neomake_test_enabledmakers = ['true']
-  normal! iline1
-
-  " InsertLeave triggered with 10ms timer.
-  if has('timers')
-    NeomakeTestsWaitForNextMessage
-  endif
-
-  AssertNeomakeMessage 'automake: automake for event InsertLeave.'
+  AssertNeomakeMessage 'Maker not found (for filetype neomake_tests): nonexisting.', 3
   AssertNeomakeMessage 'Exe (maker_without_exe) of auto-configured maker maker_without_exe is not executable, skipping.'
-  AssertNeomakeMessage 'Nothing to make: no valid makers.'
+  AssertNeomakeMessage 'automake: configured buffer for ft=neomake_tests (no enabled makers).', 3
 
   " TODO: better to have automake.ft.neomake_tests.enabled_makers ?!
   call neomake#config#set('ft.neomake_tests.automake.enabled_makers', ['true'])
@@ -217,10 +207,7 @@ Execute (Automake):
   AssertNeomakeMessage 'automake: configured buffer for ft=neomake_tests (true (global)).'
   AssertEqual len(g:neomake_test_jobfinished), 0
 
-  doautocmd InsertLeave
-  AssertNeomakeMessage 'automake: buffer was not changed.', 3
   normal! ifoo
-  doautocmd InsertLeave
   NeomakeTestsWaitForNextFinishedJob
   AssertEqual len(g:neomake_test_jobfinished), 1
 
@@ -390,7 +377,11 @@ Execute (neomake#configure#automake_for_buffer can configure makers (dict)):
 
   let maker = {'name': 'my-maker'}
   call neomake#configure#automake_for_buffer('r', 0, {'makers': [maker]})
-  AssertNeomakeMessage 'automake: configured buffer for ft= (my-maker (options)).', 3
+  AssertNeomakeMessage 'Exe (my-maker) of maker my-maker is not executable.', 0
+
+  let maker = {'name': 'true'}
+  call neomake#configure#automake_for_buffer('r', 0, {'makers': [maker]})
+  AssertNeomakeMessage 'automake: configured buffer for ft= (true (options)).', 3
   AssertNeomakeMessage 'automake: registered events: FileChangedShellPost, FileType, BufWinEnter.', 3
   bwipe
 
@@ -402,10 +393,11 @@ Execute (neomake#configure#automake_for_buffer can configure makers (list)):
   AssertNeomakeMessage 'Maker not found (for empty filetype): maker_1.', 0
   AssertNeomakeMessage 'Maker not found (for empty filetype): maker_2.', 0
 
-  let maker1 = {'name': 'maker_1'}
+  let maker1 = {'name': 'maker_1', 'exe': 'true'}
   let maker2 = {'name': 'maker_2'}
   call neomake#configure#automake_for_buffer('r', 0, [maker1, maker2])
-  AssertNeomakeMessage 'automake: configured buffer for ft= (maker_1, maker_2 (options)).', 3
+  AssertNeomakeMessage 'Exe (maker_2) of maker maker_2 is not executable.', 0
+  AssertNeomakeMessage 'automake: configured buffer for ft= (maker_1 (options)).', 3
   AssertNeomakeMessage 'automake: registered events: FileChangedShellPost, FileType, BufWinEnter.', 3
   bwipe
 
@@ -569,6 +561,7 @@ Execute (Automake restarts if context changed):
     new
     norm! iword1 word2
     set filetype=neomake_tests
+    let b:neomake_enabled_makers = [g:true_maker]
     call neomake#configure#automake_for_buffer({'CursorHold': {'delay': 5}})
     doautocmd CursorHold
     AssertNeomakeMessage '\vautomake: started timer \(5ms\): (\d+)'
@@ -576,6 +569,7 @@ Execute (Automake restarts if context changed):
     sleep 10m
     AssertNeomakeMessage "automake: context/position changed: [[0, 1, 11, 0], 'n'] => [[0, 1, 1, 0], 'n'].", 3
     AssertNeomakeMessage '\vautomake: started timer \(5ms\): (\d+)'
+    NeomakeTestsWaitForFinishedJobs
     bwipe!
   endif
 
@@ -585,6 +579,7 @@ Execute (Timer callback ignores wiped buffer):
   else
     new
     set filetype=neomake_tests
+    let b:neomake_enabled_makers = [g:true_maker]
     call neomake#configure#automake_for_buffer({'CursorHold': {'delay': 5}})
     doautocmd CursorHold
     AssertNeomakeMessage '\vautomake: started timer \(5ms\): (\d+)'
@@ -592,6 +587,7 @@ Execute (Timer callback ignores wiped buffer):
     bwipe
     sleep 10m
     AssertNeomakeMessage 'automake: automake: cleaning timer for wiped buffer: '.timer.'.'
+    NeomakeTestsWaitForFinishedJobs
   endif
 
 Execute (Timer callback ignores wiped buffer with noautocmd):
@@ -600,6 +596,7 @@ Execute (Timer callback ignores wiped buffer with noautocmd):
   else
     new
     set filetype=neomake_tests
+    let b:neomake_enabled_makers = [g:true_maker]
     call neomake#configure#automake_for_buffer({'CursorHold': {'delay': 5}})
     doautocmd CursorHold
     AssertNeomakeMessage '\vautomake: started timer \(5ms\): (\d+)'
@@ -613,6 +610,7 @@ Execute (Toggling disables automaking):
   Save g:neomake
   new
   set filetype=neomake_tests
+  let b:neomake_enabled_makers = [g:true_maker]
   NeomakeToggleBuffer
   call neomake#configure#automake({'InsertLeave': {'delay': 0}})
   doautocmd InsertLeave
@@ -647,24 +645,24 @@ Execute (Handles timeout in another buffer):
 Execute (neomake#configure#automake_for_buffer can configure makers (buffer var)):
   new
   set filetype=myft
-  let b:neomake_myft_my_maker_maker = {'name': 'my_maker'}
+  let b:neomake_myft_my_maker_maker = {'name': 'my_maker', 'exe': 'true'}
   call neomake#configure#automake_for_buffer('n', 300, ['my_maker'])
   AssertNeomakeMessage 'automake: configured buffer for ft=myft (my_maker (options)).', 3
 
-  let b:neomake_myft_my_other_maker_maker = {'name': 'my_other_maker'}
+  let b:neomake_myft_my_other_maker_maker = {'name': 'my_other_maker', 'exe': 'true'}
   call neomake#configure#automake_for_buffer('n', 300, {'makers': ['my_other_maker']})
   AssertNeomakeMessage 'automake: configured buffer for ft=myft (my_other_maker (options)).', 3
   bwipe
 
 Execute (neomake#configure#automake_for_buffer can configure other buffers):
-  let maker = {'name': 'my_maker'}
+  let maker = {'name': 'my_maker', 'exe': 'true'}
   new
   let bufnr = bufnr('%')
   call neomake#configure#automake_for_buffer('n', 300, {'makers': [maker], 'bufnr': bufnr})
   AssertNeomakeMessage 'automake: configured buffer for ft= (my_maker (options)).', 3, {'bufnr': bufnr}
 
   " Configuration for another buffer.
-  let my_other_maker = {'name': 'my_other_maker'}
+  let my_other_maker = {'name': 'my_other_maker', 'exe': 'true'}
   new
   call neomake#configure#automake_for_buffer('n', 300, {'makers': [my_other_maker], 'bufnr': bufnr})
   Assert !exists('b:neomake')
@@ -707,3 +705,35 @@ Execute (No warning with delay=0 if there is no timer support):
     AssertNeomakeMessageAbsent 'automake: timer support is required for delayed events.', 1
     bwipe
   endif
+
+Execute (Automake pre-created maker_job instances):
+  Save g:neomake
+
+  new
+  let s:call_count = 0
+  let maker = {'exe': 'true', 'cwd': '%:h'}
+  function maker.fn(...)
+    let s:call_count += 1
+  endfunction
+  let b:neomake_enabled_makers = [maker]
+  call neomake#configure#automake('n', 0)
+
+  doautocmd InsertLeave
+  AssertNeomakeMessage 'cwd: '.getcwd().'.'
+  AssertNeomakeMessage '\vautomake: started jobs: \[\d+\].'
+  NeomakeTestsWaitForFinishedJobs
+  AssertEqual s:call_count, 1
+
+  normal! ifoo
+  AssertNeomakeMessage '\vautomake: started jobs: \[\d+\].'
+  " .fn gets called only once.
+  AssertEqual s:call_count, 1
+
+  " 'cwd' gets resolved with the pre-compiled job.
+  let tmpdir = tempname()
+  exe 'file '.tmpdir.'/file'
+  normal! ifoo
+  AssertNeomakeMessage "\\v^unnamed_maker: could not change to maker's cwd \\(".tmpdir."\\): .*"
+  NeomakeTestsWaitForFinishedJobs
+
+  bwipe!


### PR DESCRIPTION
This factors out `neomake#core#create_jobs` and uses it to create the
list of jobs for automaking only once.

This causes checks to happen earlier (which is good).

The `cwd` handling is kept out, since a buffer's name (and therefore a
`cwd` based on it) can change.