### PR TITLE
python: pylint: ignore "Using config file" output

### DIFF
--- a/autoload/neomake/makers/ft/python.vim
+++ b/autoload/neomake/makers/ft/python.vim
@@ -42,7 +42,7 @@ function! neomake#makers#ft#python#pylint() abort
         \ ]}
     function! maker.filter_output(lines, context) abort
         if a:context.source ==# 'stderr'
-            call filter(a:lines, "v:val !=# 'No config file found, using default configuration'")
+            call filter(a:lines, "v:val !=# 'No config file found, using default configuration' && v:val !~# '^Using config file '")
         endif
     endfunction
     return maker

--- a/tests/ft_python.vader
+++ b/tests/ft_python.vader
@@ -179,3 +179,23 @@ Execute (python: pylint):
   call neomake#makers#ft#python#PylintEntryProcess(entry)
   AssertEqual entry.type, 'I'
   AssertEqual entry.col, 2
+
+Execute (python: pylint: filters expected msgs on stderr):
+  let stderr = [
+  \ 'No config file found, using default configuration',
+  \ 'Using config file /Users/liyong/.pylintrc',
+  \ 'Some unexpected error',
+  \ ]
+  let maker = neomake#GetMaker('pylint', 'python')
+  let output = copy(stderr)
+  call maker.filter_output(output, {'source': 'stderr'})
+  AssertEqual output, [
+  \ 'Some unexpected error',
+  \ ]
+  let output = copy(stderr)
+  call maker.filter_output(output, {'source': 'stdout'})
+  AssertEqual output, [
+  \ 'No config file found, using default configuration',
+  \ 'Using config file /Users/liyong/.pylintrc',
+  \ 'Some unexpected error',
+  \ ]


### PR DESCRIPTION
Fixes https://github.com/neomake/neomake/issues/1806.
Closes https://github.com/neomake/neomake/pull/1808.