### PR TITLE
Undo 712c3ac zsh>sh + shellcheck

### DIFF
--- a/autoload/neomake/makers/ft/zsh.vim
+++ b/autoload/neomake/makers/ft/zsh.vim
@@ -1,13 +1,10 @@
 " vim: ts=4 sw=4 et
 
-function! neomake#makers#ft#zsh#SupersetOf() abort
-    return 'sh'
-endfunction
-
 function! neomake#makers#ft#zsh#EnabledMakers() abort
     return ['zsh']
 endfunction
 
+" Note: newer versions of shellcheck do not support zsh.
 function! neomake#makers#ft#zsh#shellcheck() abort
     let maker = neomake#makers#ft#sh#shellcheck()
     let maker.args += ['--shell', 'zsh']


### PR DESCRIPTION
It isn't a superset of sh, it is a different shell
Also shellcheck does not have a --shell=zsh (anymore? since 2015 https://github.com/koalaman/shellcheck/blob/102683ab04bcb8a0a6f5d492e70fc8d3703edcc1/ShellCheck/Parser.hs#L2800-L2809)
https://github.com/koalaman/shellcheck/issues/809

being a superset enables shellcheck by default

todo:
- [ ] update wiki entry