### PR TITLE
logging: do not include context information always

### DIFF
--- a/autoload/neomake/log.vim
+++ b/autoload/neomake/log.vim
@@ -37,12 +37,16 @@ function! s:log(level, msg, ...) abort
         return
     endif
 
-    let msg = printf('[%s.%s:%s:%d] %s',
-                \ get(context, 'make_id', '-'),
-                \ get(context, 'id', '-'),
-                \ get(context, 'bufnr', get(context, 'file_mode', 0) ? '?' : '-'),
-                \ winnr(),
-                \ a:msg)
+    if a:0
+        let msg = printf('[%s.%s:%s:%d] %s',
+                    \ get(context, 'make_id', '-'),
+                    \ get(context, 'id', '-'),
+                    \ get(context, 'bufnr', get(context, 'file_mode', 0) ? '?' : '-'),
+                    \ winnr(),
+                    \ a:msg)
+    else
+        let msg = a:msg
+    endif
 
     " Use Vader's log for messages during tests.
     " @vimlint(EVL104, 1, l:timediff)

--- a/tests/isolated/logging.vader
+++ b/tests/isolated/logging.vader
@@ -40,8 +40,12 @@ Execute (neomake#log#debug handles missing make_options):
   let g:neomake_test_messages = []
 
 Execute (neomake#log#error uses echohl):
-  call neomake#log#error('some error.')
-  AssertEqual NeomakeTestsGetVimMessages(), ['Neomake: [-.-:-:1] some error.']
+  call neomake#log#error('some error with context.', {})
+  call neomake#log#error('some error without context.')
+  AssertEqual NeomakeTestsGetVimMessages(), [
+  \ 'Neomake: [-.-:-:1] some error with context.',
+  \ 'Neomake: some error without context.',
+  \ ]
 
 Execute (neomake#log#debug_obj does not call neomake#utils#Stringify if not necessary):
   Save g:neomake_verbose

--- a/tests/log.vader
+++ b/tests/log.vader
@@ -11,11 +11,11 @@ Execute (neomake#log#debug writes to logfile always):
   else
     let logfile_msg = readfile(g:neomake_logfile)[0]
   endif
-  Assert logfile_msg =~# '\v\d\d:\d\d:\d\d \[D      \] \[-.-:-:\d+\] msg2.$', 'unexpected msg: '.logfile_msg
+  Assert logfile_msg =~# '\v\d\d:\d\d:\d\d \[D      \] msg2.$', 'unexpected msg: '.logfile_msg
 
   call neomake#log#debug('msg3.')
   sleep 10m
-  call neomake#log#debug('msg4.')
+  call neomake#log#debug('msg4.', {})
   let logfile_msg = readfile(g:neomake_logfile)[-1]
   Assert logfile_msg =~# '\v\d\d:\d\d:\d\d \[D \+0.0\d\] \[-.-:-:\d+\] msg4.$', 'Message does not match: '.logfile_msg
 


### PR DESCRIPTION
This was changed in 5d46a240 recently, and now works again like before.