### PR TITLE
statusline: fix/improve call to redrawstatus

### DIFF
--- a/autoload/neomake/statusline.vim
+++ b/autoload/neomake/statusline.vim
@@ -37,6 +37,10 @@ function! neomake#statusline#make_finished(make_info) abort
         let s:loclist_counts[bufnr] = {}
     endif
     call s:clear_cache(bufnr)
+
+    " Trigger redraw of all statuslines.
+    " TODO: only do this if some relevant formats are used?!
+    redrawstatus!
 endfunction
 
 function! neomake#statusline#ResetCountsForBuf(...) abort
@@ -305,9 +309,6 @@ function! s:setup_statusline_augroup_for_use() abort
         return
     endif
     augroup neomake_statusline
-        " Trigger redraw of all statuslines.
-        " TODO: only do this if some relevant formats are used?!
-        autocmd User NeomakeJobFinished redrawstatus!
         autocmd ColorScheme * call neomake#statusline#DefineHighlights()
     augroup END
     let s:did_setup_statusline_augroup_for_use = 1

--- a/tests/processing.vader
+++ b/tests/processing.vader
@@ -770,7 +770,7 @@ Execute (action queue handles E48 in process_output):
   AssertNeomakeMessage 'Cleaning jobinfo.', 3, jobinfo
 
 Execute (job finishes while in tabline function):
-  if neomake#has_async_support()  " use manual setup without autocmds to work around bug in vim8069
+  if NeomakeAsyncTestsSetup()
     Save &tabline, g:neomake_test_flagfile
 
     let g:neomake_test_flagfile = tempname()
@@ -808,8 +808,6 @@ Execute (job finishes while in tabline function):
     bwipe
     Assert exists('#neomake_statusline'), 'statusline augroup was created'
     Assert !exists('#neomake_statusline#ColorScheme'), 'ColorScheme was not hooked into'
-  else
-    NeomakeTestsSkip 'no async support.'
   endif
 
 Execute (get_list_entries job processes entries while in tabline function):

--- a/tests/processing.vader
+++ b/tests/processing.vader
@@ -801,6 +801,8 @@ Execute (job finishes while in tabline function):
     AssertNeomakeMessage 'Queueing action: s:CleanJobinfo for WinEnter.'
     AssertNeomakeMessage 'tabline_end.', 3
 
+    " Restore here already for vim8090 (E117: Unknown function: s:NeomakeTestTabline)
+    Restore &tabline
     doautocmd WinEnter
     AssertEqual map(getloclist(0), 'v:val.text'), ['finished_in_tabline']
     bwipe


### PR DESCRIPTION
With the same buffer opened in two windows, the non-current one might
have an "unknown" status, just because Neovim would have redrawn the
statusline too early.