### PR TITLE
Add languagetool maker for HTTP server

### DIFF
--- a/autoload/neomake/makers/ft/text.vim
+++ b/autoload/neomake/makers/ft/text.vim
@@ -27,3 +27,80 @@ function! neomake#makers#ft#text#writegood() abort
                 \ 'postprocess': function('neomake#makers#ft#text#PostprocessWritegood'),
                 \ }
 endfunction
+
+function! s:fn_languagetool_curl(jobinfo) abort dict
+    " XXX: update method to get filename!
+    let self.args = ['-s',
+                \ '--data-urlencode', printf('text@%s', fnameescape(fnamemodify(bufname(a:jobinfo.bufnr), ':p'))),
+                \ '--data-urlencode', printf('language=%s', get(split(&spelllang, ','), 0, 'en')),
+		\ '--data-urlencode', printf('motherTongue=%s', 'pt-PT'),
+                \ 'http://localhost:8081/v2/check']
+endfunction
+
+function! neomake#makers#ft#text#GetEntriesForOutput_LanguagetoolCurl(context) abort
+    if a:context.source ==# 'stderr'
+        return []
+    endif
+    let output = neomake#utils#JSONdecode(join(a:context.output, ''))
+    call neomake#utils#DebugObject('output', output)
+    if !len(output)
+        return []
+    endif
+
+    let entries = []
+    for _m in get(output, 'matches', [])
+        let offset = get(_m, 'offset') + 0
+        let length = get(_m, 'length') + 0
+        let rule = get(_m, 'rule')
+        let rule_id = get(rule, 'id')
+        let rule_type = get(rule, 'issueType')
+        let message_long = get(_m, 'message')
+        let message_short = get(_m, 'shortMessage')
+
+        let message = ''
+        if rule_type == 'misspelling'
+            let type = 'E'
+            let replacements = map(get(_m, 'replacements'), 'v:val.value')
+            if !len(replacements)
+                let message = message_long
+            else
+                let message = message_short . ' => ' . join((map(replacements,'"\"". v:val ."\""')), ' | ')
+            endif
+        else
+            let type = 'W'
+            let message = message_long
+        endif
+
+        let offset = offset
+        let line_maybe = byte2line(offset)
+        if line2byte(line_maybe + 1) == offset + 1
+            " Next line starts in the next byte
+            " This means the error is in the first character of the next line
+            let line_num = line_maybe + 1
+            let col_num = 1
+        else
+            let line_num = line_maybe
+            let col_num = offset - line2byte(line_num) + 2
+        endif
+        let entry = {
+                    \ 'text': message,
+                    \ 'lnum': line_num,
+                    \ 'col': col_num,
+                    \ 'length': length,
+                    \ 'type': type,
+                    \ 'bufnr': a:context.jobinfo.bufnr,
+                    \ }
+
+        call add(entries, entry)
+    endfor
+    return entries
+endfunction
+
+function! neomake#makers#ft#text#languagetool_curl() abort
+    return {
+          \ 'exe': 'curl',
+          \ 'fn': function('s:fn_languagetool_curl'),
+          \ 'process_output': function('neomake#makers#ft#text#GetEntriesForOutput_LanguagetoolCurl'),
+	  \ 'output_stream': 'stdout',
+          \ }
+endfunction

--- a/autoload/neomake/makers/ft/text.vim
+++ b/autoload/neomake/makers/ft/text.vim
@@ -130,5 +130,6 @@ function! neomake#makers#ft#text#languagetool_curl() abort
                 \ 'fn': function('s:fn_languagetool_curl'),
                 \ 'process_output': function('neomake#makers#ft#text#GetEntriesForOutput_LanguagetoolCurl'),
                 \ 'output_stream': 'stdout',
+                \ 'append_file': 0,
                 \ }
 endfunction

--- a/autoload/neomake/makers/ft/text.vim
+++ b/autoload/neomake/makers/ft/text.vim
@@ -9,18 +9,18 @@ endfunction
 
 function! neomake#makers#ft#text#proselint() abort
     return {
-          \ 'errorformat': '%W%f:%l:%c: %m',
-          \ 'postprocess': function('neomake#postprocess#GenericLengthPostprocess'),
-          \ }
+                \ 'errorformat': '%W%f:%l:%c: %m',
+                \ 'postprocess': function('neomake#postprocess#GenericLengthPostprocess'),
+                \ }
 endfunction
 
 function! neomake#makers#ft#text#PostprocessWritegood(entry) abort
     let a:entry.col += 1
     if a:entry.text[0] ==# '"'
-      let matchend = match(a:entry.text, '\v^[^"]+\zs"', 1)
-      if matchend != -1
-        let a:entry.length = matchend - 1
-      endif
+        let matchend = match(a:entry.text, '\v^[^"]+\zs"', 1)
+        if matchend != -1
+            let a:entry.length = matchend - 1
+        endif
     endif
 endfunction
 
@@ -110,9 +110,9 @@ endfunction
 
 function! neomake#makers#ft#text#languagetool_curl() abort
     return {
-          \ 'exe': 'curl',
-          \ 'fn': function('s:fn_languagetool_curl'),
-          \ 'process_output': function('neomake#makers#ft#text#GetEntriesForOutput_LanguagetoolCurl'),
-	  \ 'output_stream': 'stdout',
-          \ }
+                \ 'exe': 'curl',
+                \ 'fn': function('s:fn_languagetool_curl'),
+                \ 'process_output': function('neomake#makers#ft#text#GetEntriesForOutput_LanguagetoolCurl'),
+                \ 'output_stream': 'stdout',
+                \ }
 endfunction

--- a/autoload/neomake/makers/ft/text.vim
+++ b/autoload/neomake/makers/ft/text.vim
@@ -1,4 +1,4 @@
-function! s:getVar(varname, default)
+function! s:getVar(varname, default) abort
     return get(b:, a:varname, get(g:, a:varname, a:default))
 endfunction
 

--- a/autoload/neomake/makers/ft/text.vim
+++ b/autoload/neomake/makers/ft/text.vim
@@ -45,6 +45,10 @@ function! s:fn_languagetool_curl(jobinfo) abort dict
     if motherTongue != v:null
         let args += ['--data-urlencode', printf('motherTongue=%s', motherTongue)]
     endif
+    let preferredVariants = s:getVar('neomake_text_languagetool_curl_preferredVariants', v:null)
+    if l:preferredVariants != v:null && l:language == 'auto'
+        let args += ['--data-urlencode', printf('preferredVariants', join(preferredVariants, ','))]
+    endif
     " Public API: https://languagetool.org/api
     let server = s:getVar('neomake_text_languagetool_curl_server', 'http://localhost:8081')
     let args += [printf('%s/v2/check', server)]

--- a/autoload/neomake/makers/ft/text.vim
+++ b/autoload/neomake/makers/ft/text.vim
@@ -34,10 +34,12 @@ endfunction
 
 function! s:fn_languagetool_curl(jobinfo) abort dict
     let defaultFallbackLanguage = 'en'  " Without variants there is no spell checking
+    let language = s:getVar('neomake_text_languagetool_curl_language',
+                \ get(split(&spelllang, ','), 0, defaultFallbackLanguage) )
     " XXX: update method to get filename!
     let l:args = ['-s',
                 \ '--data-urlencode', printf('text@%s', fnameescape(fnamemodify(bufname(a:jobinfo.bufnr), ':p'))),
-                \ '--data-urlencode', printf('language=%s', get(split(&spelllang, ','), 0, defaultFallbackLanguage))
+                \ '--data-urlencode', printf('language=%s', language),
                 \ ]
     let motherTongue = s:getVar('neomake_text_languagetool_curl_motherTongue', v:null)
     if motherTongue != v:null

--- a/tests/ft_asciidoc.vader
+++ b/tests/ft_asciidoc.vader
@@ -35,4 +35,4 @@ Execute (asciidoc):
 Execute (asciidoc: enabled makers):
   AssertEqual map(copy(neomake#GetEnabledMakers('asciidoc')), 'v:val.name'), ['asciidoc']
   AssertEqual neomake#GetMakers('asciidoc'),
-  \ ['asciidoc', 'asciidoctor', 'proselint', 'writegood']
+  \ ['asciidoc', 'asciidoctor', 'languagetool_curl', 'proselint', 'writegood']

--- a/tests/ft_markdown.vader
+++ b/tests/ft_markdown.vader
@@ -1,3 +1,3 @@
 Execute (markdown: makers):
   AssertEqual neomake#GetMakers('markdown'),
-  \ ['alex', 'markdownlint', 'mdl', 'proselint', 'writegood']
+  \ ['alex', 'markdownlint', 'mdl', 'languagetool_curl', 'proselint', 'writegood']

--- a/tests/ft_pandoc.vader
+++ b/tests/ft_pandoc.vader
@@ -1,3 +1,3 @@
 Execute (pandoc: makers):
   AssertEqual neomake#GetMakers('pandoc'),
-  \ ['alex', 'markdownlint', 'mdl', 'proselint', 'writegood']
+  \ ['alex', 'markdownlint', 'mdl', 'languagetool_curl', 'proselint', 'writegood']


### PR DESCRIPTION
This adds a new text maker for languagetool, using the HTTP server.

This is #1728.

Defaults to a server @ `localhost:8081`.

See https://gist.github.com/somini/b3421a3c89bd6a6716de1123e39cefad for
socket activation systemd configuration.