### PR TITLE
asciidoc: prefer asciidoctor over asciidoc

### DIFF
--- a/autoload/neomake/makers/ft/asciidoc.vim
+++ b/autoload/neomake/makers/ft/asciidoc.vim
@@ -3,7 +3,8 @@ function! neomake#makers#ft#asciidoc#SupersetOf() abort
 endfunction
 
 function! neomake#makers#ft#asciidoc#EnabledMakers() abort
-    return ['asciidoc'] + neomake#makers#ft#text#EnabledMakers()
+    let makers = executable('asciidoctor') ? ['asciidoctor'] : ['asciidoc']
+    return makers + neomake#makers#ft#text#EnabledMakers()
 endfunction
 
 function! neomake#makers#ft#asciidoc#asciidoc() abort


### PR DESCRIPTION
asciidoc is EOL (final release), and recommends using asciidoctor
instead: https://github.com/asciidoc/asciidoc/releases/tag/8.6.10.