### PR TITLE
Fix statusline formatting with empty string

### DIFF
--- a/autoload/neomake/statusline.vim
+++ b/autoload/neomake/statusline.vim
@@ -161,7 +161,11 @@ endfunction
 
 function! s:formatter.format(f, args) abort
     let self.args = a:args
-    return substitute(a:f, '{{\(.\{-}\)}}', '\=self._substitute(submatch(1))', 'g')
+    if a:f == ''
+        return ''
+    else
+        return substitute(a:f, '{{\(.\{-}\)}}', '\=self._substitute(submatch(1))', 'g')
+    endif
 endfunction
 
 

--- a/autoload/neomake/statusline.vim
+++ b/autoload/neomake/statusline.vim
@@ -160,12 +160,11 @@ function! s:formatter._substitute(m) abort
 endfunction
 
 function! s:formatter.format(f, args) abort
-    let self.args = a:args
-    if a:f == ''
-        return ''
-    else
-        return substitute(a:f, '{{\(.\{-}\)}}', '\=self._substitute(submatch(1))', 'g')
+    if empty(a:f)
+        return a:f
     endif
+    let self.args = a:args
+    return substitute(a:f, '{{\(.\{-}\)}}', '\=self._substitute(submatch(1))', 'g')
 endfunction
 
 


### PR DESCRIPTION
If the input string is empty, the output includes some detritus like `-q`.