### PR TITLE
Add process_json output handler

### DIFF
--- a/autoload/neomake/compat.vim
+++ b/autoload/neomake/compat.vim
@@ -68,11 +68,10 @@ else
             try
                 let object = eval(a:json)
             catch
-                " malformed JSON
-                let object = ''
+                throw 'Neomake: Failed to parse JSON input'
             endtry
         else
-            let object = ''
+            throw 'Neomake: Failed to parse JSON input'
         endif
 
         return object

--- a/autoload/neomake/debug.vim
+++ b/autoload/neomake/debug.vim
@@ -3,17 +3,32 @@
 function! neomake#debug#validate_maker(maker) abort
     let issues = {'errors': [], 'warnings': []}
 
-    if has_key(a:maker, 'process_output')
-        if has_key(a:maker, 'mapexpr')
-            let issues.warnings += ['maker has mapexpr, but only process_output will be used.']
-        endif
-        if has_key(a:maker, 'postprocess')
-            let issues.warnings += ['maker has postprocess, but only process_output will be used.']
-        endif
-        if has_key(a:maker, 'errorformat')
-            let issues.warnings += ['maker has errorformat, but only process_output will be used.']
-        endif
+    if has_key(a:maker, 'process_json') && has_key(a:maker, 'process_output')
+        let issues.warnings += ['maker has process_json and process_output, but only process_json will be used.']
+        let check_process = ['process_json']
+    else
+        let check_process = ['process_json', 'process_output']
     endif
+
+    for f in check_process
+        if has_key(a:maker, f)
+            if has_key(a:maker, 'mapexpr')
+                let issues.warnings += [printf(
+                            \ 'maker has mapexpr, but only %s will be used.',
+                            \ f)]
+            endif
+            if has_key(a:maker, 'postprocess')
+                let issues.warnings += [printf(
+                            \ 'maker has postprocess, but only %s will be used.',
+                            \ f)]
+            endif
+            if has_key(a:maker, 'errorformat')
+                let issues.warnings += [printf(
+                            \ 'maker has errorformat, but only %s will be used.',
+                            \ f)]
+            endif
+        endif
+    endfor
 
     if !executable(a:maker.exe)
         let t = get(a:maker, 'auto_enabled', 0) ? 'warnings' : 'errors'

--- a/doc/neomake.txt
+++ b/doc/neomake.txt
@@ -271,6 +271,23 @@ are required.  `bufnr` defaults to the jobs's buffer.
 Using this method skips the processing based on `errorformat` (including
 `mapexpr` and `postprocess`).
 
+See |neomake-makers-process_json| below for handling JSON output.
+
+                                                 *neomake-makers-process_json*
+A maker's `process_json` function gets a |dict| with parsed JSON directly,
+handling the JSON parsing and any errors before.
+
+The function gets called with a `context` dictionary, containing the following
+entries:
+ - `json`: a dictionary with the parsed JSON
+ - `source`: the source of the output (`stderr`, `stdout`)
+ - `jobinfo`: the jobinfo object, see |neomake-object-jobinfo|
+It should return a list of entries (dictionaries), where `text` and `lnum`
+are required.  `bufnr` defaults to the jobs's buffer.
+
+Using this method skips the processing based on `errorformat` (including
+`mapexpr` and `postprocess`).
+
                                                       *neomake-makers-mapexpr*
 You can define two optional properties on a maker object to process its
 output: `mapexpr` is applied to the maker's output before any processing, and

--- a/doc/neomake.txt
+++ b/doc/neomake.txt
@@ -288,6 +288,15 @@ are required.  `bufnr` defaults to the jobs's buffer.
 Using this method skips the processing based on `errorformat` (including
 `mapexpr` and `postprocess`).
 
+                                                *neomake-makers-filter_output*
+A maker's `filter_output` function can filter any output before it gets
+processed further.
+
+The function gets called with two arguments: the list of lines (to be modified
+in place) and a context dictionary with the following entries:
+ - `source`: the source of the output (`stderr`, `stdout`)
+ - `jobinfo`: the jobinfo object, see |neomake-object-jobinfo|
+
                                                       *neomake-makers-mapexpr*
 You can define two optional properties on a maker object to process its
 output: `mapexpr` is applied to the maker's output before any processing, and

--- a/tests/compat.vader
+++ b/tests/compat.vader
@@ -39,6 +39,16 @@ Execute (neomake#compat#json_decode):
   AssertEqual neomake#compat#json_decode(''), g:neomake#compat#json_none
   Assert neomake#compat#json_decode('') is g:neomake#compat#json_none
 
+  if has('nvim')
+    let expected_exception = 'Vim(return):E474: Unidentified byte: success'
+  elseif exists('*json_decode')
+    let expected_exception = 'Vim(return):E474: Invalid argument'
+  else
+    let expected_exception = 'Neomake: Failed to parse JSON input'
+  endif
+  AssertThrows call neomake#compat#json_decode('success')
+  AssertEqual g:vader_exception, expected_exception
+
 Execute (neomake#compat#json_none):
   AssertThrows call items(g:neomake#compat#json_none)
   AssertEqual g:vader_exception, 'Vim(call):E715: Dictionary required'

--- a/tests/debug.vader
+++ b/tests/debug.vader
@@ -1,0 +1,26 @@
+Include: include/setup.vader
+
+Execute (neomake#debug#validate_maker):
+  let maker = {'exe': 'true'}
+  function maker.process_json()
+  endfunction
+  function maker.process_output()
+  endfunction
+
+  AssertEqual neomake#debug#validate_maker(maker), {
+  \ 'errors': [],
+  \ 'warnings': [
+  \   'maker has process_json and process_output, but only process_json will be used.',
+  \ ]}
+
+  let maker.mapexpr = 'v:val'
+  let maker.postprocess = function('tr')
+  let maker.errorformat = '%m'
+  AssertEqual neomake#debug#validate_maker(maker), {
+  \ 'errors': [],
+  \ 'warnings': [
+  \   'maker has process_json and process_output, but only process_json will be used.',
+  \   'maker has mapexpr, but only process_json will be used.',
+  \   'maker has postprocess, but only process_json will be used.',
+  \   'maker has errorformat, but only process_json will be used.',
+  \ ]}

--- a/tests/main.vader
+++ b/tests/main.vader
@@ -9,6 +9,7 @@ Include (Completion): completion.vader
 Include (Compat): compat.vader
 Include (Config): config.vader
 Include (Current working dir): cwd.vader
+Include (Debug/Checks/Feedback): debug.vader
 Include (Environment variables): env.vader
 Include (Error handling): errors.vader
 Include (Filetype handling): filetypes.vader

--- a/tests/makers.vader
+++ b/tests/makers.vader
@@ -406,6 +406,56 @@ Execute (Makers: get_list_entries with exception):
   AssertEqual len(g:neomake_test_jobfinished), 1
   AssertEqual len(g:neomake_test_finished), 1
 
+Execute (Makers: process_output with non-list return value):
+  call neomake#statusline#ResetCounts()
+  call g:NeomakeSetupAutocmdWrappers()
+
+  let maker = copy(g:success_maker)
+  function! maker.process_output(...) abort dict
+  endfunction
+
+  CallNeomake 1, [maker]
+  AssertNeomakeMessage "Calling maker's process_output method with 1 lines of output on stdout.", 3
+  AssertNeomakeMessage 'The process_output method for maker success-maker did not return a list, but: 0.', 0
+
+  AssertEqual len(g:neomake_test_countschanged), 0
+  AssertEqual len(g:neomake_test_jobfinished), 1
+  AssertEqual len(g:neomake_test_finished), 1
+
+Execute (Makers: process_json with invalid JSON):
+  call neomake#statusline#ResetCounts()
+  call g:NeomakeSetupAutocmdWrappers()
+
+  let maker = copy(g:success_maker)
+  function! maker.process_json(...) abort dict
+  endfunction
+
+  CallNeomake 1, [maker]
+  if has('nvim')
+    AssertNeomakeMessage "Failed to decode JSON: Vim(return):E474: Unidentified byte: success (output: 'success').", 0
+  elseif exists('*json_decode')
+    AssertNeomakeMessage "Failed to decode JSON: Vim(return):E474: Invalid argument (output: 'success').", 0
+  else
+    AssertNeomakeMessage "Failed to decode JSON: Failed to parse JSON input (output: 'success').", 0
+  endif
+
+Execute (Makers: process_json with non-list return value):
+  call neomake#statusline#ResetCounts()
+  call g:NeomakeSetupAutocmdWrappers()
+
+  let maker = NeomakeTestsCommandMaker('json-maker', 'echo ''{"foo": 1, "bar": 2}''')
+  function! maker.process_json(...) abort dict
+  endfunction
+
+  CallNeomake 1, [maker]
+
+  AssertNeomakeMessage "Calling maker's process_json method with 2 JSON entries.", 3
+  AssertNeomakeMessage 'The process_json method for maker json-maker did not return a list, but: 0.', 0
+
+  AssertEqual len(g:neomake_test_countschanged), 0
+  AssertEqual len(g:neomake_test_jobfinished), 1
+  AssertEqual len(g:neomake_test_finished), 1
+
 Execute (Makers: get_list_entries with sandbox exception):
   call neomake#statusline#ResetCounts()
   call g:NeomakeSetupAutocmdWrappers()


### PR DESCRIPTION
Fixes https://github.com/neomake/neomake/issues/1795

TODO:
~~- [ ] should use a more pipe-aware approach, i.e. if both `process_output` and `process_json` are there, `process_output` should be called first - allowing to fix the output for the internal `process_json` wrapper.~~ (there is filter_output already)