### PR TITLE
neomake#utils#shellescape: do not quote =

### DIFF
--- a/autoload/neomake/utils.vim
+++ b/autoload/neomake/utils.vim
@@ -605,7 +605,7 @@ function! s:gsub(str,pat,rep) abort
 endfunction
 
 function! neomake#utils#shellescape(arg) abort
-    if a:arg =~# '^[A-Za-z0-9_/.-]\+$'
+    if a:arg =~# '^[A-Za-z0-9_/.=-]\+$'
         return a:arg
     elseif &shell =~? 'cmd' || exists('+shellslash') && !&shellslash
         return '"'.s:gsub(s:gsub(a:arg, '"', '""'), '\%', '"%"').'"'

--- a/tests/utils.vader
+++ b/tests/utils.vader
@@ -633,6 +633,7 @@ Execute (neomake#utils#shellescape):
   AssertEqual neomake#utils#shellescape('foo_bar'), 'foo_bar'
   AssertEqual neomake#utils#shellescape('foo bar'), "'foo bar'"
   AssertEqual neomake#utils#shellescape('foo bar "baz"'), "'foo bar \"baz\"'"
+  AssertEqual neomake#utils#shellescape('--foo=bar'), '--foo=bar'
 
   Save &shell
   let &shell = 'cmd.exe'


### PR DESCRIPTION
This skips escaping of `--foo=bar`, which is used often.