### PR TITLE
Make :runtime for ft makers silent

### DIFF
--- a/autoload/neomake/utils.vim
+++ b/autoload/neomake/utils.vim
@@ -290,7 +290,7 @@ function! neomake#utils#load_ft_makers(ft) abort
     " monkeypatching it in tests).
     if index(s:loaded_ft_maker_runtime, a:ft) == -1
         if !exists('*neomake#makers#ft#'.a:ft.'#EnabledMakers')
-            exe 'runtime! autoload/neomake/makers/ft/'.a:ft.'.vim'
+            silent exe 'runtime! autoload/neomake/makers/ft/'.a:ft.'.vim'
         endif
         call add(s:loaded_ft_maker_runtime, a:ft)
     endif

--- a/tests/cmd_neomakeinfo.vader
+++ b/tests/cmd_neomakeinfo.vader
@@ -177,5 +177,16 @@ Execute (NeomakeInfo displays new-style config):
     Assert i > idx, 'line not found: "'.line.'" (idx: '.idx.')'."\n".join(info, "\n")
     let idx = i
   endfor
-
   bwipe
+
+Execute (Verbose NeomakeInfo does not display message for filetype with no makers):
+  new
+  noautocmd set filetype=doesnotexist
+
+  call NeomakeTestsSetVimMessagesMarker()
+  verbose let info = neomake#debug#_get_info_lines()
+  let msgs = NeomakeTestsGetVimMessages()
+  bwipe
+
+  AssertEqual msgs, []
+  Assert index(info, 'For the current filetype ("doesnotexist", used with :Neomake):') > 0


### PR DESCRIPTION
Otherwise `:verbose NeomakeInfo` would display a message for a filetype
without any makers (e.g. startify).