### PR TITLE
Neovim: use "detach" option with `jobstart()`

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -359,7 +359,8 @@ function! s:MakeJob(make_id, options) abort
                 let opts = {
                     \ 'on_stdout': function('s:nvim_output_handler'),
                     \ 'on_stderr': function('s:nvim_output_handler'),
-                    \ 'on_exit': function('s:nvim_exit_handler')
+                    \ 'on_exit': function('s:nvim_exit_handler'),
+                    \ 'detach': 1,
                     \ }
                 try
                     let job = jobstart(jobinfo.argv, opts)


### PR DESCRIPTION
This helps with https://github.com/neomake/neomake/issues/1704, and
seems like a good idea in general.
Stopping active makes (i.e. jobs) gets done on `VimLeave` already, so
Neovim not stopping the jobs itself on exit seems to be OK.