### PR TITLE
js: flow: ignore No-errors msg in errorformat

### DIFF
--- a/autoload/neomake/makers/ft/javascript.vim
+++ b/autoload/neomake/makers/ft/javascript.vim
@@ -76,7 +76,9 @@ endfunction
 function! neomake#makers#ft#javascript#flow() abort
     return {
         \ 'args': ['--from=vim', '--show-all-errors'],
-        \ 'errorformat': '%EFile "%f"\, line %l\, characters %c-%m,'
+        \ 'errorformat':
+        \   '%-GNo errors!,'
+        \   .'%EFile "%f"\, line %l\, characters %c-%m,'
         \   .'%trror: File "%f"\, line %l\, characters %c-%m,'
         \   .'%C%m,%Z%m',
         \ 'postprocess': function('neomake#makers#ft#javascript#FlowProcess')

--- a/tests/ft_javascript.vader
+++ b/tests/ft_javascript.vader
@@ -72,3 +72,12 @@ Execute (javascript: standard: errorformat):
   \ 'nr': -1, 'type': 'W', 'pattern': '',
   \ 'text': 'Expected an assignment or function call and instead saw an expression. (no-unused-expressions)'}]
   bwipe
+
+Execute (javascript: flow):
+  new
+  let flow_maker = NeomakeTestsGetMakerWithOutput('neomake#makers#ft#javascript#flow', [
+    \ 'No errors!',
+    \ ])
+  CallNeomake 1, [flow_maker]
+  AssertEqual getloclist(0), []
+  bwipe


### PR DESCRIPTION
Ref: https://github.com/neomake/neomake/issues/1730

Might work around #1730 - so I would like to merge it only after it is clear what happens there.