### PR TITLE
highlights: link to SpellBad/SpellCap

### DIFF
--- a/autoload/neomake/highlights.vim
+++ b/autoload/neomake/highlights.vim
@@ -120,20 +120,15 @@ else
 endif
 
 function! neomake#highlights#DefineHighlights() abort
-    for [group, fg_from] in items({
-                \ 'NeomakeError': ['Error', 'bg'],
-                \ 'NeomakeWarning': ['Todo', 'fg'],
-                \ 'NeomakeInfo': ['Question', 'fg'],
-                \ 'NeomakeMessage': ['ModeMsg', 'fg']
+    for [group, link] in items({
+                \ 'NeomakeError': 'SpellBad',
+                \ 'NeomakeWarning': 'SpellCap',
+                \ 'NeomakeInfo': 'NeomakeWarning',
+                \ 'NeomakeMessage': 'NeomakeWarning'
                 \ })
-        let [fg_group, fg_attr] = fg_from
-        let ctermfg = neomake#utils#GetHighlight(fg_group, fg_attr)
-        let guisp = neomake#utils#GetHighlight(fg_group, fg_attr.'#')
-        exe 'hi '.group.'Default ctermfg='.ctermfg.' guisp='.guisp.' cterm=underline gui=undercurl'
-        if neomake#utils#highlight_is_defined(group)
-            continue
+        if !neomake#utils#highlight_is_defined(group)
+            exe 'highlight link '.group.' '.link
         endif
-        exe 'hi link '.group.' '.group.'Default'
     endfor
 endfunction
 

--- a/doc/neomake.txt
+++ b/doc/neomake.txt
@@ -577,21 +577,20 @@ This setting enables highlighting of lines for items from the location and
 quickfix list. This overrides |g:neomake_highlight_columns|, since it
 highlights the whole line already. Defaults to 0.
 
-The following highlighting groups are used. They default to fg/bg colors from
-common highlighting groups, similar to |neomake-signs|, but
-underlined/undercurled (GUI).
- - NeomakeError
- - NeomakeWarning
- - NeomakeInfo
- - NeomakeMessage
+The following highlighting groups are used:
+ - NeomakeError: links to "SpellBad" (|hl-SpellBad|)
+ - NeomakeWarning: links to "SpellCap" (|hl-SpellCap|)
+ - NeomakeInfo: links to "NeomakeWarning"
+ - NeomakeMessage: links to "NeomakeWarning"
 
 You can define them yourself: >
 
     augroup my_neomake_highlights
         au!
         autocmd ColorScheme *
-          \ hi link NeomakeError SpellBad |
-          \ hi link NeomakeWarning SpellCap
+          \ highlight NeomakeError … |
+          \ highlight NeomakeWarning …
+          guisp=White
     augroup END
 >
 

--- a/tests/highlights.vader
+++ b/tests/highlights.vader
@@ -93,9 +93,9 @@ Execute (Highlights get (re-)defined on ColorScheme event):
     let colorscheme = 'default'
     let had_colorscheme = 0
   endif
-  let orig = neomake#utils#redir('hi NeomakeErrorDefault')
+  let orig = neomake#utils#redir('hi NeomakeError')
   exe 'colorscheme' colorscheme
-  let new = neomake#utils#redir('hi NeomakeErrorDefault')
+  let new = neomake#utils#redir('hi NeomakeError')
   if had_colorscheme
     AssertEqual orig, new
   else


### PR DESCRIPTION
This is what Syntastic and ALE are using.

Fixes https://github.com/neomake/neomake/issues/1463.
Fixes https://github.com/neomake/neomake/issues/1662.