### PR TITLE
Add eslint maker for .json

### DIFF
--- a/autoload/neomake/makers/ft/json.vim
+++ b/autoload/neomake/makers/ft/json.vim
@@ -23,3 +23,15 @@ function! neomake#makers#ft#json#jsonlint() abort
             \ '%-G%.%#'
         \ }
 endfunction
+
+function! neomake#makers#ft#json#eslint() abort
+    let maker = neomake#makers#ft#javascript#eslint()
+    let maker.args += ['--plugin', 'json']
+    return maker
+endfunction
+
+function! neomake#makers#ft#json#eslint_d() abort
+    let maker = neomake#makers#ft#javascript#eslint_d()
+    let maker.args += ['--plugin', 'json']
+    return maker
+endfunction


### PR DESCRIPTION
I don't know if this is something useful for others or not:

I wanted to use eslint for my json files. Maker definitions copied from `autoload/neomake/makers/ft/javascript.vim/javascript.vim` but adding `--plugin json` to `args`.