### PR TITLE
neomake#GetMaker: do not set append_file

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -734,12 +734,6 @@ function! neomake#GetMaker(name_or_maker, ...) abort
         if maker is# s:unset_dict
             if !empty(ft)
                 let maker = s:GetMakerForFiletype(ft, a:name_or_maker)
-                if maker isnot# s:unset_dict
-                    " Filetype makers default to 1 for append_file.
-                    if !has_key(maker, 'append_file')
-                        let maker.append_file = 1
-                    endif
-                endif
             endif
             if maker is# s:unset_dict
                 call neomake#utils#load_global_makers()

--- a/tests/makers.vader
+++ b/tests/makers.vader
@@ -588,11 +588,17 @@ Execute (Neomake/Neomake! run ft maker in project mode):
   Neomake! echo_args
   NeomakeTestsWaitForFinishedJobs
   AssertNeomakeMessage 'Running makers: echo_args.'
+  AssertEqual map(getqflist(), 'v:val.text'), ['']
+
+  call neomake#config#set('b:append_file', 1)
+  CallNeomake 0, ['echo_args']
+  AssertNeomakeMessage 'Running makers: echo_args.'
+  AssertNeomakeMessage "Using setting append_file=1 from 'buffer'.", 3
   AssertEqual map(getqflist(), 'v:val.text'), [expand('%:p')]
 
   AssertEqual map(getloclist(0), 'v:val.text'), [expand('%:p')]
 
-  AssertEqual map(copy(g:neomake_test_jobfinished), 'v:val.jobinfo.file_mode'), [1, 0]
+  AssertEqual map(copy(g:neomake_test_jobfinished), 'v:val.jobinfo.file_mode'), [1, 0, 0]
   bwipe
 
 Execute (Maker can pass opts for jobstart/job_start):


### PR DESCRIPTION
If `neomake#GetMaker` is used for non-file_mode it should not create a
maker with `append_file = 1`.