### PR TITLE
customqf: do not display buf:0 with buffer=0 msgs

### DIFF
--- a/autoload/neomake/quickfix.vim
+++ b/autoload/neomake/quickfix.vim
@@ -194,18 +194,14 @@ function! neomake#quickfix#FormatQuickfix() abort
     let buffer_names = {}
     if len(buffers) > 1
         for b in buffers
-            if b
-                let bufname = bufname(b)
-                if empty(bufname)
-                    let bufname = 'buf:'.b
-                else
-                    let bufname = fnamemodify(bufname, ':t')
-                    if len(bufname) > 15
-                        let bufname = bufname[0:13].'…'
-                    endif
-                endif
+            let bufname = bufname(b)
+            if empty(bufname)
+                let bufname = 'buf:'.b
             else
-                let bufname = ''
+                let bufname = fnamemodify(bufname, ':t')
+                if len(bufname) > 15
+                    let bufname = bufname[0:13].'…'
+                endif
             endif
             let buffer_names[b] = bufname
         endfor

--- a/autoload/neomake/quickfix.vim
+++ b/autoload/neomake/quickfix.vim
@@ -189,18 +189,23 @@ function! neomake#quickfix#FormatQuickfix() abort
     endif
 
     " Count number of different buffers and cache their names.
-    let buffers = neomake#compat#uniq(sort(map(copy(qflist), 'v:val.bufnr')))
+    let buffers = neomake#compat#uniq(sort(
+                \ filter(map(copy(qflist), 'v:val.bufnr'), 'v:val != 0')))
     let buffer_names = {}
     if len(buffers) > 1
         for b in buffers
-            let bufname = b ? bufname(b) : ''
-            if empty(bufname)
-                let bufname = 'buf:'.b
-            else
-                let bufname = fnamemodify(bufname, ':t')
-                if len(bufname) > 15
-                    let bufname = bufname[0:13].'…'
+            if b
+                let bufname = bufname(b)
+                if empty(bufname)
+                    let bufname = 'buf:'.b
+                else
+                    let bufname = fnamemodify(bufname, ':t')
+                    if len(bufname) > 15
+                        let bufname = bufname[0:13].'…'
+                    endif
                 endif
+            else
+                let bufname = ''
             endif
             let buffer_names[b] = bufname
         endfor
@@ -215,7 +220,7 @@ function! neomake#quickfix#FormatQuickfix() abort
         let i += 1
 
         let text = item.text
-        if !empty(buffer_names)
+        if item.bufnr != 0 && !empty(buffer_names)
             if last_bufnr != item.bufnr
                 let text = printf('[%s] %s', buffer_names[item.bufnr], text)
                 let last_bufnr = item.bufnr

--- a/tests/customqf.vader
+++ b/tests/customqf.vader
@@ -282,11 +282,15 @@ Execute (neomake#quickfix#FormatQuickfix handles entries without bufnr)):
     file test_bufname
     call setloclist(0, [
     \ {'text': 'msg1 nmcfg:{"name": "maker", "short": "makr"}', 'bufnr': 0},
-    \ {'text': 'msg2', 'bufnr': bufnr('%')}
+    \ {'text': 'msg2', 'bufnr': bufnr('%')},
+    \ {'text': 'msg3', 'bufnr': 0},
+    \ {'text': 'msg4', 'bufnr': bufnr('%')},
     \ ])
     lopen
-    AssertEqual getline(1), "makr   [buf:0] msg1"
-    AssertEqual getline(2), "makr   [test_bufname] msg2"
+    AssertEqual getline(1), "makr   msg1"
+    AssertEqual getline(2), "makr   msg2"
+    AssertEqual getline(3), "makr   msg3"
+    AssertEqual getline(4), "makr   msg4"
     lclose
     bwipe
   finally


### PR DESCRIPTION
Those are typically informational messages, and having those trigger
displaying of bufnames in general (if there is only a single buffer
otherwise), and the "buf:0" itself is not helpful.