### PR TITLE
neovim: jobstart: use detach=1 with Neovim before 0.2.3

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -414,12 +414,12 @@ function! s:MakeJob(make_id, options) abort
                                 \ 'on_exit': function('s:nvim_exit_handler'),
                                 \ }
                 endif
-                if !has('nvim-0.2.3')
-                    " Always use detach to trigger setsid().
-                    let opts.detach = 1
-                endif
                 if has_key(maker, 'nvim_job_opts')
                     call extend(opts, maker.nvim_job_opts)
+                endif
+                if !has('nvim-0.2.3') && !has_key(opts, 'detach') && !has_key(opts, 'pty')
+                    " Always use detach to trigger setsid().
+                    let opts.detach = 1
                 endif
                 try
                     let job = jobstart(jobinfo.argv, opts)

--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -414,6 +414,10 @@ function! s:MakeJob(make_id, options) abort
                                 \ 'on_exit': function('s:nvim_exit_handler'),
                                 \ }
                 endif
+                if !has('nvim-0.2.3')
+                    " Always use detach to trigger setsid().
+                    let opts.detach = 1
+                endif
                 if has_key(maker, 'nvim_job_opts')
                     call extend(opts, maker.nvim_job_opts)
                 endif


### PR DESCRIPTION
Fixes https://github.com/neomake/neomake/issues/1216 for unix-likes.