### PR TITLE
NeomakeFinished: remove jobinfo from hook context

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -1522,12 +1522,10 @@ function! s:handle_locqf_list_for_finished_jobs(make_info) abort
         endif
     endif
 
-    " TODO: remove/deprecate jobinfo.
     let hook_context = {
                 \ 'make_id': a:make_info.options.make_id,
                 \ 'options': a:make_info.options,
                 \ 'finished_jobs': a:make_info.finished_jobs,
-                \ 'jobinfo': extend(copy(a:make_info.options), {'DEPRECATED': 1}),
                 \ }
     call neomake#utils#hook('NeomakeFinished', hook_context)
     call s:do_clean_make_info(a:make_info)

--- a/tests/hooks.vader
+++ b/tests/hooks.vader
@@ -14,7 +14,7 @@ Execute (Hook execution gets logged):
 
   AssertNeomakeMessage '\mCalling User autocmd NeomakeFinished with context: {''options'': ', 2
   AssertEqual map(copy(g:neomake_test_finished), 'sort(keys(v:val))'), [
-  \ ['finished_jobs', 'jobinfo', 'make_id', 'options']]
+  \ ['finished_jobs', 'make_id', 'options']]
 
 Execute (NeomakeJobFinished):
   if NeomakeAsyncTestsSetup()


### PR DESCRIPTION
This was the jobinfo of the last job (already provided with
`NeomakeJobFinished`).
Instead the make info would be interesting, which can be retrieved via
`make_id` and `neomake#GetStatus().make_info` if needed.