### PR TITLE
neovim: Windows: do not use `detach` by default

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -410,8 +410,11 @@ function! s:MakeJob(make_id, options) abort
                 if has_key(maker, 'nvim_job_opts')
                     call extend(opts, maker.nvim_job_opts)
                 endif
-                if !has('nvim-0.2.3') && !has_key(opts, 'detach') && !has_key(opts, 'pty')
-                    " Always use detach to trigger setsid().
+                if !has('nvim-0.3.0')
+                            \ && neomake#utils#IsRunningWindows()
+                            \ && !has_key(opts, 'detach')
+                            \ && !has_key(opts, 'pty')
+                    " Always use detach to trigger setsid() with older Neovim.
                     let opts.detach = 1
                 endif
                 try


### PR DESCRIPTION
Fixes https://github.com/neomake/neomake/issues/1955.