### PR TITLE
neomake#GetMaker: fix overriding config

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -757,7 +757,7 @@ function! neomake#GetMaker(name_or_maker, ...) abort
                 \ })
         endif
         for [key, default] in items(defaults)
-            let maker[key] = neomake#utils#GetSetting(key, maker, default, ft, bufnr, 1)
+            let maker[key] = neomake#utils#GetSetting(key, {'name': maker.name}, get(maker, key, default), ft, bufnr, 1)
             unlet default  " for Vim without patch-7.4.1546
         endfor
     endif

--- a/tests/config.vader
+++ b/tests/config.vader
@@ -202,3 +202,23 @@ Execute (neomake#config#get handles non-dicts on the way):
   AssertEqual neomake#config#get('foo.bar', 'default'), 'baz'
   AssertEqual neomake#config#get('foo.bar.baz', 'default'), 'default'
   bwipe
+
+Execute (old-style config is used for maker defaults):
+  let maker = {'name': 'mymaker', 'args': ['default']}
+
+  new
+  let b:neomake = {'some': 'config'}
+  AssertEqual neomake#GetMaker(maker).args, ['default']
+  let b:neomake_mymaker_args = ['args1']
+  AssertEqual neomake#GetMaker(maker).args, ['args1']
+
+  noautocmd set filetype=myft
+  AssertEqual neomake#GetMaker(maker).args, ['args1']
+  let b:neomake_myft_mymaker_args = ['args2']
+  AssertEqual neomake#GetMaker(maker).args, ['args2']
+
+  " New-style config overrides it.
+  call neomake#config#set('b:mymaker.args', ['new-style'])
+  AssertEqual neomake#GetMaker(maker).args, ['new-style']
+
+  bwipe


### PR DESCRIPTION
Only use 'name' with maker passed to `neomake#utils#GetSetting`, so that
checking the new-style config (that is used with automaking) will not
use the default from the maker.

Fixes https://github.com/neomake/neomake/issues/1616.