### PR TITLE
Specify stdout as the output stream for rubocop & rubocop_rails.

### DIFF
--- a/autoload/neomake/makers/ft/ruby.vim
+++ b/autoload/neomake/makers/ft/ruby.vim
@@ -8,7 +8,8 @@ function! neomake#makers#ft#ruby#rubocop() abort
     return {
         \ 'args': ['--format', 'emacs', '--force-exclusion', '--display-cop-names'],
         \ 'errorformat': '%f:%l:%c: %t: %m,%E%f:%l: %m',
-        \ 'postprocess': function('neomake#makers#ft#ruby#RubocopEntryProcess')
+        \ 'postprocess': function('neomake#makers#ft#ruby#RubocopEntryProcess'),
+        \ 'output_stream': 'stdout',
         \ }
 endfunction
 
@@ -17,7 +18,8 @@ function! neomake#makers#ft#ruby#rubocop_rails() abort
         \ 'args': ['--format', 'emacs', '--force-exclusion', '--display-cop-names', '--rails'],
         \ 'exe': 'rubocop',
         \ 'errorformat': '%f:%l:%c: %t: %m,%E%f:%l: %m',
-        \ 'postprocess': function('neomake#makers#ft#ruby#RubocopEntryProcess')
+        \ 'postprocess': function('neomake#makers#ft#ruby#RubocopEntryProcess'),
+        \ 'output_stream': 'stdout',
         \ }
 endfunction
 


### PR DESCRIPTION
Github Issue: https://github.com/neomake/neomake/issues/1886

Rubocop frequently updates their `.rubocop.yml` syntax, which is annoying. This cascades into silent failures when running `:Neomake` because neomake is trying to process the output from `stderr`. 