### PR TITLE
Add additional errorrformat for gometalinter

### DIFF
--- a/autoload/neomake/makers/ft/go.vim
+++ b/autoload/neomake/makers/ft/go.vim
@@ -62,7 +62,7 @@ function! neomake#makers#ft#go#gometalinter() abort
         \ 'append_file': 0,
         \ 'cwd': '%:h',
         \ 'errorformat':
-            \ '%f:%l:%c:%t%*[^:]: %m', .
+            \ '%f:%l:%c:%t%*[^:]: %m,' .
             \ '%f:%l::%t%*[^:]: %m'
         \ }
 endfunction

--- a/autoload/neomake/makers/ft/go.vim
+++ b/autoload/neomake/makers/ft/go.vim
@@ -61,6 +61,8 @@ function! neomake#makers#ft#go#gometalinter() abort
         \ 'args': ['--disable-all', '--enable=errcheck', '--enable=megacheck'],
         \ 'append_file': 0,
         \ 'cwd': '%:h',
-        \ 'errorformat': '%f:%l:%c:%t%*[^:]: %m',
+        \ 'errorformat':
+            \ '%f:%l:%c:%t%*[^:]: %m', .
+            \ '%f:%l::%t%*[^:]: %m'
         \ }
 endfunction

--- a/tests/ft_go.vader
+++ b/tests/ft_go.vader
@@ -25,3 +25,14 @@ Execute (go: go):
   \  .'/home/user/bin/go1.x/src/bytes (from $GOROOT) '
   \  .'/home/user/go/src/bytes (from $GOPATH)'}]
   bwipe
+
+Execute (go: gometalinter):
+  new
+  file git.go
+
+  let &efm = neomake#makers#ft#go#gometalinter().errorformat
+  lgetexpr 'git.go:17::warning: Subprocess launching with variable.,HIGH,HIGH (gas)'
+  AssertEqual getloclist(0), [
+  \ {'lnum': 17, 'bufnr': bufnr('%'), 'col': 0, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': 'w', 'pattern': '', 'text': 'Subprocess launching with variable.,HIGH,HIGH (gas)'},
+  \ ]
+  bwipe


### PR DESCRIPTION
Without this additional format, results from some linters (like [gas](https://github.com/GoASTScanner/gas)) are ignored