### PR TITLE
only concat extramsg if nonempty

### DIFF
--- a/autoload/neomake/makers/ft/perl.vim
+++ b/autoload/neomake/makers/ft/perl.vim
@@ -29,6 +29,6 @@ function! neomake#makers#ft#perl#PerlEntryProcess(entry) abort
     let extramsg = substitute(extramsg, '\\\$', '', '')
 
     if !empty(extramsg)
-        let a:entry.text = a:entry.text . ' ' . extramsg
+        let a:entry.text .= ' ' . extramsg
     endif
 endfunction

--- a/autoload/neomake/makers/ft/perl.vim
+++ b/autoload/neomake/makers/ft/perl.vim
@@ -27,5 +27,8 @@ endfunction
 function! neomake#makers#ft#perl#PerlEntryProcess(entry) abort
     let extramsg = substitute(a:entry.pattern, '\^\\V', '', '')
     let extramsg = substitute(extramsg, '\\\$', '', '')
-    let a:entry.text = a:entry.text . ' ' . extramsg
+
+    if !empty(extramsg)
+        let a:entry.text = a:entry.text . ' ' . extramsg
+    endif
 endfunction

--- a/tests/ft_perl.vader
+++ b/tests/ft_perl.vader
@@ -18,5 +18,10 @@ Execute (perl: errorformat):
 
 Execute (perl: postprocess):
   let entry = {'text': 'text', 'pattern': ''}
+
   call neomake#makers#ft#perl#PerlEntryProcess(entry)
   AssertEqual entry.text, 'text'
+
+  let entry.pattern = 'pattern'
+  call neomake#makers#ft#perl#PerlEntryProcess(entry)
+  AssertEqual entry.text, 'text pattern'

--- a/tests/ft_perl.vader
+++ b/tests/ft_perl.vader
@@ -15,3 +15,8 @@ Execute (perl: errorformat):
   lgetexpr syntax_ok
   AssertEqual getloclist(0), []
   bwipe /home/test/test.pl
+
+Execute (perl: postprocess):
+  let entry = {'text': 'text', 'pattern': ''}
+  call neomake#makers#ft#perl#PerlEntryProcess(entry)
+  AssertEqual entry.text, 'text'


### PR DESCRIPTION
This prevents a stray extra space from appearing in the error message.