### PR TITLE
Ignores pylint config file message for ~1.7+, closes #1806

### DIFF
--- a/autoload/neomake/makers/ft/python.vim
+++ b/autoload/neomake/makers/ft/python.vim
@@ -43,6 +43,7 @@ function! neomake#makers#ft#python#pylint() abort
     function! maker.filter_output(lines, context) abort
         if a:context.source ==# 'stderr'
             call filter(a:lines, "v:val !=# 'No config file found, using default configuration'")
+            call filter(a:lines, "v:val !~ 'Using config file'")
         endif
     endfunction
     return maker


### PR DESCRIPTION
Pylint added a message to stderr sometime around version 1.7.  (Current is now 1.8.1).  This message isn't ignored explicitly by the pylint filter and causes an error message when running neomake, as described in #1806.

This filter line should remove lines that match the text `Using config file` that are sent to stderr, but I'd appreciate it if someone who understands the `filter()` syntax better than I were to check the implementation.

`tests/ft_python.vader` passes, but I'm not clear if that test ends up covering this function. 