### PR TITLE
Add filter_output setting/maker method

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -2027,6 +2027,20 @@ function! s:need_to_postpone_loclist(jobinfo) abort
 endfunction
 
 function! s:RegisterJobOutput(jobinfo, lines, source) abort
+    " Allow to filter output (storing the setting on the jobinfo lazily).
+    if !has_key(a:jobinfo, 'filter_output')
+        let a:jobinfo.filter_output = neomake#utils#GetSetting('filter_output', a:jobinfo.maker, '', a:jobinfo.ft, a:jobinfo.bufnr)
+    endif
+    if !empty(a:jobinfo.filter_output)
+        call call(a:jobinfo.filter_output, [
+                    \ a:lines, {'source': a:source, 'jobinfo': a:jobinfo}],
+                    \ a:jobinfo.maker)
+    endif
+
+    if empty(a:lines)
+        return
+    endif
+
     if a:jobinfo.output_stream !=# 'both' && a:jobinfo.output_stream !=# a:source
         if !has_key(a:jobinfo, 'unexpected_output')
             let a:jobinfo.unexpected_output = {}

--- a/tests/filter_output.vader
+++ b/tests/filter_output.vader
@@ -1,0 +1,60 @@
+Include: include/setup.vader
+
+Execute (filter_output can filter messages on stderr):
+  let maker = NeomakeTestsCommandMaker('stderr_and_stdout',
+  \ 'echo stderr >&2; echo stdout; echo stderr2 >&2')
+
+  CallNeomake 0, [maker]
+  AssertEqual sort(map(getqflist(), 'v:val.text')), ['stderr', 'stderr2', 'stdout']
+
+  function maker.filter_output(lines, context)
+    if a:context.source ==# 'stderr'
+      call filter(a:lines, "v:val !=# 'stderr'")
+    endif
+  endfunction
+
+  CallNeomake 0, [maker]
+  AssertEqual map(getqflist(), 'v:val.text'), ['stdout', 'stderr2']
+
+Execute (filter_output can be set for a buffer):
+  let maker = NeomakeTestsCommandMaker('stderr_and_stdout',
+  \ 'echo stderr >&2; echo stdout; echo stderr2 >&2')
+  function! maker.filter_output(lines, context)
+    Assert 0, 'should not get called'
+  endfunction
+
+  new
+  set ft=neomake_tests
+
+  let s:override_called = 0
+  let s:maker = maker
+  function NeomakeTestF(lines, context) dict
+    let s:override_called = 1
+    AssertEqual self.name, 'stderr_and_stdout'
+  endfunction
+  let b:neomake_neomake_tests_stderr_and_stdout_filter_output = function('NeomakeTestF')
+
+  CallNeomake 0, [maker]
+  AssertEqual sort(map(getqflist(), 'v:val.text')), ['stderr', 'stderr2', 'stdout']
+  AssertEqual s:override_called, 1, 's:override was called'
+  delfunction NeomakeTestF
+  bwipe
+
+Execute (filter_output can be used to filter unexpected output):
+  let maker = NeomakeTestsCommandMaker('stderr_and_stdout',
+  \ 'echo stderr >&2; echo stdout; echo stderr2 >&2')
+  let maker.output_stream = 'stdout'
+
+  CallNeomake 0, [maker]
+  AssertNeomakeMessage 'stderr_and_stdout: unexpected output on stderr: stderr\nstderr2.', 3
+  AssertNeomakeMessage 'stderr_and_stdout: unexpected output. See :messages for more information.', 0
+        '
+  AssertEqual sort(map(getqflist(), 'v:val.text')), ['stdout']
+
+  function! maker.filter_output(lines, context)
+    if a:context.source ==# 'stderr'
+      call filter(a:lines, 'v:val !~# "^stderr"')
+    endif
+  endfunction
+  CallNeomake 0, [maker]
+  AssertEqual sort(map(getqflist(), 'v:val.text')), ['stdout']

--- a/tests/main.vader
+++ b/tests/main.vader
@@ -12,6 +12,7 @@ Include (Current working dir): cwd.vader
 Include (Environment variables): env.vader
 Include (Error handling): errors.vader
 Include (Filetype handling): filetypes.vader
+Include (Filter output): filter_output.vader
 Include (Hooks): hooks.vader
 Include (Hooks get queued): hooks-queue.vader
 Include (Highlights): highlights.vader


### PR DESCRIPTION
This allows for filtering output in general, and allows for pylint to
filter away the "No config file found, using default configuration"
message on stderr, without having to use output_stream=both.