### PR TITLE
neomake#CancelJob: handle already exited jobs

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -182,6 +182,8 @@ function! neomake#CancelJob(job_id, ...) abort
     let ret = 0
     if get(jobinfo, 'finished')
         call neomake#utils#DebugMessage('Removing already finished job.', jobinfo)
+    elseif has_key(jobinfo, 'exit_code')
+        call neomake#utils#DebugMessage('Job exited already.', jobinfo)
     elseif s:async
         call neomake#utils#DebugMessage('Stopping job.', jobinfo)
         if has('nvim')

--- a/tests/processing.vader
+++ b/tests/processing.vader
@@ -533,20 +533,7 @@ Execute (Already running job gets restarted in case of exception):
 
     AssertNeomakeMessage printf('Cancelling already running job (%d.%d) for the same maker.',
     \ make_id, jobinfo.id), 2, {'make_id': make_id+1}
-
-    if has('nvim')
-      AssertNeomakeMessage 'jobstop failed: Vim(call):E900: Invalid job id.', 2, jobinfo
-    else
-      try
-        AssertNeomakeMessage 'job_stop: job was not running anymore.', 2, jobinfo
-      catch
-        " Happens at least on Vim 8.0.69.
-        if !has('patch-8.0.70')
-          throw v:exception.' (might be a flaky test)'
-        endif
-      endtry
-    endif
-
+    AssertNeomakeMessage 'Job exited already.', 3, jobinfo
     AssertNeomakeMessage "Starting async job: ['printf', 'foo']."
 
     " Needs careful cleanup after exception.


### PR DESCRIPTION
They should not get cleaned especially, since this might still happen
later in the exit handler.