### PR TITLE
Revert "CircleCI: test merge commit (#1673)"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,19 +6,6 @@ common: &common
   working_directory: ~/repo
   steps:
     - checkout
-    - run:
-        name: checkout merge commit for PRs
-        command: |
-          set -x
-          PR_NUMBER=${CI_PULL_REQUEST//*pull\//}
-          if [ -n "$PR_NUMBER" ]; then
-            if ! git pull --ff-only origin "refs/pull/$PR_NUMBER/merge"; then
-                echo
-                echo -e "\033[0;31mERROR: Failed to merge your branch with the latest master."
-                echo -e "Please manually merge master into your branch, and push the changes to GitHub.\033[0m"
-                exit 1
-            fi
-          fi
     - run: make --keep-going testcoverage TEST_VIM=$TEST_VIM
     - run:
         name: Upload coverage results


### PR DESCRIPTION
This reverts commit 3468a63116bc5b5ec766c23af991c55c67bb94cd.

Codecov currently does not handle coverage uploads for merge commits
properly.

This keeps it for the "checkqa" build.