### PR TITLE
neomake#utils#MakerFromCommand: remove _exe_wrapped_in_shell

### DIFF
--- a/autoload/neomake/utils.vim
+++ b/autoload/neomake/utils.vim
@@ -241,11 +241,9 @@ function! s:command_maker.fn(jobinfo) dict abort
         let argv = split(&shell) + split(&shellcmdflag)
         let maker.exe = argv[0]
         let maker.args = argv[1:] + [command]
-        let maker._exe_wrapped_in_shell = split(command)[0]
     else
         let maker.exe = command[0]
         let maker.args = command[1:]
-        let maker._exe_wrapped_in_shell = ''
     endif
 
     if get(maker, 'append_file', a:jobinfo.file_mode)

--- a/tests/utils.vader
+++ b/tests/utils.vader
@@ -412,7 +412,7 @@ Execute (neomake#utils#MakerFromCommand appends args for file_mode (string)):
   let jobinfo = {'file_mode': 0, 'bufnr': bufnr('%')}
   let shell_argv = split(&shell) + split(&shellcmdflag)
   AssertEqual maker.fn(jobinfo), {
-  \ 'args': shell_argv[1:] + ['echo "%" 1'], 'exe': shell_argv[0], 'remove_invalid_entries': 0, '_exe_wrapped_in_shell': 'echo'}
+  \ 'args': shell_argv[1:] + ['echo "%" 1'], 'exe': shell_argv[0], 'remove_invalid_entries': 0}
 
   let fname = expand('%:p')
   let jobinfo = NeomakeTestsFakeJobinfo()
@@ -435,7 +435,7 @@ Execute (neomake#utils#MakerFromCommand appends args for file_mode (list)):
   let jobinfo = {'file_mode': 0, 'bufnr': 0}
 
   AssertEqual maker.fn(jobinfo), {
-  \ 'args': ['%', '1'], 'exe': 'echo', 'remove_invalid_entries': 0, '_exe_wrapped_in_shell': ''}
+  \ 'args': ['%', '1'], 'exe': 'echo', 'remove_invalid_entries': 0}
 
   new
   edit tests/fixtures/a\ filename\ with\ spaces


### PR DESCRIPTION
It was never used really.