### PR TITLE
exclude vendor directories when running gometalinter

### DIFF
--- a/autoload/neomake/makers/ft/go.vim
+++ b/autoload/neomake/makers/ft/go.vim
@@ -58,7 +58,7 @@ function! neomake#makers#ft#go#gometalinter() abort
     "
     " All linters are only warnings, the go compiler will report errors
     return {
-        \ 'args': ['--disable-all', '--enable=errcheck', '--enable=megacheck'],
+        \ 'args': ['--disable-all', '--enable=errcheck', '--enable=megacheck', '--vendor'],
         \ 'append_file': 0,
         \ 'cwd': '%:h',
         \ 'errorformat':


### PR DESCRIPTION
without this option, gometalinter output will be crazy, so ignoring vendor directories is definitely preferable to most golang users.

https://github.com/alecthomas/gometalinter/issues/344