### PR TITLE
cpp: fix clangtidy/clangcheck

### DIFF
--- a/autoload/neomake/makers/ft/cpp.vim
+++ b/autoload/neomake/makers/ft/cpp.vim
@@ -21,19 +21,11 @@ function! neomake#makers#ft#cpp#gcc() abort
 endfunction
 
 function! neomake#makers#ft#cpp#clangtidy() abort
-    let maker = neomake#makers#ft#c#clangtidy()
-    " clang arguments are passed to clang-tidy after a literal "--"
-    " clang arguments like -fsyntax-only break clang-tidy
-    let maker.args += ['--', '-std=c++1z', '-I./']
-    return maker
+    return neomake#makers#ft#c#clangtidy()
 endfunction
 
 function! neomake#makers#ft#cpp#clangcheck() abort
-    let maker = neomake#makers#ft#c#clangcheck()
-    " clang arguments are passed to clang-check after a literal "--"
-    " clang arguments like -fsyntax-only break clang-check
-    let maker.args += ['--', '-std=c++1z', '-I./']
-    return maker
+    return neomake#makers#ft#c#clangcheck()
 endfunction
 
 function! neomake#makers#ft#cpp#cppcheck() abort


### PR DESCRIPTION
Do not pass options after `--`.

Fixes https://github.com/neomake/neomake/issues/1596.