### PR TITLE
improve perl errorformat

### DIFF
--- a/autoload/neomake/makers/ft/perl.vim
+++ b/autoload/neomake/makers/ft/perl.vim
@@ -14,7 +14,12 @@ endfunction
 function! neomake#makers#ft#perl#perl() abort
     return {
          \ 'args' : ['-c', '-X', '-Mwarnings'],
-         \ 'errorformat': '%E%m at %f line %l%s,%-G%f syntax OK,%-G%f had compilation errors.',
+         \ 'errorformat': '%-G%.%#had too many errors.,'
+         \  . '%-G%.%#had compilation errors.,'
+         \  . '%-G%.%#syntax OK,'
+         \  . '%m at %f line %l.,'
+         \  . '%+E%.%# at %f line %l\,%.%#,'
+         \  . '%+C%.%#',
          \ 'postprocess': function('neomake#makers#ft#perl#PerlEntryProcess'),
      \}
 endfunction


### PR DESCRIPTION
Align the perl error format more closely with the one provided by `:compiler perl`.