### PR TITLE
clippy: use warning instead of error about nightly rust installation

### DIFF
--- a/autoload/neomake/makers/clippy.vim
+++ b/autoload/neomake/makers/clippy.vim
@@ -12,7 +12,7 @@ function! neomake#makers#clippy#clippy() abort
             let s:rustup_has_nightly = 0
             call system('rustc --version | grep -q "\-nightly"')
             if v:shell_error
-                call neomake#utils#ErrorMessage('Clippy requires a nightly rust installation.')
+                call neomake#utils#QuietMessage('Clippy requires a nightly rust installation.')
             endif
         else
             call system('rustup show | grep -q "^nightly-"')


### PR DESCRIPTION
Ref: https://github.com/neomake/neomake/issues/1453