### PR TITLE
rust: cargo: use dir with Cargo.toml as cwd

### DIFF
--- a/autoload/neomake/makers/ft/rust.vim
+++ b/autoload/neomake/makers/ft/rust.vim
@@ -24,12 +24,17 @@ endfunction
 function! neomake#makers#ft#rust#cargo() abort
     let maker_command = get(b:, 'neomake_rust_cargo_command',
                 \ get(g:, 'neomake_rust_cargo_command', ['check']))
-    return {
+    let maker = {
         \ 'cwd': '%:p:h',
         \ 'args': maker_command + ['--message-format=json', '--quiet'],
         \ 'append_file': 0,
         \ 'process_output': function('neomake#makers#ft#rust#CargoProcessOutput'),
         \ }
+    let cargo_toml = neomake#utils#FindGlobFile('Cargo.toml')
+    if !empty(cargo_toml)
+        let maker.cwd = fnamemodify(cargo_toml, ':h')
+    endif
+    return maker
 endfunction
 
 function! neomake#makers#ft#rust#CargoProcessOutput(context) abort

--- a/tests/ft_rust.vader
+++ b/tests/ft_rust.vader
@@ -38,3 +38,20 @@ Execute (cargo error without span):
 
   AssertEqual [], getloclist(0)
   bwipe
+
+Execute (rust: cargo: uses directory with Cargo.toml as cwd):
+  let maker = neomake#makers#ft#rust#cargo()
+  AssertEqual maker.cwd, '%:p:h'
+
+  let tempdir = tempname()
+  let slash = neomake#utils#Slash()
+  let subdir = tempdir . slash . 'subdir'
+  call mkdir(subdir, 'p')
+  let cargo_toml = tempdir . slash . 'Cargo.toml'
+  call writefile([], cargo_toml)
+
+  new
+  exe 'lcd' subdir
+  let maker = neomake#makers#ft#rust#cargo()
+  AssertEqual maker.cwd, tempdir
+  bwipe


### PR DESCRIPTION
This is required due to recent changes.

Fixes https://github.com/neomake/neomake/issues/1809.