### PR TITLE
tests: fix tests/isolated/compat-get_argv-on-emulated-windows.vader

### DIFF
--- a/tests/isolated/compat-get_argv-on-emulated-windows.vader
+++ b/tests/isolated/compat-get_argv-on-emulated-windows.vader
@@ -26,7 +26,3 @@ Execute (neomake#compat#get_argv on (emulated) Windows):
 
 Execute (neomake#utils#DevNull on (emulated) Windows):
   AssertEqual neomake#utils#DevNull(), 'NUL'
-
-Execute (Restore):
-  runtime autoload/neomake/utils.vim
-  runtime autoload/neomake/compat.vim


### PR DESCRIPTION
Do not restore, which removes existing coverage info.