### PR TITLE
Define an Erlang maker aware of header and code path locations

### DIFF
--- a/autoload/neomake/compat.vim
+++ b/autoload/neomake/compat.vim
@@ -166,6 +166,13 @@ function! neomake#compat#globpath_list(path, pattern, suf) abort
     return split(globpath(a:path, a:pattern, a:suf), '\n')
 endfunction
 
+function! neomake#compat#glob_list(pattern) abort
+    if v:version <= 703
+        return split(glob(a:pattern), '\n')
+    endif
+    return glob(a:pattern, '', 1)
+endfunction
+
 if neomake#utils#IsRunningWindows()
     " Windows needs a shell to handle PATH/%PATHEXT% etc.
     function! neomake#compat#get_argv(exe, args, args_is_list) abort

--- a/autoload/neomake/compat.vim
+++ b/autoload/neomake/compat.vim
@@ -168,9 +168,9 @@ endfunction
 
 function! neomake#compat#glob_list(pattern) abort
     if v:version <= 703
-        return split(glob(a:pattern), '\n')
+        return split(glob(a:pattern, 1), '\n')
     endif
-    return glob(a:pattern, '', 1)
+    return glob(a:pattern, 1, 1)
 endfunction
 
 if neomake#utils#IsRunningWindows()

--- a/autoload/neomake/makers/ft/erlang.vim
+++ b/autoload/neomake/makers/ft/erlang.vim
@@ -1,6 +1,6 @@
 
 function! neomake#makers#ft#erlang#EnabledMakers() abort
-    return ['rebar3_erlc']
+    return ['erlc_glob_paths']
 endfunction
 
 function! neomake#makers#ft#erlang#erlc() abort
@@ -11,24 +11,31 @@ function! neomake#makers#ft#erlang#erlc() abort
         \ }
 endfunction
 
-function! neomake#makers#ft#erlang#rebar3_erlc() abort
+function! neomake#makers#ft#erlang#erlc_glob_paths() abort
     return {
         \ 'exe': 'erlc',
-        \ 'args': function("neomake#makers#ft#erlang#rebar3_glob_paths"),
+        \ 'args': function("neomake#makers#ft#erlang#glob_paths"),
         \ 'errorformat':
             \ '%W%f:%l: Warning: %m,' .
             \ '%E%f:%l: %m'
         \ }
 endfunction
 
-function! neomake#makers#ft#erlang#rebar3_glob_paths() abort
+function! neomake#makers#ft#erlang#glob_paths() abort
     if match(expand('%'), "SUITE.erl$") > -1
         let l:profile = "test"
     else
         let l:profile = "default"
     endif
     let l:ebins = glob("_build/" . l:profile . "/lib/*/ebin", "", 1)
-    let l:args = []
+    " Set g:erlang_extra_deps in a project-local .vimrc, e.g.:
+    "   let g:erlang_extra_deps = ['deps.local']
+    if exists("g:erlang_extra_deps")
+        for extra_deps in g:erlang_extra_deps
+            let l:ebins += glob(extra_deps . "/*/ebin", "", 1)
+        endfor
+    endif
+    let l:args = ['-I', 'include', '-I', 'src']
     for ebin in ebins
         call add(l:args, '-pa')
         call add(l:args, ebin)

--- a/autoload/neomake/makers/ft/erlang.vim
+++ b/autoload/neomake/makers/ft/erlang.vim
@@ -16,7 +16,22 @@ if !exists("g:rebar3_command")
 endif
 
 function! neomake#makers#ft#erlang#rebar3_erlc() abort
-    let l:ebins = systemlist(g:rebar3_command . " path")
+    return {
+        \ 'exe': 'erlc',
+        \ 'args': function("neomake#makers#ft#erlang#rebar3_paths"),
+        \ 'errorformat':
+            \ '%W%f:%l: Warning: %m,' .
+            \ '%E%f:%l: %m'
+        \ }
+endfunction
+
+function! neomake#makers#ft#erlang#rebar3_paths() abort
+    if match(expand('%'), "SUITE.erl$") > -1
+        let l:maybe_profile = "as test"
+    else
+        let l:maybe_profile = ""
+    endif
+    let l:ebins = split(system(g:rebar3_command . " " . l:maybe_profile . " path"), " ")
     let l:args = []
     for ebin in ebins
         call add(l:args, '-pa')
@@ -26,11 +41,5 @@ function! neomake#makers#ft#erlang#rebar3_erlc() abort
     endfor
     call add(l:args, '-o')
     call add(l:args, '_build/neomake')
-    return {
-        \ 'exe': 'erlc',
-        \ 'args': l:args,
-        \ 'errorformat':
-            \ '%W%f:%l: Warning: %m,' .
-            \ '%E%f:%l: %m'
-        \ }
+    return l:args
 endfunction

--- a/autoload/neomake/makers/ft/erlang.vim
+++ b/autoload/neomake/makers/ft/erlang.vim
@@ -17,7 +17,7 @@ function! neomake#makers#ft#erlang#GlobPaths() abort
     let root = fnamemodify(neomake#utils#FindGlobFile('rebar.config'), ':h')
     if empty(root)
         " At least try with CWD
-        root = getcwd()
+        let root = getcwd()
     endif
     let build_dir = root . '/_build'
     let ebins = []

--- a/autoload/neomake/makers/ft/erlang.vim
+++ b/autoload/neomake/makers/ft/erlang.vim
@@ -22,12 +22,15 @@ function! neomake#makers#ft#erlang#erlc_glob_paths() abort
 endfunction
 
 function! neomake#makers#ft#erlang#glob_paths() abort
+    " Pick the rebar3 profile to use.
     if match(expand('%'), 'SUITE.erl$') > -1
         let profile = 'test'
     else
         let profile = 'default'
     endif
-    let ebins = glob('_build/' . profile . '/lib/*/ebin', '', 1)
+    " Find project root directory.
+    let root = fnamemodify(neomake#utils#FindGlobFile('rebar.config'), ':h')
+    let ebins = glob(root . '/_build/' . profile . '/lib/*/ebin', '', 1)
     " Set g:erlang_extra_deps in a project-local .vimrc, e.g.:
     "   let g:erlang_extra_deps = ['deps.local']
     if exists('g:erlang_extra_deps')

--- a/autoload/neomake/makers/ft/erlang.vim
+++ b/autoload/neomake/makers/ft/erlang.vim
@@ -30,14 +30,14 @@ function! neomake#makers#ft#erlang#GlobPaths() abort
         if expand('%') =~# '_SUITE.erl$'
             let profile = 'test'
         endif
-        let ebins += neomake#makers#ft#erlang#Glob(build_dir . '/' . profile . '/lib/*/ebin')
+        let ebins += neomake#compat#glob_list(build_dir . '/' . profile . '/lib/*/ebin')
         let target_dir = build_dir . '/neomake'
     else
         let target_dir = tempname()
     endif
     " If <root>/_build doesn't exist it might be a rebar2/erlang.mk project
     if isdirectory(root . 'deps')
-        let ebins += neomake#makers#ft#erlang#Glob(root . 'deps/*/ebin')
+        let ebins += neomake#compat#glob_list(root . 'deps/*/ebin')
     endif
     " Set g:neomake_erlang_erlc_extra_deps in a project-local .vimrc, e.g.:
     "   let g:neomake_erlang_erlc_extra_deps = ['deps.local']
@@ -49,7 +49,7 @@ function! neomake#makers#ft#erlang#GlobPaths() abort
             if extra_deps[-1] !=# '/'
                 let extra_deps .= '/'
             endif
-            let ebins += neomake#makers#ft#erlang#Glob(extra_deps . '*/ebin')
+            let ebins += neomake#compat#glob_list(extra_deps . '*/ebin')
         endfor
     endif
     let args = ['-pa', 'ebin', '-I', 'include', '-I', 'src']
@@ -62,11 +62,4 @@ function! neomake#makers#ft#erlang#GlobPaths() abort
     endif
     let args += ['-o', target_dir]
     return args
-endfunction
-
-function! neomake#makers#ft#erlang#Glob(expr) abort
-    if v:version <= 703
-        return split(glob(a:expr))
-    endif
-    return glob(a:expr, '', 1)
 endfunction

--- a/autoload/neomake/makers/ft/erlang.vim
+++ b/autoload/neomake/makers/ft/erlang.vim
@@ -12,6 +12,10 @@ function! neomake#makers#ft#erlang#erlc() abort
         \ }
 endfunction
 
+if !exists('g:neomake_erlang_erlc_target_dir')
+    let g:neomake_erlang_erlc_target_dir = tempname()
+endif
+
 function! neomake#makers#ft#erlang#GlobPaths() abort
     " Find project root directory.
     let rebar_config = neomake#utils#FindGlobFile('rebar.config')
@@ -33,7 +37,8 @@ function! neomake#makers#ft#erlang#GlobPaths() abort
         let ebins += neomake#compat#glob_list(build_dir . '/' . profile . '/lib/*/ebin')
         let target_dir = build_dir . '/neomake'
     else
-        let target_dir = tempname()
+        let target_dir = get(b:, 'neomake_erlang_erlc_target_dir',
+                       \ get(g:, 'neomake_erlang_erlc_target_dir'))
     endif
     " If <root>/_build doesn't exist it might be a rebar2/erlang.mk project
     if isdirectory(root . 'deps')

--- a/autoload/neomake/makers/ft/erlang.vim
+++ b/autoload/neomake/makers/ft/erlang.vim
@@ -5,7 +5,6 @@ endfunction
 
 function! neomake#makers#ft#erlang#erlc() abort
     return {
-        \ 'exe': 'erlc',
         \ 'args': function('neomake#makers#ft#erlang#GlobPaths'),
         \ 'errorformat':
             \ '%W%f:%l: Warning: %m,' .

--- a/autoload/neomake/makers/ft/erlang.vim
+++ b/autoload/neomake/makers/ft/erlang.vim
@@ -23,10 +23,13 @@ function! neomake#makers#ft#erlang#GlobPaths() abort
     " Find project root directory.
     let root = fnamemodify(neomake#utils#FindGlobFile('rebar.config'), ':h')
     let ebins = glob(root . '/_build/' . profile . '/lib/*/ebin', '', 1)
-    " Set g:erlang_extra_deps in a project-local .vimrc, e.g.:
-    "   let g:erlang_extra_deps = ['deps.local']
-    if exists('g:erlang_extra_deps')
-        for extra_deps in g:erlang_extra_deps
+    " Set g:neomake_erlang_erlc_extra_deps in a project-local .vimrc, e.g.:
+    "   let g:neomake_erlang_erlc_extra_deps = ['deps.local']
+    " Or just b:neomake_erlang_erlc_extra_deps in a specific buffer.
+    let extra_deps_dirs = get(b:, 'neomake_erlang_erlc_extra_deps',
+                        \ get(g:, 'neomake_erlang_erlc_extra_deps'))
+    if !empty(extra_deps_dirs)
+        for extra_deps in extra_deps_dirs
             let ebins += glob(extra_deps . '/*/ebin', '', 1)
         endfor
     endif

--- a/autoload/neomake/makers/ft/erlang.vim
+++ b/autoload/neomake/makers/ft/erlang.vim
@@ -30,14 +30,14 @@ function! neomake#makers#ft#erlang#GlobPaths() abort
         if expand('%') =~# '_SUITE.erl$'
             let profile = 'test'
         endif
-        let ebins += glob(build_dir . '/' . profile . '/lib/*/ebin', '', 1)
+        let ebins += neomake#makers#ft#erlang#Glob(build_dir . '/' . profile . '/lib/*/ebin')
         let target_dir = build_dir . '/neomake'
     else
         let target_dir = tempname()
     endif
     " If <root>/_build doesn't exist it might be a rebar2/erlang.mk project
     if isdirectory(root . 'deps')
-        let ebins += glob(root . 'deps/*/ebin', '', 1)
+        let ebins += neomake#makers#ft#erlang#Glob(root . 'deps/*/ebin')
     endif
     " Set g:neomake_erlang_erlc_extra_deps in a project-local .vimrc, e.g.:
     "   let g:neomake_erlang_erlc_extra_deps = ['deps.local']
@@ -49,7 +49,7 @@ function! neomake#makers#ft#erlang#GlobPaths() abort
             if extra_deps[-1] !=# '/'
                 let extra_deps .= '/'
             endif
-            let ebins += glob(extra_deps . '*/ebin', '', 1)
+            let ebins += neomake#makers#ft#erlang#Glob(extra_deps . '*/ebin')
         endfor
     endif
     let args = ['-pa', 'ebin', '-I', 'include', '-I', 'src']
@@ -62,4 +62,11 @@ function! neomake#makers#ft#erlang#GlobPaths() abort
     endif
     let args += ['-o', target_dir]
     return args
+endfunction
+
+function! neomake#makers#ft#erlang#Glob(expr) abort
+    if v:version <= 703
+        return split(glob(a:expr))
+    endif
+    return glob(a:expr, '', 1)
 endfunction

--- a/autoload/neomake/makers/ft/erlang.vim
+++ b/autoload/neomake/makers/ft/erlang.vim
@@ -15,7 +15,7 @@ endfunction
 
 function! neomake#makers#ft#erlang#GlobPaths() abort
     " Pick the rebar3 profile to use.
-    if match(expand('%'), 'SUITE.erl$') > -1
+    if expand('%') =~# '_SUITE.erl$'
         let profile = 'test'
     else
         let profile = 'default'

--- a/autoload/neomake/makers/ft/erlang.vim
+++ b/autoload/neomake/makers/ft/erlang.vim
@@ -40,7 +40,9 @@ function! neomake#makers#ft#erlang#glob_paths() abort
     " the same way erlc does by default.
     if isdirectory(build_dir)
         let target_dir = build_dir . '/neomake'
-        call mkdir(target_dir)
+        if !isdirectory(target_dir)
+            call mkdir(target_dir, 'p')
+        endif
         let args += ['-o', target_dir]
     endif
     return args

--- a/autoload/neomake/makers/ft/erlang.vim
+++ b/autoload/neomake/makers/ft/erlang.vim
@@ -6,14 +6,14 @@ endfunction
 function! neomake#makers#ft#erlang#erlc() abort
     return {
         \ 'exe': 'erlc',
-        \ 'args': function('neomake#makers#ft#erlang#glob_paths'),
+        \ 'args': function('neomake#makers#ft#erlang#GlobPaths'),
         \ 'errorformat':
             \ '%W%f:%l: Warning: %m,' .
             \ '%E%f:%l: %m'
         \ }
 endfunction
 
-function! neomake#makers#ft#erlang#glob_paths() abort
+function! neomake#makers#ft#erlang#GlobPaths() abort
     " Pick the rebar3 profile to use.
     if match(expand('%'), 'SUITE.erl$') > -1
         let profile = 'test'

--- a/autoload/neomake/makers/ft/erlang.vim
+++ b/autoload/neomake/makers/ft/erlang.vim
@@ -46,7 +46,7 @@ function! neomake#makers#ft#erlang#GlobPaths() abort
                         \ get(g:, 'neomake_erlang_erlc_extra_deps'))
     if !empty(extra_deps_dirs)
         for extra_deps in extra_deps_dirs
-            if extra_deps[-1] != '/'
+            if extra_deps[-1] !=# '/'
                 let extra_deps .= '/'
             endif
             let ebins += glob(extra_deps . '*/ebin', '', 1)

--- a/autoload/neomake/makers/ft/erlang.vim
+++ b/autoload/neomake/makers/ft/erlang.vim
@@ -14,7 +14,7 @@ endfunction
 function! neomake#makers#ft#erlang#erlc_glob_paths() abort
     return {
         \ 'exe': 'erlc',
-        \ 'args': function("neomake#makers#ft#erlang#glob_paths"),
+        \ 'args': function('neomake#makers#ft#erlang#glob_paths'),
         \ 'errorformat':
             \ '%W%f:%l: Warning: %m,' .
             \ '%E%f:%l: %m'
@@ -22,17 +22,17 @@ function! neomake#makers#ft#erlang#erlc_glob_paths() abort
 endfunction
 
 function! neomake#makers#ft#erlang#glob_paths() abort
-    if match(expand('%'), "SUITE.erl$") > -1
-        let l:profile = "test"
+    if match(expand('%'), 'SUITE.erl$') > -1
+        let l:profile = 'test'
     else
-        let l:profile = "default"
+        let l:profile = 'default'
     endif
-    let l:ebins = glob("_build/" . l:profile . "/lib/*/ebin", "", 1)
+    let l:ebins = glob('_build/' . l:profile . '/lib/*/ebin', '', 1)
     " Set g:erlang_extra_deps in a project-local .vimrc, e.g.:
     "   let g:erlang_extra_deps = ['deps.local']
-    if exists("g:erlang_extra_deps")
+    if exists('g:erlang_extra_deps')
         for extra_deps in g:erlang_extra_deps
-            let l:ebins += glob(extra_deps . "/*/ebin", "", 1)
+            let l:ebins += glob(extra_deps . '/*/ebin', '', 1)
         endfor
     endif
     let l:args = ['-pa', 'ebin', '-I', 'include', '-I', 'src']
@@ -40,7 +40,7 @@ function! neomake#makers#ft#erlang#glob_paths() abort
         call add(l:args, '-pa')
         call add(l:args, ebin)
         call add(l:args, '-I')
-        call add(l:args, substitute(ebin, "ebin$", "include", ""))
+        call add(l:args, substitute(ebin, 'ebin$', 'include', ''))
     endfor
     call add(l:args, '-o')
     call add(l:args, '_build/neomake')

--- a/autoload/neomake/makers/ft/erlang.vim
+++ b/autoload/neomake/makers/ft/erlang.vim
@@ -1,17 +1,9 @@
 
 function! neomake#makers#ft#erlang#EnabledMakers() abort
-    return ['erlc_glob_paths']
+    return ['erlc']
 endfunction
 
 function! neomake#makers#ft#erlang#erlc() abort
-    return {
-        \ 'errorformat':
-            \ '%W%f:%l: Warning: %m,' .
-            \ '%E%f:%l: %m'
-        \ }
-endfunction
-
-function! neomake#makers#ft#erlang#erlc_glob_paths() abort
     return {
         \ 'exe': 'erlc',
         \ 'args': function('neomake#makers#ft#erlang#glob_paths'),

--- a/autoload/neomake/makers/ft/erlang.vim
+++ b/autoload/neomake/makers/ft/erlang.vim
@@ -30,10 +30,8 @@ function! neomake#makers#ft#erlang#GlobPaths() abort
     let ebins = []
     if isdirectory(build_dir)
         " Pick the rebar3 profile to use
-        let profile = 'default'
-        if expand('%') =~# '_SUITE.erl$'
-            let profile = 'test'
-        endif
+        let default_profile = expand('%') =~# '_SUITE.erl$' ?  'test' : 'default'
+        let profile = get(b:, 'neomake_erlang_erlc_rebar3_profile', default_profile)
         let ebins += neomake#compat#glob_list(build_dir . '/' . profile . '/lib/*/ebin')
         let target_dir = build_dir . '/neomake'
     else

--- a/autoload/neomake/makers/ft/erlang.vim
+++ b/autoload/neomake/makers/ft/erlang.vim
@@ -43,7 +43,13 @@ function! neomake#makers#ft#erlang#glob_paths() abort
         let args += [ '-pa', ebin,
                     \ '-I', substitute(ebin, 'ebin$', 'include', '') ]
     endfor
-    call add(args, '-o')
-    call add(args, '_build/neomake')
+    let build_dir = root . '/_build'
+    " If <project-root>/_build doesn't exist we'll clutter CWD with .beam files,
+    " the same way erlc does by default.
+    if isdirectory(build_dir)
+        let target_dir = build_dir . '/neomake'
+        call mkdir(target_dir)
+        let args += ['-o', target_dir]
+    endif
     return args
 endfunction

--- a/autoload/neomake/makers/ft/erlang.vim
+++ b/autoload/neomake/makers/ft/erlang.vim
@@ -30,9 +30,11 @@ function! neomake#makers#ft#erlang#GlobPaths() abort
         let ebins += glob(build_dir . '/' . profile . '/lib/*/ebin', '', 1)
         let target_dir = build_dir . '/neomake'
     else
-        " If <root>/_build doesn't exist it might be a rebar2/erlang.mk project
-        let ebins += glob(root . '/deps/*/ebin', '', 1)
         let target_dir = tempname()
+    endif
+    " If <root>/_build doesn't exist it might be a rebar2/erlang.mk project
+    if isdirectory(root . '/deps')
+        let ebins += glob(root . '/deps/*/ebin', '', 1)
     endif
     " Set g:neomake_erlang_erlc_extra_deps in a project-local .vimrc, e.g.:
     "   let g:neomake_erlang_erlc_extra_deps = ['deps.local']

--- a/autoload/neomake/makers/ft/erlang.vim
+++ b/autoload/neomake/makers/ft/erlang.vim
@@ -11,27 +11,23 @@ function! neomake#makers#ft#erlang#erlc() abort
         \ }
 endfunction
 
-if !exists("g:rebar3_command")
-    let g:rebar3_command = "rebar3"
-endif
-
 function! neomake#makers#ft#erlang#rebar3_erlc() abort
     return {
         \ 'exe': 'erlc',
-        \ 'args': function("neomake#makers#ft#erlang#rebar3_paths"),
+        \ 'args': function("neomake#makers#ft#erlang#rebar3_glob_paths"),
         \ 'errorformat':
             \ '%W%f:%l: Warning: %m,' .
             \ '%E%f:%l: %m'
         \ }
 endfunction
 
-function! neomake#makers#ft#erlang#rebar3_paths() abort
+function! neomake#makers#ft#erlang#rebar3_glob_paths() abort
     if match(expand('%'), "SUITE.erl$") > -1
-        let l:maybe_profile = "as test"
+        let l:profile = "test"
     else
-        let l:maybe_profile = ""
+        let l:profile = "default"
     endif
-    let l:ebins = split(system(g:rebar3_command . " " . l:maybe_profile . " path"), " ")
+    let l:ebins = glob("_build/" . l:profile . "/lib/*/ebin", "", 1)
     let l:args = []
     for ebin in ebins
         call add(l:args, '-pa')

--- a/autoload/neomake/makers/ft/erlang.vim
+++ b/autoload/neomake/makers/ft/erlang.vim
@@ -1,10 +1,34 @@
 
 function! neomake#makers#ft#erlang#EnabledMakers() abort
-    return ['erlc']
+    return ['rebar3_erlc']
 endfunction
 
 function! neomake#makers#ft#erlang#erlc() abort
     return {
+        \ 'errorformat':
+            \ '%W%f:%l: Warning: %m,' .
+            \ '%E%f:%l: %m'
+        \ }
+endfunction
+
+if !exists("g:rebar3_command")
+    let g:rebar3_command = "rebar3"
+endif
+
+function! neomake#makers#ft#erlang#rebar3_erlc() abort
+    let l:ebins = systemlist(g:rebar3_command . " path")
+    let l:args = []
+    for ebin in ebins
+        call add(l:args, '-pa')
+        call add(l:args, ebin)
+        call add(l:args, '-I')
+        call add(l:args, substitute(ebin, "ebin$", "include", ""))
+    endfor
+    call add(l:args, '-o')
+    call add(l:args, '_build/neomake')
+    return {
+        \ 'exe': 'erlc',
+        \ 'args': l:args,
         \ 'errorformat':
             \ '%W%f:%l: Warning: %m,' .
             \ '%E%f:%l: %m'

--- a/autoload/neomake/makers/ft/erlang.vim
+++ b/autoload/neomake/makers/ft/erlang.vim
@@ -35,7 +35,7 @@ function! neomake#makers#ft#erlang#glob_paths() abort
             let l:ebins += glob(extra_deps . "/*/ebin", "", 1)
         endfor
     endif
-    let l:args = ['-I', 'include', '-I', 'src']
+    let l:args = ['-pa', 'ebin', '-I', 'include', '-I', 'src']
     for ebin in ebins
         call add(l:args, '-pa')
         call add(l:args, ebin)

--- a/autoload/neomake/makers/ft/erlang.vim
+++ b/autoload/neomake/makers/ft/erlang.vim
@@ -23,26 +23,24 @@ endfunction
 
 function! neomake#makers#ft#erlang#glob_paths() abort
     if match(expand('%'), 'SUITE.erl$') > -1
-        let l:profile = 'test'
+        let profile = 'test'
     else
-        let l:profile = 'default'
+        let profile = 'default'
     endif
-    let l:ebins = glob('_build/' . l:profile . '/lib/*/ebin', '', 1)
+    let ebins = glob('_build/' . profile . '/lib/*/ebin', '', 1)
     " Set g:erlang_extra_deps in a project-local .vimrc, e.g.:
     "   let g:erlang_extra_deps = ['deps.local']
     if exists('g:erlang_extra_deps')
         for extra_deps in g:erlang_extra_deps
-            let l:ebins += glob(extra_deps . '/*/ebin', '', 1)
+            let ebins += glob(extra_deps . '/*/ebin', '', 1)
         endfor
     endif
-    let l:args = ['-pa', 'ebin', '-I', 'include', '-I', 'src']
+    let args = ['-pa', 'ebin', '-I', 'include', '-I', 'src']
     for ebin in ebins
-        call add(l:args, '-pa')
-        call add(l:args, ebin)
-        call add(l:args, '-I')
-        call add(l:args, substitute(ebin, 'ebin$', 'include', ''))
+        let args += [ '-pa', ebin,
+                    \ '-I', substitute(ebin, 'ebin$', 'include', '') ]
     endfor
-    call add(l:args, '-o')
-    call add(l:args, '_build/neomake')
-    return l:args
+    call add(args, '-o')
+    call add(args, '_build/neomake')
+    return args
 endfunction

--- a/tests/compat.vader
+++ b/tests/compat.vader
@@ -147,3 +147,12 @@ Execute (neomake#compat#get_mode with insert mode completion (imap)):
   AssertEqual getline('.'), 'word'
 
   bwipe!
+
+Execute (neomake#compat#glob_list):
+  AssertEqual neomake#compat#glob_list('doesnotexist'), []
+  AssertEqual neomake#compat#glob_list(g:vader_file), [g:vader_file]
+
+  Save &wildignore
+  let &wildignore = '*.vader'
+  AssertEqual fnamemodify(g:vader_file, ':e'), 'vader'
+  AssertEqual neomake#compat#glob_list(g:vader_file), [g:vader_file]

--- a/tests/ft_erlang.vader
+++ b/tests/ft_erlang.vader
@@ -90,7 +90,6 @@ Execute (erlc: buffer local extra deps):
   let args = neomake#makers#ft#erlang#GlobPaths()
   let dep1_ebin_opt = args[6:7]
   let dep1_include_opt = args[8:9]
-  "AssertEqual '', args
   AssertEqual ['-pa', 'deps.local/dep1/ebin'], dep1_ebin_opt
   AssertEqual ['-I', 'deps.local/dep1/include'], dep1_include_opt
   bwipe

--- a/tests/ft_erlang.vader
+++ b/tests/ft_erlang.vader
@@ -1,0 +1,94 @@
+Include: include/setup.vader
+
+Before (prepare an empty working directory):
+  let s:root = tempname()
+  call mkdir(s:root, 'p')
+  execute 'cd ' . s:root
+
+After (clean up the working directory):
+  execute 'silent !rm -rf ' . s:root
+
+Execute (erlc: common settings):
+  new
+  file src/myapp.erl
+
+  let args = neomake#makers#ft#erlang#GlobPaths()
+  AssertEqual args[:-2], ['-pa', 'ebin', '-I', 'include', '-I', 'src', '-o']
+  let output_dir = args[-1]
+  Assert isdirectory(output_dir)
+  bwipe
+
+Execute (erlc: output to _build/neomake if _build is present):
+  call mkdir('_build', 'p')
+  new
+  file src/myapp.erl
+
+  let args = neomake#makers#ft#erlang#GlobPaths()
+  let output_dir = args[-1]
+  Assert output_dir =~# '/_build/neomake$'
+  Assert isdirectory(output_dir)
+  bwipe
+
+Execute (erlc: rebar3 default profile - no rebar.config):
+  call mkdir('_build/default/lib/dep1/ebin', 'p')
+  new
+  file src/myapp.erl
+
+  let args = neomake#makers#ft#erlang#GlobPaths()
+  let dep1_ebin_opt = args[6:7]
+  let dep1_include_opt = args[8:9]
+  AssertEqual ['-pa', s:root . '/_build/default/lib/dep1/ebin'], dep1_ebin_opt
+  AssertEqual ['-I', s:root . '/_build/default/lib/dep1/include'], dep1_include_opt
+  bwipe
+
+Execute (erlc: rebar3 default profile):
+  call mkdir('_build/default/lib/dep1/ebin', 'p')
+  write rebar.config
+  new
+  file src/myapp.erl
+
+  let args = neomake#makers#ft#erlang#GlobPaths()
+  let dep1_ebin_opt = args[6:7]
+  let dep1_include_opt = args[8:9]
+  AssertEqual ['-pa', s:root . '/_build/default/lib/dep1/ebin'], dep1_ebin_opt
+  AssertEqual ['-I', s:root . '/_build/default/lib/dep1/include'], dep1_include_opt
+  bwipe
+
+Execute (erlc: rebar3 test profile):
+  call mkdir('_build/test/lib/dep1/ebin', 'p')
+  new
+  file test/myapp_SUITE.erl
+
+  let args = neomake#makers#ft#erlang#GlobPaths()
+  let dep1_ebin_opt = args[6:7]
+  let dep1_include_opt = args[8:9]
+  AssertEqual ['-pa', s:root . '/_build/test/lib/dep1/ebin'], dep1_ebin_opt
+  AssertEqual ['-I', s:root . '/_build/test/lib/dep1/include'], dep1_include_opt
+  bwipe
+
+Execute (erlc: rebar2/erlang.mk deps/ present):
+  call mkdir('deps/dep1/ebin', 'p')
+  new
+  file src/myapp.erl
+
+  let args = neomake#makers#ft#erlang#GlobPaths()
+  let dep1_ebin_opt = args[6:7]
+  let dep1_include_opt = args[8:9]
+  AssertEqual ['-pa', s:root . '/deps/dep1/ebin'], dep1_ebin_opt
+  AssertEqual ['-I', s:root . '/deps/dep1/include'], dep1_include_opt
+  bwipe
+
+Execute (erlc: buffer local extra deps):
+  call mkdir('deps.local/dep1/ebin', 'p')
+  new
+  file src/myapp.erl
+  let b:neomake_erlang_erlc_extra_deps = ['deps.local']
+
+
+  let args = neomake#makers#ft#erlang#GlobPaths()
+  let dep1_ebin_opt = args[6:7]
+  let dep1_include_opt = args[8:9]
+  "AssertEqual '', args
+  AssertEqual ['-pa', 'deps.local/dep1/ebin'], dep1_ebin_opt
+  AssertEqual ['-I', 'deps.local/dep1/include'], dep1_include_opt
+  bwipe

--- a/tests/ft_erlang.vader
+++ b/tests/ft_erlang.vader
@@ -1,15 +1,5 @@
 Include: include/setup.vader
 
-Before (prepare an empty working directory):
-  let s:root = tempname()
-  call mkdir(s:root, 'p')
-  let s:old_cwd = fnamemodify('.', ':p')
-  execute 'cd ' . s:root
-
-After (clean up the working directory):
-  execute 'cd ' . s:old_cwd
-  execute 'silent !rm -rf ' . s:root
-
 Execute (erlc: common settings):
   new
   file src/myapp.erl
@@ -21,6 +11,11 @@ Execute (erlc: common settings):
   bwipe
 
 Execute (erlc: output to _build/neomake if _build is present):
+  let root = tempname()
+  call mkdir(root, 'p')
+  let s:old_cwd = fnamemodify('.', ':p')
+  execute 'cd ' . root
+
   call mkdir('_build', 'p')
   new
   file src/myapp.erl
@@ -31,7 +26,14 @@ Execute (erlc: output to _build/neomake if _build is present):
   Assert isdirectory(output_dir)
   bwipe
 
+  execute 'cd ' . s:old_cwd
+
 Execute (erlc: rebar3 default profile - no rebar.config):
+  let root = tempname()
+  call mkdir(root, 'p')
+  let s:old_cwd = fnamemodify('.', ':p')
+  execute 'cd ' . root
+
   call mkdir('_build/default/lib/dep1/ebin', 'p')
   new
   file src/myapp.erl
@@ -39,24 +41,39 @@ Execute (erlc: rebar3 default profile - no rebar.config):
   let args = neomake#makers#ft#erlang#GlobPaths()
   let dep1_ebin_opt = args[6:7]
   let dep1_include_opt = args[8:9]
-  AssertEqual ['-pa', s:root . '/_build/default/lib/dep1/ebin'], dep1_ebin_opt
-  AssertEqual ['-I', s:root . '/_build/default/lib/dep1/include'], dep1_include_opt
+  AssertEqual ['-pa', root . '/_build/default/lib/dep1/ebin'], dep1_ebin_opt
+  AssertEqual ['-I', root . '/_build/default/lib/dep1/include'], dep1_include_opt
   bwipe
+
+  execute 'cd ' . s:old_cwd
 
 Execute (erlc: rebar3 default profile):
+  let root = tempname()
+  call mkdir(root, 'p')
+  let s:old_cwd = fnamemodify('.', ':p')
+  execute 'cd ' . root
+
   call mkdir('_build/default/lib/dep1/ebin', 'p')
   write rebar.config
+  bwipe rebar.config
   new
   file src/myapp.erl
 
   let args = neomake#makers#ft#erlang#GlobPaths()
   let dep1_ebin_opt = args[6:7]
   let dep1_include_opt = args[8:9]
-  AssertEqual ['-pa', s:root . '/_build/default/lib/dep1/ebin'], dep1_ebin_opt
-  AssertEqual ['-I', s:root . '/_build/default/lib/dep1/include'], dep1_include_opt
+  AssertEqual ['-pa', root . '/_build/default/lib/dep1/ebin'], dep1_ebin_opt
+  AssertEqual ['-I', root . '/_build/default/lib/dep1/include'], dep1_include_opt
   bwipe
 
+  execute 'cd ' . s:old_cwd
+
 Execute (erlc: rebar3 test profile):
+  let root = tempname()
+  call mkdir(root, 'p')
+  let s:old_cwd = fnamemodify('.', ':p')
+  execute 'cd ' . root
+
   call mkdir('_build/test/lib/dep1/ebin', 'p')
   new
   file test/myapp_SUITE.erl
@@ -64,11 +81,18 @@ Execute (erlc: rebar3 test profile):
   let args = neomake#makers#ft#erlang#GlobPaths()
   let dep1_ebin_opt = args[6:7]
   let dep1_include_opt = args[8:9]
-  AssertEqual ['-pa', s:root . '/_build/test/lib/dep1/ebin'], dep1_ebin_opt
-  AssertEqual ['-I', s:root . '/_build/test/lib/dep1/include'], dep1_include_opt
+  AssertEqual ['-pa', root . '/_build/test/lib/dep1/ebin'], dep1_ebin_opt
+  AssertEqual ['-I', root . '/_build/test/lib/dep1/include'], dep1_include_opt
   bwipe
 
+  execute 'cd ' . s:old_cwd
+
 Execute (erlc: rebar2/erlang.mk deps/ present):
+  let root = tempname()
+  call mkdir(root, 'p')
+  let s:old_cwd = fnamemodify('.', ':p')
+  execute 'cd ' . root
+
   call mkdir('deps/dep1/ebin', 'p')
   new
   file src/myapp.erl
@@ -76,16 +100,22 @@ Execute (erlc: rebar2/erlang.mk deps/ present):
   let args = neomake#makers#ft#erlang#GlobPaths()
   let dep1_ebin_opt = args[6:7]
   let dep1_include_opt = args[8:9]
-  AssertEqual ['-pa', s:root . '/deps/dep1/ebin'], dep1_ebin_opt
-  AssertEqual ['-I', s:root . '/deps/dep1/include'], dep1_include_opt
+  AssertEqual ['-pa', root . '/deps/dep1/ebin'], dep1_ebin_opt
+  AssertEqual ['-I', root . '/deps/dep1/include'], dep1_include_opt
   bwipe
 
+  execute 'cd ' . s:old_cwd
+
 Execute (erlc: buffer local extra deps):
+  let root = tempname()
+  call mkdir(root, 'p')
+  let s:old_cwd = fnamemodify('.', ':p')
+  execute 'cd ' . root
+
   call mkdir('deps.local/dep1/ebin', 'p')
   new
   file src/myapp.erl
   let b:neomake_erlang_erlc_extra_deps = ['deps.local']
-
 
   let args = neomake#makers#ft#erlang#GlobPaths()
   let dep1_ebin_opt = args[6:7]
@@ -93,3 +123,5 @@ Execute (erlc: buffer local extra deps):
   AssertEqual ['-pa', 'deps.local/dep1/ebin'], dep1_ebin_opt
   AssertEqual ['-I', 'deps.local/dep1/include'], dep1_include_opt
   bwipe
+
+  execute 'cd ' . s:old_cwd

--- a/tests/ft_erlang.vader
+++ b/tests/ft_erlang.vader
@@ -3,9 +3,11 @@ Include: include/setup.vader
 Before (prepare an empty working directory):
   let s:root = tempname()
   call mkdir(s:root, 'p')
+  let s:old_cwd = fnamemodify('.', ':p')
   execute 'cd ' . s:root
 
 After (clean up the working directory):
+  execute 'cd ' . s:old_cwd
   execute 'silent !rm -rf ' . s:root
 
 Execute (erlc: common settings):

--- a/tests/ft_erlang.vader
+++ b/tests/ft_erlang.vader
@@ -138,3 +138,25 @@ Execute (erlc: buffer local extra deps):
   finally
     execute 'cd ' . old_cwd
   endtry
+
+Execute (erlc: buffer local profile override):
+  let old_cwd = getcwd()
+  try
+    let root = tempname()
+    call mkdir(root, 'p')
+    execute 'cd ' . root
+
+    call mkdir('_build/test/lib/dep1/ebin', 'p')
+    new
+    file config/not_a_SUITE_file.erl
+    let b:neomake_erlang_erlc_rebar3_profile = 'test'
+
+    let args = neomake#makers#ft#erlang#GlobPaths()
+    let dep1_ebin_opt = args[6:7]
+    let dep1_include_opt = args[8:9]
+    AssertEqual ['-pa', root . '/_build/test/lib/dep1/ebin'], dep1_ebin_opt
+    AssertEqual ['-I', root . '/_build/test/lib/dep1/include'], dep1_include_opt
+    bwipe
+  finally
+    execute 'cd ' . old_cwd
+  endtry

--- a/tests/ft_erlang.vader
+++ b/tests/ft_erlang.vader
@@ -11,117 +11,130 @@ Execute (erlc: common settings):
   bwipe
 
 Execute (erlc: output to _build/neomake if _build is present):
-  let root = tempname()
-  call mkdir(root, 'p')
-  let s:old_cwd = fnamemodify('.', ':p')
-  execute 'cd ' . root
+  let old_cwd = getcwd()
+  try
+    let root = tempname()
+    call mkdir(root, 'p')
+    execute 'cd ' . root
 
-  call mkdir('_build', 'p')
-  new
-  file src/myapp.erl
+    call mkdir('_build', 'p')
+    new
+    file src/myapp.erl
 
-  let args = neomake#makers#ft#erlang#GlobPaths()
-  let output_dir = args[-1]
-  Assert output_dir =~# '/_build/neomake$'
-  Assert isdirectory(output_dir)
-  bwipe
-
-  execute 'cd ' . s:old_cwd
+    let args = neomake#makers#ft#erlang#GlobPaths()
+    let output_dir = args[-1]
+    Assert output_dir =~# '/_build/neomake$'
+    Assert isdirectory(output_dir)
+    bwipe
+  finally
+    execute 'cd ' . old_cwd
+  endtry
 
 Execute (erlc: rebar3 default profile - no rebar.config):
-  let root = tempname()
-  call mkdir(root, 'p')
-  let s:old_cwd = fnamemodify('.', ':p')
-  execute 'cd ' . root
+  let old_cwd = getcwd()
+  try
+    let root = tempname()
+    call mkdir(root, 'p')
+    execute 'cd ' . root
 
-  call mkdir('_build/default/lib/dep1/ebin', 'p')
-  new
-  file src/myapp.erl
+    call mkdir('_build/default/lib/dep1/ebin', 'p')
+    new
+    file src/myapp.erl
 
-  let args = neomake#makers#ft#erlang#GlobPaths()
-  let dep1_ebin_opt = args[6:7]
-  let dep1_include_opt = args[8:9]
-  AssertEqual ['-pa', root . '/_build/default/lib/dep1/ebin'], dep1_ebin_opt
-  AssertEqual ['-I', root . '/_build/default/lib/dep1/include'], dep1_include_opt
-  bwipe
+    let args = neomake#makers#ft#erlang#GlobPaths()
+    let dep1_ebin_opt = args[6:7]
+    let dep1_include_opt = args[8:9]
+    AssertEqual ['-pa', root . '/_build/default/lib/dep1/ebin'], dep1_ebin_opt
+    AssertEqual ['-I', root . '/_build/default/lib/dep1/include'], dep1_include_opt
+    bwipe
+  finally
+    execute 'cd ' . old_cwd
+  endtry
 
-  execute 'cd ' . s:old_cwd
 
 Execute (erlc: rebar3 default profile):
-  let root = tempname()
-  call mkdir(root, 'p')
-  let s:old_cwd = fnamemodify('.', ':p')
-  execute 'cd ' . root
+  let old_cwd = getcwd()
+  try
+    let root = tempname()
+    call mkdir(root, 'p')
+    execute 'cd ' . root
 
-  call mkdir('_build/default/lib/dep1/ebin', 'p')
-  write rebar.config
-  bwipe rebar.config
-  new
-  file src/myapp.erl
+    call mkdir('_build/default/lib/dep1/ebin', 'p')
+    write rebar.config
+    bwipe rebar.config
+    new
+    file src/myapp.erl
 
-  let args = neomake#makers#ft#erlang#GlobPaths()
-  let dep1_ebin_opt = args[6:7]
-  let dep1_include_opt = args[8:9]
-  AssertEqual ['-pa', root . '/_build/default/lib/dep1/ebin'], dep1_ebin_opt
-  AssertEqual ['-I', root . '/_build/default/lib/dep1/include'], dep1_include_opt
-  bwipe
-
-  execute 'cd ' . s:old_cwd
+    let args = neomake#makers#ft#erlang#GlobPaths()
+    let dep1_ebin_opt = args[6:7]
+    let dep1_include_opt = args[8:9]
+    AssertEqual ['-pa', root . '/_build/default/lib/dep1/ebin'], dep1_ebin_opt
+    AssertEqual ['-I', root . '/_build/default/lib/dep1/include'], dep1_include_opt
+    bwipe
+  finally
+    execute 'cd ' . old_cwd
+  endtry
 
 Execute (erlc: rebar3 test profile):
-  let root = tempname()
-  call mkdir(root, 'p')
-  let s:old_cwd = fnamemodify('.', ':p')
-  execute 'cd ' . root
+  let old_cwd = getcwd()
+  try
+    let root = tempname()
+    call mkdir(root, 'p')
+    execute 'cd ' . root
 
-  call mkdir('_build/test/lib/dep1/ebin', 'p')
-  new
-  file test/myapp_SUITE.erl
+    call mkdir('_build/test/lib/dep1/ebin', 'p')
+    new
+    file test/myapp_SUITE.erl
 
-  let args = neomake#makers#ft#erlang#GlobPaths()
-  let dep1_ebin_opt = args[6:7]
-  let dep1_include_opt = args[8:9]
-  AssertEqual ['-pa', root . '/_build/test/lib/dep1/ebin'], dep1_ebin_opt
-  AssertEqual ['-I', root . '/_build/test/lib/dep1/include'], dep1_include_opt
-  bwipe
-
-  execute 'cd ' . s:old_cwd
+    let args = neomake#makers#ft#erlang#GlobPaths()
+    let dep1_ebin_opt = args[6:7]
+    let dep1_include_opt = args[8:9]
+    AssertEqual ['-pa', root . '/_build/test/lib/dep1/ebin'], dep1_ebin_opt
+    AssertEqual ['-I', root . '/_build/test/lib/dep1/include'], dep1_include_opt
+    bwipe
+  finally
+    execute 'cd ' . old_cwd
+  endtry
 
 Execute (erlc: rebar2/erlang.mk deps/ present):
-  let root = tempname()
-  call mkdir(root, 'p')
-  let s:old_cwd = fnamemodify('.', ':p')
-  execute 'cd ' . root
+  let old_cwd = getcwd()
+  try
+    let root = tempname()
+    call mkdir(root, 'p')
+    execute 'cd ' . root
 
-  call mkdir('deps/dep1/ebin', 'p')
-  new
-  file src/myapp.erl
+    call mkdir('deps/dep1/ebin', 'p')
+    new
+    file src/myapp.erl
 
-  let args = neomake#makers#ft#erlang#GlobPaths()
-  let dep1_ebin_opt = args[6:7]
-  let dep1_include_opt = args[8:9]
-  AssertEqual ['-pa', root . '/deps/dep1/ebin'], dep1_ebin_opt
-  AssertEqual ['-I', root . '/deps/dep1/include'], dep1_include_opt
-  bwipe
-
-  execute 'cd ' . s:old_cwd
+    let args = neomake#makers#ft#erlang#GlobPaths()
+    let dep1_ebin_opt = args[6:7]
+    let dep1_include_opt = args[8:9]
+    AssertEqual ['-pa', root . '/deps/dep1/ebin'], dep1_ebin_opt
+    AssertEqual ['-I', root . '/deps/dep1/include'], dep1_include_opt
+    bwipe
+  finally
+    execute 'cd ' . old_cwd
+  endtry
 
 Execute (erlc: buffer local extra deps):
-  let root = tempname()
-  call mkdir(root, 'p')
-  let s:old_cwd = fnamemodify('.', ':p')
-  execute 'cd ' . root
+  let old_cwd = getcwd()
+  try
+    let root = tempname()
+    call mkdir(root, 'p')
+    execute 'cd ' . root
 
-  call mkdir('deps.local/dep1/ebin', 'p')
-  new
-  file src/myapp.erl
-  let b:neomake_erlang_erlc_extra_deps = ['deps.local']
+    call mkdir('deps.local/dep1/ebin', 'p')
+    new
+    file src/myapp.erl
+    let b:neomake_erlang_erlc_extra_deps = ['deps.local']
 
-  let args = neomake#makers#ft#erlang#GlobPaths()
-  let dep1_ebin_opt = args[6:7]
-  let dep1_include_opt = args[8:9]
-  AssertEqual ['-pa', 'deps.local/dep1/ebin'], dep1_ebin_opt
-  AssertEqual ['-I', 'deps.local/dep1/include'], dep1_include_opt
-  bwipe
-
-  execute 'cd ' . s:old_cwd
+    let args = neomake#makers#ft#erlang#GlobPaths()
+    let dep1_ebin_opt = args[6:7]
+    let dep1_include_opt = args[8:9]
+    AssertEqual ['-pa', 'deps.local/dep1/ebin'], dep1_ebin_opt
+    AssertEqual ['-I', 'deps.local/dep1/include'], dep1_include_opt
+    bwipe
+  finally
+    execute 'cd ' . old_cwd
+  endtry

--- a/tests/main.vader
+++ b/tests/main.vader
@@ -48,6 +48,7 @@ Include (Shell): ft_sh.vader
 Include (Text): ft_text.vader
 Include (Elixir): ft_elixir.vader
 Include (Elm): ft_elm.vader
+Include (Erlang): ft_erlang.vader
 Include (PHP): ft_php.vader
 Include (Cs): ft_cs.vader
 Include (Css): ft_css.vader


### PR DESCRIPTION
This maker does an educated guess about where `include` and `ebin` directories might be. It tries standard Rebar 3 paths, but also allows to set `g:erlang_extra_deps` to provide a custom file location. ~It uses relative paths, as it assumes that Vim is run in the project's directory and CWD is not changed to the file-being-edited location.~

It heavily follows the 80/20 rule, so the most common false errors in the majority of straightforward Rebar3 (and possibly old Rebar2) projects should be covered, but there are no guarantees. Still, it's way better than running `erlc` with no command line params at all.

It's my first 30 lines of VimScript, so I beg for mercy :)