### PR TITLE
tests: bump Docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 
 common: &common
   docker:
-    - image: neomake/vims-for-tests:24@sha256:03d4327af38a81347e26fb66f669add51856aa45d2a9fed0bfa7882bc471326e
+    - image: neomake/vims-for-tests:25@sha256:96a5e30deacc856b34998209bfb06accd964aa9d7337fb4a7755547481016ce2
   working_directory: ~/repo
   steps:
     - checkout

--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -17,7 +17,7 @@ RUN install_vim -tag v7.3.429 -name vim73 --with-features=huge -build \
                 -tag neovim:v0.2.2 -py3 -build \
   && rm -rf /vim-build/vim/vim/*/share/vim/*/tutor
 
-ENV NEOMAKE_DOCKERFILE_UPDATE=2018-04-15
+ENV NEOMAKE_DOCKERFILE_UPDATE=2018-05-09
 
 # Git master in a separate layer, since the above is meant to be stable.
 RUN install_vim -tag master -build \

--- a/Makefile
+++ b/Makefile
@@ -177,7 +177,7 @@ vimhelplint: | $(if $(VIMHELPLINT_DIR),,build/vimhelplint)
 
 # Run tests in dockerized Vims.
 DOCKER_REPO:=neomake/vims-for-tests
-DOCKER_TAG:=24
+DOCKER_TAG:=25
 NEOMAKE_DOCKER_IMAGE?=
 DOCKER_IMAGE:=$(if $(NEOMAKE_DOCKER_IMAGE),$(NEOMAKE_DOCKER_IMAGE),$(DOCKER_REPO):$(DOCKER_TAG))
 DOCKER_STREAMS:=-ti

--- a/tests/customqf.vader
+++ b/tests/customqf.vader
@@ -96,7 +96,7 @@ Execute (Sets quickfix title (location list)):
     RunNeomake error_maker true
 
     " Location list entry contains marker.
-    AssertEqual getloclist(0), [
+    AssertEqualQf getloclist(0), [
     \ {'lnum': 1, 'bufnr': bufnr, 'col': 0, 'valid': 1, 'vcol': 0, 'nr': -1,
     \  'type': 'E', 'pattern': '',
     \  'text': 'error_msg_1 nmcfg:{''short'': ''errmkr'', ''name'': ''error_maker''}'}]

--- a/tests/cwd.vader
+++ b/tests/cwd.vader
@@ -195,7 +195,7 @@ Execute (get_list_entries: filename with cwd (non-existing file)):
   " uses unlisted buffer if file does not exist
   call neomake#Make(1, [maker])
   NeomakeTestsWaitForFinishedJobs
-  AssertEqual getloclist(0), [{
+  AssertEqualQf getloclist(0), [{
   \ 'lnum': 23,
   \ 'bufnr': bufnr + 1,
   \ 'col': 42,
@@ -222,7 +222,7 @@ Execute (get_list_entries: filename with cwd (non-existing file)):
     let expected_bufnr = unlisted_bufnr + 1
     let bwipe_buffers += [expected_bufnr]
   endif
-  AssertEqual getloclist(0), [{
+  AssertEqualQf getloclist(0), [{
   \ 'lnum': 23,
   \ 'bufnr': expected_bufnr,
   \ 'col': 42,
@@ -268,7 +268,7 @@ Execute (get_list_entries: filename with cwd):
   NeomakeTestsWaitForFinishedJobs
   AssertNeomakeMessage 'Updating entry bufnr: 0 => '.bufnr.'.'
 
-  AssertEqual getloclist(0), [{
+  AssertEqualQf getloclist(0), [{
   \ 'lnum': 23,
   \ 'bufnr': bufnr('%'),
   \ 'col': 42,
@@ -310,7 +310,7 @@ Execute (process_output: filename with cwd):
 
   AssertNeomakeMessage 'Updating entry bufnr: 0 => '.bufnr.'.'
 
-  AssertEqual getloclist(0), [{
+  AssertEqualQf getloclist(0), [{
   \ 'lnum': 23,
   \ 'bufnr': bufnr('%'),
   \ 'col': 42,
@@ -345,7 +345,7 @@ Execute (legacy errorformat maker: filename with cwd):
   call neomake#Make(1, [maker])
   NeomakeTestsWaitForFinishedJobs
 
-  AssertEqual getloclist(0), [{
+  AssertEqualQf getloclist(0), [{
   \ 'lnum': 23,
   \ 'bufnr': bufnr('%'),
   \ 'col': 42,
@@ -412,7 +412,7 @@ Execute (legacy errorformat maker: filename with cwd (error: removed)):
   endif
 
   " Filtering out 'shell-init: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory'
-  AssertEqual filter(getloclist(0), "v:val.text !~# '^shell-init'"), [{
+  AssertEqualQf filter(getloclist(0), "v:val.text !~# '^shell-init'"), [{
   \ 'lnum': 23,
   \ 'bufnr': expected_bufnr,
   \ 'col': 42,
@@ -453,7 +453,7 @@ Execute (legacy errorformat maker: filename with cwd (error: maker rmdir)):
   AssertNotEqual bufnr('%'), unlisted_bufnr
 
   " Filtering out 'shell-init: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory'
-  AssertEqual filter(getloclist(0), "v:val.text !~# '^shell-init'"), [{
+  AssertEqualQf filter(getloclist(0), "v:val.text !~# '^shell-init'"), [{
   \ 'lnum': 23,
   \ 'bufnr': unlisted_bufnr,
   \ 'col': 42,

--- a/tests/ft_asciidoc.vader
+++ b/tests/ft_asciidoc.vader
@@ -10,7 +10,7 @@ Execute (asciidoc):
   \ "asciidoc: WARNING: t.asciidoc: line 1: include file not found: /etc/asciidoc/asciidoc.css\n".
   \ 'asciidoc: ERROR: t.asciidoc: line 2: only book doctypes can contain level 0 sections'
 
-  AssertEqual getloclist(0), [
+  AssertEqualQf getloclist(0), [
   \ {'lnum': 1,
   \  'bufnr': bufnr('%'),
   \  'col': 0,

--- a/tests/ft_cs.vader
+++ b/tests/ft_cs.vader
@@ -7,7 +7,7 @@ Execute (cs: msbuild: errorformat):
   file FooBar.cs
 
   lgetexpr "FooBar.cs(21,63): error CS1002: ; expected [Foo\Foobar.csproj]"
-  AssertEqual getloclist(0), [{
+  AssertEqualQf getloclist(0), [{
     \ 'lnum': 21,
     \ 'bufnr': bufnr('%'),
     \ 'col': 63,
@@ -19,7 +19,7 @@ Execute (cs: msbuild: errorformat):
     \ 'text': "; expected"}]
 
   lgetexpr "FooBar.cs(25,29): warning CS0168: The variable 'ex' is declared but never used [Foo\Foobar.csproj]"
-  AssertEqual getloclist(0), [{
+  AssertEqualQf getloclist(0), [{
     \ 'lnum': 25,
     \ 'bufnr': bufnr('%'),
     \ 'col': 29,

--- a/tests/ft_css.vader
+++ b/tests/ft_css.vader
@@ -11,7 +11,7 @@ Execute (csslint: errorformat):
   Save &errorformat
   let &errorformat = neomake#makers#ft#css#csslint().errorformat
   lgetexpr output
-  AssertEqual getloclist(0), [
+  AssertEqualQf getloclist(0), [
   \ {'lnum': 315, 'bufnr': bufnr('%'), 'col': 1, 'valid': 1, 'vcol': 0,
   \  'nr': -1, 'type': 'W', 'pattern': '',
   \  'text': 'Don''t use IDs in selectors. (ids)'},
@@ -72,7 +72,7 @@ Execute (stylelint: error with no config):
   CallNeomake 1, [maker]
 
   let bufnr = bufnr('/path/to/foo.css')
-  AssertEqual getloclist(0), [{
+  AssertEqualQf getloclist(0), [{
   \ 'lnum': 0, 'bufnr': bufnr, 'col': 0, 'valid': 1, 'vcol': 0,
   \ 'nr': -1, 'type': 'E', 'pattern': '',
   \ 'text': 'Error: No configuration provided for /path/to/foo.css'}]

--- a/tests/ft_go.vader
+++ b/tests/ft_go.vader
@@ -18,7 +18,7 @@ Execute (go: go):
   AssertNeomakeMessage printf('cwd: %s/build (changed).', getcwd())
   AssertNeomakeMessage 'unnamed_maker: processing 3 lines of output.'
   AssertNeomakeMessage 'Processing 1 entries.'
-  AssertEqual getloclist(0), [
+  AssertEqualQf getloclist(0), [
   \ {'lnum': 24, 'bufnr': bufnr('%'), 'col': 2, 'valid': 1, 'vcol': 0,
   \  'nr': -1, 'type': 'E', 'pattern': '',
   \  'text': 'cannot find package "bytes" in any of: '
@@ -32,7 +32,7 @@ Execute (go: gometalinter):
 
   let &efm = neomake#makers#ft#go#gometalinter().errorformat
   lgetexpr 'git.go:17::warning: Subprocess launching with variable.,HIGH,HIGH (gas)'
-  AssertEqual getloclist(0), [
+  AssertEqualQf getloclist(0), [
   \ {'lnum': 17, 'bufnr': bufnr('%'), 'col': 0, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': 'w', 'pattern': '', 'text': 'Subprocess launching with variable.,HIGH,HIGH (gas)'},
   \ ]
   bwipe

--- a/tests/ft_javascript.vader
+++ b/tests/ft_javascript.vader
@@ -14,7 +14,7 @@ Execute (javascript: eslint: errorformat):
   \ ]
 
   lgetexpr output
-  AssertEqual getloclist(0), [{
+  AssertEqualQf getloclist(0), [{
     \ 'lnum': 2,
     \ 'bufnr': bufnr,
     \ 'col': 10,
@@ -33,7 +33,7 @@ Execute (javascript: eslint: errorformat):
   \ ]
 
   lgetexpr output
-  AssertEqual getloclist(0), [{
+  AssertEqualQf getloclist(0), [{
     \ 'lnum': 2,
     \ 'bufnr': bufnr,
     \ 'col': 10,
@@ -67,13 +67,13 @@ Execute (javascript: standard: errorformat):
   \ '  /path/to/file.js:1:1: Expected an assignment or function call and instead saw an expression. (no-unused-expressions)',
   \ ]
   lgetexpr output
-  AssertEqual getloclist(0), [{
+  AssertEqualQf getloclist(0), [{
   \ 'lnum': 1, 'bufnr': bufnr('%'), 'col': 1, 'valid': 1, 'vcol': 0,
   \ 'nr': -1, 'type': 'W', 'pattern': '',
   \ 'text': 'Expected an assignment or function call and instead saw an expression. (no-unused-expressions)'}]
   bwipe
 
-Execute (javascript: flow):
+Execute (javascript: flow: no errors):
   new
   let flow_maker = NeomakeTestsGetMakerWithOutput('neomake#makers#ft#javascript#flow', [
     \ 'No errors!',

--- a/tests/ft_python.vader
+++ b/tests/ft_python.vader
@@ -7,7 +7,7 @@ Execute (python: errorformat):
   Neomake python
   NeomakeTestsWaitForFinishedJobs
 
-  AssertEqual getloclist(0), [{
+  AssertEqualQf getloclist(0), [{
   \ 'lnum': 1,
   \ 'bufnr': bufnr('%'),
   \ 'col': 22,
@@ -25,14 +25,14 @@ Execute (python: pylama: errorformat):
   new
   file file1.py
   lgetexpr "file1.py:16:1: [C] C901 'load_library' is too complex (13) [mccabe]"
-  AssertEqual getloclist(0), [
+  AssertEqualQf getloclist(0), [
     \ {'lnum': 16, 'bufnr': bufnr('%'), 'col': 1, 'valid': 1, 'vcol': 0,
     \  'nr': -1, 'type': 'C', 'pattern': '',
     \  'text': 'C901 ''load_library'' is too complex (13) [mccabe]'}]
 
   let e = getloclist(0)[0]
   call neomake#makers#ft#python#PylamaEntryProcess(e)
-  AssertEqual e, {
+  AssertEqualQf [e], [{
   \ 'lnum': 16,
   \ 'bufnr': bufnr('%'),
   \ 'col': 1,
@@ -41,7 +41,7 @@ Execute (python: pylama: errorformat):
   \ 'nr': 901,
   \ 'type': 'I',
   \ 'pattern': '',
-  \ 'text': "C901 'load_library' is too complex (13) [mccabe]"}
+  \ 'text': "C901 'load_library' is too complex (13) [mccabe]"}]
   bwipe
 
 Execute (python: pylama: cwd):
@@ -71,14 +71,14 @@ Execute (python: flake8: errorformat/postprocess: F811):
   norm ofrom os import os
   lgetexpr "file1.py:2:1: F811 redefinition of unused 'os' from line 1"
 
-  AssertEqual [
+  AssertEqualQf getloclist(0), [
   \ {'lnum': 2, 'bufnr': bufnr('%'), 'col': 1, 'valid': 1, 'vcol': 0,
   \  'nr': 811, 'type': 'F', 'pattern': '',
-  \  'text': "redefinition of unused 'os' from line 1"}], getloclist(0)
+  \  'text': "redefinition of unused 'os' from line 1"}]
 
   let e = getloclist(0)[0]
   call neomake#makers#ft#python#Flake8EntryProcess(e)
-  AssertEqual {
+  AssertEqualQf [e], [{
   \ 'lnum': 2,
   \ 'bufnr': bufnr('%'),
   \ 'col': 21,
@@ -88,18 +88,18 @@ Execute (python: flake8: errorformat/postprocess: F811):
   \ 'nr': '',
   \ 'length': 2,
   \ 'type': 'E',
-  \ 'text': "F811 redefinition of unused 'os' from line 1"}, e
+  \ 'text': "F811 redefinition of unused 'os' from line 1"}]
 
   lgetexpr "file1.py:3:1: F811 redefinition of unused 'os' from line 2"
 
-  AssertEqual [
+  AssertEqualQf getloclist(0), [
   \ {'lnum': 3, 'bufnr': bufnr('%'), 'col': 1, 'valid': 1, 'vcol': 0,
   \  'nr': 811, 'type': 'F', 'pattern': '',
-  \  'text': "redefinition of unused 'os' from line 2"}], getloclist(0)
+  \  'text': "redefinition of unused 'os' from line 2"}]
 
   let e = getloclist(0)[0]
   call neomake#makers#ft#python#Flake8EntryProcess(e)
-  AssertEqual {
+  AssertEqualQf [e], [{
   \ 'lnum': 3,
   \ 'bufnr': bufnr('%'),
   \ 'col': 16,
@@ -109,7 +109,7 @@ Execute (python: flake8: errorformat/postprocess: F811):
   \ 'nr': '',
   \ 'length': 2,
   \ 'type': 'E',
-  \ 'text': "F811 redefinition of unused 'os' from line 2"}, e
+  \ 'text': "F811 redefinition of unused 'os' from line 2"}]
   bwipe!
 
 Execute (flake8: postprocess for F821 in continuous f-strings):
@@ -194,15 +194,15 @@ Execute (python: flake8):
   lgetexpr 'foo/bar.py:90:1: I001 isort found an import in the wrong position'
   let llist = getloclist(0)
   let bufnr = bufnr('%')
-  AssertEqual llist, [
+  AssertEqualQf llist, [
   \ {'lnum': 90, 'bufnr': bufnr, 'col': 1, 'valid': 1, 'vcol': 0,
   \  'nr': 1, 'type': 'I', 'pattern': '',
   \  'text': 'isort found an import in the wrong position'}]
   let entry = llist[0]
   call neomake#makers#ft#python#Flake8EntryProcess(entry)
-  AssertEqual entry, {'lnum': 90, 'bufnr': bufnr, 'col': 1, 'valid': 1,
+  AssertEqualQf [entry], [{'lnum': 90, 'bufnr': bufnr, 'col': 1, 'valid': 1,
   \ 'vcol': 0, 'nr': '', 'type': 'I', 'pattern': '',
-  \ 'text': 'I1 isort found an import in the wrong position'}
+  \ 'text': 'I1 isort found an import in the wrong position'}]
   bwipe
 
 Execute (python: flake8: supports_stdin):

--- a/tests/ft_rst.vader
+++ b/tests/ft_rst.vader
@@ -10,7 +10,7 @@ Execute (rst: rstlint: errorformat):
   \ 'unknown option: "linenos".',
   \ ]
   lgetexpr output
-  AssertEqual getloclist(0), [
+  AssertEqualQf getloclist(0), [
   \ {'lnum': 40, 'bufnr': bufnr('%'), 'col': 0, 'valid': 1, 'vcol': 0,
   \  'nr': -1, 'type': 'E', 'pattern': '',
   \  'text': 'Error in "code-block" directive:'."\n".'unknown option: "linenos".',
@@ -19,7 +19,7 @@ Execute (rst: rstlint: errorformat):
   " Newline gets trimmed when going through postprocess.
   let maker = NeomakeTestsGetMakerWithOutput('neomake#makers#ft#rst#rstlint', output)
   CallNeomake 1, [maker]
-  AssertEqual getloclist(0), [
+  AssertEqualQf getloclist(0), [
   \ {'lnum': 40, 'bufnr': bufnr('%'), 'col': 0, 'valid': 1, 'vcol': 0,
   \  'nr': -1, 'type': 'E', 'pattern': '',
   \  'text': 'Error in "code-block" directive: unknown option: "linenos".',
@@ -103,27 +103,22 @@ Execute (rst: sphinx: handles docutils warnings and adds first additional line):
   let unlisted_bufnr = bufnr('/some/path/inline.rst')
   let bufnr = bufnr('%')
 
-  let loclist = getloclist(0)
-  AssertEqual len(loclist), 5, 'loclist should have 5 entries: '.string(loclist)
-  AssertEqual loclist[0],
+  AssertEqualQf getloclist(0), [
   \ {'lnum': 8, 'bufnr': unlisted_bufnr, 'col': 0, 'valid': 1, 'vcol': 0,
   \  'nr': -1, 'type': 'E', 'pattern': '',
-  \  'text': 'Malformed table. No bottom table border found.'}
-  AssertEqual loclist[1],
+  \  'text': 'Malformed table. No bottom table border found.'},
   \ {'lnum': 9, 'bufnr': unlisted_bufnr, 'col': 0, 'valid': 1, 'vcol': 0,
   \  'nr': -1, 'type': 'W', 'pattern': '',
-  \  'text': 'Block quote ends without a blank line; unexpected unindent.'}
-  AssertEqual loclist[2],
+  \  'text': 'Block quote ends without a blank line; unexpected unindent.'},
   \ {'lnum': 40, 'bufnr': unlisted_bufnr, 'col': 0, 'valid': 1, 'vcol': 0,
   \  'nr': -1, 'type': 'E', 'pattern': '',
-  \  'text': 'Error in "code-block" directive: unknown option: "linenoss".'}
-  AssertEqual loclist[3],
+  \  'text': 'Error in "code-block" directive: unknown option: "linenoss".'},
   \ {'lnum': 70, 'bufnr': bufnr, 'col': 0, 'valid': 1, 'vcol': 0,
   \  'nr': -1, 'type': 'W', 'pattern': '',
-  \  'text': 'numfig is disabled. :numref: is ignored.'}
-  AssertEqual loclist[4],
+  \  'text': 'numfig is disabled. :numref: is ignored.'},
   \ {'lnum': 71, 'bufnr': bufnr, 'col': 0, 'valid': 1, 'vcol': 0,
   \  'nr': -1, 'type': 'W', 'pattern': '',
   \  'text': 'numfig is disabled. :numref: is ignored.'}
+  \ ]
   exe 'bwipe' unlisted_bufnr
   bwipe

--- a/tests/ft_sh.vader
+++ b/tests/ft_sh.vader
@@ -86,20 +86,21 @@ Execute (Test Neomake on errors.sh with shellcheck):
   RunNeomake shellcheck
   AssertEqual len(g:neomake_test_finished), 1
   AssertNeomakeMessage 'Running makers: shellcheck.'
-  AssertEqual getloclist(0)[0], {
+  AssertEqualQf getloclist(0), [{
   \ 'lnum': 3, 'bufnr': bufnr, 'col': 1, 'valid': 1, 'vcol': 0, 'nr': 2034,
-  \ 'type': 'w', 'pattern': '', 'text': 'a appears unused. Verify it or export it.'}
-  AssertEqual getloclist(0)[1], {
+  \ 'type': 'w', 'pattern': '', 'text': 'a appears unused. Verify it or export it.',
+  \ }, {
   \ 'lnum': 3, 'bufnr': bufnr, 'col': 3, 'valid': 1, 'vcol': 0, 'nr': 2016,
-  \ 'type': 'I', 'pattern': '', 'text': 'Expressions don''t expand in single quotes, use double quotes for that.'}
-  AssertEqual getloclist(0)[2], {
+  \ 'type': 'I', 'pattern': '', 'text': 'Expressions don''t expand in single quotes, use double quotes for that.',
+  \ }, {
   \ 'lnum': 5, 'bufnr': bufnr, 'col': 4, 'valid': 1, 'vcol': 0, 'nr': 1036,
-  \ 'type': 'e', 'pattern': '', 'text': '''('' is invalid here. Did you forget to escape it?'}
-  AssertEqual getloclist(0)[3], {
+  \ 'type': 'e', 'pattern': '', 'text': '''('' is invalid here. Did you forget to escape it?',
+  \ }, {
   \ 'lnum': 5, 'bufnr': bufnr, 'col': 4, 'valid': 1, 'vcol': 0, 'nr': 1088,
-  \ 'type': 'e', 'pattern': '', 'text': 'Parsing stopped here. Invalid use of parentheses?'}
-  AssertEqual getloclist(0)[4], {
+  \ 'type': 'e', 'pattern': '', 'text': 'Parsing stopped here. Invalid use of parentheses?',
+  \ }, {
   \ 'lnum': 5, 'bufnr': bufnr, 'col': 4, 'valid': 1, 'vcol': 0, 'nr': 1065,
-  \ 'type': 'e', 'pattern': '', 'text': 'Trying to declare parameters? Don''t. Use () and refer to params as $1, $2..'}
+  \ 'type': 'e', 'pattern': '', 'text': 'Trying to declare parameters? Don''t. Use () and refer to params as $1, $2..',
+  \ }]
   AssertNeomakeMessage 'exit: shellcheck: 1.', 3
   bwipe

--- a/tests/ft_text.vader
+++ b/tests/ft_text.vader
@@ -30,7 +30,7 @@ Execute (proselint):
   \ "file.txt:2:9: weasel_words.very Substitute 'damn' every time you're inclined to write 'very;' your editor will delete it and the writing will be just as it should be."])
   norm! Gdd
   lgetbuffer
-  AssertEqual getloclist(0), [
+  AssertEqualQf getloclist(0), [
   \ {'lnum': 1, 'bufnr': bufnr('%'), 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1,
   \  'type': 'W', 'pattern': '', 'text': 'typography.symbols.ellipsis ''...'' is an approximation, use the ellipsis symbol ''…''.'},
   \ {'lnum': 2, 'bufnr': bufnr('%'), 'col': 9, 'valid': 1, 'vcol': 0, 'nr': -1,
@@ -75,7 +75,7 @@ Execute (writegood: handles wrapped message):
   \ 'README.md:2:1:something else']
 
   let bufnr = bufnr('README.md')
-  AssertEqual getloclist(0), [
+  AssertEqualQf getloclist(0), [
   \ {'lnum': 1, 'bufnr': bufnr, 'col': 73, 'valid': 1, 'vcol': 0, 'nr': -1,
   \  'type': 'W', 'pattern': '', 'text': "\"be\nused\" may be passive voice"},
   \ {'lnum': 2, 'bufnr': bufnr, 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1,

--- a/tests/ft_typescript.vader
+++ b/tests/ft_typescript.vader
@@ -10,7 +10,7 @@ Execute (typescript: tslint):
   lgetexpr
   \ "\nERROR: t.ts[7, 15]: Missing semicolon\n"
 
-  AssertEqual getloclist(0), [{
+  AssertEqualQf getloclist(0), [{
   \ 'lnum': 7,
   \ 'bufnr': bufnr('%'),
   \ 'col': 15,
@@ -32,7 +32,7 @@ Execute (typescript: tsc):
   lgetexpr
   \ "t.ts(13,7): error TS2322: Type '0' is not assignable to type 'string'."
 
-  AssertEqual getloclist(0), [{
+  AssertEqualQf getloclist(0), [{
   \ 'lnum': 13,
   \ 'bufnr': bufnr('%'),
   \ 'col': 7,

--- a/tests/ft_vim.vader
+++ b/tests/ft_vim.vader
@@ -20,7 +20,7 @@ Execute (Vint: generic postprocessing for highlights):
   call neomake#Make(1, [vint_maker])
   NeomakeTestsWaitForFinishedJobs
   let bufnr = bufnr('%')
-  AssertEqual getloclist(0), [{
+  AssertEqualQf getloclist(0), [{
   \ 'lnum': 1,
   \ 'bufnr': bufnr,
   \ 'col': 6,
@@ -73,22 +73,22 @@ Execute (vimlint: errorformat):
   new
   file testfile.vim
   lgetexpr 'testfile.vim:33:12:Error: EVP_0: unexpected EOL'
-  AssertEqual getloclist(0), [{
+  AssertEqualQf getloclist(0), [{
   \ 'lnum': 33, 'bufnr': bufnr('%'), 'col': 12, 'valid': 1, 'vcol': 0,
   \ 'nr': 0, 'type': 'E', 'pattern': '', 'text': 'unexpected EOL'}]
 
   lgetexpr 'testfile.vim:2:0:Error: EVP_E171: Missing :endif:    TOPLEVEL'
-  AssertEqual getloclist(0), [{
+  AssertEqualQf getloclist(0), [{
   \ 'lnum': 2, 'bufnr': bufnr('%'), 'col': 0, 'valid': 1, 'vcol': 0,
   \ 'nr': 171, 'type': 'E', 'pattern': '', 'text': 'Missing :endif:    TOPLEVEL'}]
 
   lgetexpr 'testfile.vim:1:1:Error: EVL204: constant in conditional context'
-  AssertEqual getloclist(0), [{
+  AssertEqualQf getloclist(0), [{
   \ 'lnum': 1, 'bufnr': bufnr('%'), 'col': 1, 'valid': 1, 'vcol': 0,
   \ 'nr': 204, 'type': 'E', 'pattern': '', 'text': 'constant in conditional context'}]
 
   lgetexpr 'testfile.vim:2:1:Warning: EVL204: constant in conditional context'
-  AssertEqual getloclist(0), [{
+  AssertEqualQf getloclist(0), [{
   \ 'lnum': 2, 'bufnr': bufnr('%'), 'col': 1, 'valid': 1, 'vcol': 0,
   \ 'nr': 204, 'type': 'W', 'pattern': '', 'text': 'constant in conditional context'}]
   bwipe

--- a/tests/ft_xml.vader
+++ b/tests/ft_xml.vader
@@ -22,7 +22,7 @@ Execute (xml: xmllint: missing dtd):
   AssertNeomakeMessage '\vUsed bufnr from stdin buffer \d+ \(tests/fixtures/input/xmllint/missingdtd.xml\) for 2 entries: 1, 2.'
 
   let bufnr = bufnr('%')
-  AssertEqual getloclist(0), [{
+  AssertEqualQf getloclist(0), [{
   \ 'lnum': 2,
   \ 'bufnr': bufnr,
   \ 'col': 36,

--- a/tests/include/init.vim
+++ b/tests/include/init.vim
@@ -248,6 +248,15 @@ function! s:AssertNeomakeMessage(msg, ...)
 endfunction
 command! -nargs=+ AssertNeomakeMessage call s:AssertNeomakeMessage(<args>)
 
+function! s:AssertEqualQf(actual, expected, ...) abort
+  let expected = a:expected
+  if has('patch-8.0.1782')
+    let expected = map(copy(expected), "extend(v:val, {'module': ''})")
+  endif
+  call call('vader#assert#equal', [a:actual, expected] + a:000)
+endfunction
+command! -nargs=1 AssertEqualQf call s:AssertEqualQf(<args>)
+
 function! s:AssertNeomakeMessageAbsent(msg, ...)
   try
     call call('s:AssertNeomakeMessage', [a:msg] + a:000)

--- a/tests/integration.vader
+++ b/tests/integration.vader
@@ -170,7 +170,7 @@ Execute (Test Neomake on errors.sh with two makers):
   AssertEqual len(g:neomake_test_finished), 1
   AssertNeomakeMessage 'Running makers: sh, shellcheck.'
   AssertNeomakeMessage printf(
-  \ "Skipped 1 entries without bufnr: [{'lnum': 0, 'bufnr': 0, 'col': 0, 'valid': 0, 'vcol': 0, 'nr': -1, 'type': 'W', 'maker_name': 'shellcheck', 'pattern': '', 'text': 'shellcheck -fgcc -x %s'}].",
+  \ "\\vSkipped 1 entries without bufnr: [{'lnum': 0, 'bufnr': 0, .*'text': 'shellcheck -fgcc -x %s'}].",
   \ expand('%:p')), 3
   bwipe
 
@@ -343,7 +343,7 @@ Execute (NeomakeSh: echo foo):
   AssertEqual g:neomake_test_countschanged, []
   let bufnr = bufnr('%')
   RunNeomakeSh echo foo
-  AssertEqual getqflist(),
+  AssertEqualQf getqflist(),
     \ [{'lnum': 0, 'bufnr': 0, 'col': 0, 'valid': 1, 'vcol': 0, 'nr': -1,
     \   'type': '', 'pattern': '', 'text': 'foo'}]
   AssertEqual len(g:neomake_test_finished), 1
@@ -697,10 +697,10 @@ Execute (Neomake: remove_invalid_entries and default entry type):
       \ })
   call neomake#Make(1, [maker])
   NeomakeTestsWaitForFinishedJobs
-  AssertNeomakeMessage "Removing invalid entry: invalid ({'lnum': 0, 'bufnr': 0, 'col': 0, 'valid': 0, 'vcol': 0, 'nr': -1, 'type': '', 'maker_name': 'custom_maker', 'pattern': ''})."
+  AssertNeomakeMessage "\\vRemoving invalid entry: invalid \\(\\{'lnum': 0, 'bufnr': 0, .*\\}\\)."
 
   let valid = has('patch-8.0.0580')
-  AssertEqual getloclist(0),
+  AssertEqualQf getloclist(0),
     \ [{'lnum': 0, 'bufnr': 0, 'col': 0, 'valid': valid, 'vcol': 0, 'nr': -1, 'type': 'W', 'pattern': '', 'text': 'valid'}]
 
 Execute (Neomake: entry.valid < 0 and configured entry type):
@@ -728,12 +728,12 @@ Execute (Neomake: entry.valid < 0 and configured entry type):
   call neomake#Make(1, [maker])
   NeomakeTestsWaitForFinishedJobs
   AssertNeomakeMessage 'custom_maker: processing 4 lines of output.'
-  AssertNeomakeMessage "Removing invalid entry: invalid ({'lnum': 0, 'bufnr': 0, 'col': 0, 'valid': -1, 'vcol': 0, 'nr': -1, 'type': '', 'maker_name': 'custom_maker', 'pattern': ''})."
+  AssertNeomakeMessage "\\vRemoving invalid entry: invalid \\(\\{'lnum': 0, 'bufnr': 0, 'col': 0, 'valid': -1, .*\\}\\)."
   AssertNeomakeMessage 'Processing 3 entries.'
 
   " Without this patch entries are invalid always after setqflist/setloclist.
   let valid = has('patch-8.0.0580')
-  AssertEqual getloclist(0), [
+  AssertEqualQf getloclist(0), [
     \ {'lnum': 0, 'bufnr': 0, 'col': 0, 'valid': valid, 'vcol': 0, 'nr': -1, 'type': 'I', 'pattern': '', 'text': 'valid'},
     \ {'lnum': 0, 'bufnr': 0, 'col': 0, 'valid': 0, 'vcol': 0, 'nr': -1, 'type': 'I', 'pattern': '', 'text': 'invalid_but_kept'},
     \ {'lnum': 0, 'bufnr': 0, 'col': 0, 'valid': valid, 'vcol': 0, 'nr': -1, 'type': 'I', 'pattern': '', 'text': 'invalid_but_kept_as_valid'}]
@@ -753,30 +753,30 @@ Execute (Neomake: append_file from settings and empty entry type):
   call neomake#Make(1, [maker])
   let bufname = expand('%:p')
   NeomakeTestsWaitForFinishedJobs
-  AssertEqual getloclist(0),
+  AssertEqualQf getloclist(0),
     \ [{'lnum': 0, 'bufnr': 0, 'col': 0, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'output '.bufname}]
 
   Save g:neomake_myft_custom_maker_maker, g:neomake_myft_custom_maker_append_file
   let g:neomake_myft_custom_maker_maker = copy(maker)
   let g:neomake_myft_custom_maker_append_file = 0
   RunNeomake custom_maker
-  AssertEqual getloclist(0),
+  AssertEqualQf getloclist(0),
     \ [{'lnum': 0, 'bufnr': 0, 'col': 0, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'output'}]
   let g:neomake_myft_custom_maker_append_file = 1
   RunNeomake custom_maker
-  AssertEqual getloclist(0),
+  AssertEqualQf getloclist(0),
     \ [{'lnum': 0, 'bufnr': 0, 'col': 0, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'output '.bufname}]
 
   let maker.append_file = 0
   call neomake#Make(1, [maker])
   NeomakeTestsWaitForFinishedJobs
-  AssertEqual getloclist(0),
+  AssertEqualQf getloclist(0),
     \ [{'lnum': 0, 'bufnr': 0, 'col': 0, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'output '.bufname}]
 
   unlet g:neomake_myft_custom_maker_append_file
   call neomake#Make(1, [maker])
   NeomakeTestsWaitForFinishedJobs
-  AssertEqual getloclist(0),
+  AssertEqualQf getloclist(0),
     \ [{'lnum': 0, 'bufnr': 0, 'col': 0, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'output'}]
   bwipe
 
@@ -911,7 +911,7 @@ Execute (Highlights should be cleared after successful run):
   NeomakeTestsWaitForFinishedJobs
 
   AssertEqual getloclist(0)[0].text, 'error'
-  AssertEqual getloclist(0), [{
+  AssertEqualQf getloclist(0), [{
   \ 'lnum': 1,
   \ 'bufnr': bufnr('%'),
   \ 'col': 1,

--- a/tests/isolated/highlights.vader
+++ b/tests/isolated/highlights.vader
@@ -28,7 +28,7 @@ Execute (vimlint: length postprocessing):
   NeomakeTestsWaitForFinishedJobs
 
   let bufnr = bufnr('%')
-  AssertEqual [{
+  AssertEqualQf getloclist(0), [{
     \ 'lnum': 2,
     \ 'bufnr': bufnr,
     \ 'col': 6,
@@ -48,7 +48,7 @@ Execute (vimlint: length postprocessing):
     \ 'type': 'E',
     \ 'pattern': '',
     \ 'text': 'variable may not be initialized on some execution path: `l:foo`',
-    \ }], getloclist(0)
+    \ }]
 
   AssertEqual {string(bufnr): [[2, 11], [5, 3]]}, g:neomake_tests_highlight_lengths
 
@@ -67,7 +67,7 @@ Execute (vint: highlights syntax error for command):
 
   CallNeomake 1, [vint_maker]
   let bufnr = bufnr('%')
-  AssertEqual getloclist(0), [{
+  AssertEqualQf getloclist(0), [{
   \ 'lnum': 2,
   \ 'bufnr': bufnr,
   \ 'col': 1,
@@ -128,7 +128,7 @@ Execute (get_list_entries: based on example from doc):
   " Check that existing buffer was used for filename.
   AssertEqual llist[4].bufnr, buf1, 'get_list_entries_buf1 was picked up'
 
-  AssertEqual llist, [
+  AssertEqualQf llist, [
   \ {'lnum': 1, 'bufnr': buf1, 'col': 0, 'valid': 1, 'vcol': 0, 'nr': -1,
   \  'type': 'E', 'pattern': '', 'text': 'Some error'},
   \ {'lnum': 2, 'bufnr': 0, 'col': 1, 'valid': 0, 'vcol': 0, 'nr': -1,
@@ -159,7 +159,7 @@ Execute (cargo error message):
   NeomakeTestsWaitForFinishedJobs
 
   let bufnr = bufnr('%')
-  AssertEqual [{
+  AssertEqualQf getloclist(0), [{
     \ 'type': 'E',
     \ 'bufnr': bufnr,
     \ 'nr': 308,
@@ -189,7 +189,7 @@ Execute (cargo error message):
     \ 'vcol': 0,
     \ 'pattern': '',
     \ 'text': 'found type `&proc_macro::TokenStream`'
-    \ }], getloclist(0)
+    \ }]
 
   " TODO: should not call it for the same highlight twice?!
   AssertEqual {string(bufnr): [[19, 2], [25, 40], [25, 40]]}, g:neomake_tests_highlight_lengths
@@ -207,7 +207,7 @@ Execute (cargo warning message):
   NeomakeTestsWaitForFinishedJobs
 
   let bufnr = bufnr('%')
-  AssertEqual [{
+  AssertEqualQf getloclist(0), [{
     \ 'type': 'W',
     \ 'bufnr': bufnr,
     \ 'nr': -1,
@@ -216,7 +216,7 @@ Execute (cargo warning message):
     \ 'valid': 1,
     \ 'vcol': 0,
     \ 'pattern': '',
-    \ 'text': 'unused import: `Variant`, #[warn(unused_imports)] on by default'}], getloclist(0)
+    \ 'text': 'unused import: `Variant`, #[warn(unused_imports)] on by default'}]
 
   AssertEqual {string(bufnr): [[2, 7]]}, g:neomake_tests_highlight_lengths
   bwipe
@@ -236,7 +236,7 @@ Execute (cargo warning for file that is not open):
   let unlisted_bufnr = bufnr('^build/add_assign_like.rs$')
   AssertNotEqual -1, unlisted_bufnr
 
-  AssertEqual [{
+  AssertEqualQf getloclist(0), [{
     \ 'type': 'W',
     \ 'bufnr': unlisted_bufnr,
     \ 'nr': -1,
@@ -245,7 +245,7 @@ Execute (cargo warning for file that is not open):
     \ 'valid': 1,
     \ 'vcol': 0,
     \ 'pattern': '',
-    \ 'text': 'unused import: `Variant`, #[warn(unused_imports)] on by default'}], getloclist(0)
+    \ 'text': 'unused import: `Variant`, #[warn(unused_imports)] on by default'}]
 
   AssertEqual {string(unlisted_bufnr): [[2, 7]]}, g:neomake_tests_highlight_lengths
   bwipe
@@ -262,7 +262,7 @@ Execute (cargo error message children):
   NeomakeTestsWaitForFinishedJobs
 
   let bufnr = bufnr('%')
-  AssertEqual [{
+  AssertEqualQf getloclist(0), [{
     \ 'type': 'E',
     \ 'bufnr': bufnr,
     \ 'nr': -1,
@@ -271,7 +271,7 @@ Execute (cargo error message children):
     \ 'valid': 1,
     \ 'vcol': 0,
     \ 'pattern': '',
-    \ 'text': 'custom derive attribute panicked. message: Only structs and enums can derive From'}], getloclist(0)
+    \ 'text': 'custom derive attribute panicked. message: Only structs and enums can derive From'}]
 
   AssertEqual {string(bufnr): [[11, 4]]}, g:neomake_tests_highlight_lengths
   bwipe

--- a/tests/makers.vader
+++ b/tests/makers.vader
@@ -327,7 +327,7 @@ Execute (Makers: process_output):
   let expected.valid = 1
   " filename is removed
   unlet expected.filename
-  AssertEqual getloclist(0), [expected]
+  AssertEqualQf getloclist(0), [expected]
 
   AssertEqual len(g:neomake_test_countschanged), 1
   AssertEqual len(g:neomake_test_jobfinished), 1
@@ -366,7 +366,7 @@ Execute (Makers: get_list_entries):
   let expected = map(copy(g:neomake_test_entries), "extend(v:val, {'valid': 1})")
   " filename and maker_name is removed
   let expected = map(expected, "filter(v:val, 'v:key != \"filename\"')")
-  AssertEqual getloclist(0), g:neomake_test_entries
+  AssertEqualQf getloclist(0), g:neomake_test_entries
 
   AssertEqual len(g:neomake_test_countschanged), 1
   AssertEqual len(g:neomake_test_jobfinished), 1
@@ -596,7 +596,7 @@ Execute (Makers: get_list_entries via config):
   Assert !empty(unlisted_bufnr), 'unlisted_bufnr is not empty'
   let expected[0].bufnr = unlisted_bufnr
 
-  AssertEqual getloclist(0), expected
+  AssertEqualQf getloclist(0), expected
 
   AssertEqual len(g:neomake_test_countschanged), 1
   AssertEqual len(g:neomake_test_jobfinished), 1
@@ -669,7 +669,7 @@ Execute (Maker can pass opts for jobstart/job_start):
       endif
 
       CallNeomake 0, [maker]
-      AssertEqual getqflist(), [
+      AssertEqualQf getqflist(), [
       \ {'lnum': 0, 'bufnr': 0, 'col': 0, 'valid': 0, 'vcol': 0, 'nr': -1,
       \  'type': 'W', 'pattern': '', 'text': 'custom-term'}]
     endif

--- a/tests/postprocess.vader
+++ b/tests/postprocess.vader
@@ -85,7 +85,7 @@ Execute (Postprocess: called with dict+maker as self for list):
 
   call neomake#Make(1, [maker])
   NeomakeTestsWaitForFinishedJobs
-  AssertEqual getloclist(0), [{
+  AssertEqualQf getloclist(0), [{
   \ 'lnum': 1,
   \ 'bufnr': bufnr('%'),
   \ 'col': 7,
@@ -133,7 +133,7 @@ Execute (Postprocess: called with dict+maker as self for non-list):
   call neomake#Make(1, [maker])
   NeomakeTestsWaitForFinishedJobs
 
-  AssertEqual getloclist(0), [{
+  AssertEqualQf getloclist(0), [{
   \ 'lnum': 1,
   \ 'bufnr': bufnr('%'),
   \ 'col': 7,
@@ -176,7 +176,7 @@ Execute (Postprocess: removes entries with valid -1):
   AssertEqual len(g:neomake_test_called), 3
   AssertEqual g:neomake_test_called[0][1].jobinfo.maker._maker_marker, 1
 
-  AssertEqual getloclist(0), [{
+  AssertEqualQf getloclist(0), [{
   \ 'lnum': 2,
   \ 'bufnr': bufnr('%'),
   \ 'col': 5,
@@ -326,7 +326,7 @@ Execute (Postprocess: can be lambda):
     call neomake#Make(1, [maker])
     NeomakeTestsWaitForFinishedJobs
 
-    AssertEqual getloclist(0), [{
+    AssertEqualQf getloclist(0), [{
     \ 'lnum': 2,
     \ 'bufnr': bufnr('%'),
     \ 'col': 5,
@@ -359,7 +359,7 @@ Execute (Postprocess: lambda from maker):
     file file.adoc
     call neomake#Make(1, [maker])
     NeomakeTestsWaitForFinishedJobs
-    AssertEqual getloclist(0), [{
+    AssertEqualQf getloclist(0), [{
     \ 'lnum': 1,
     \ 'bufnr': bufnr('%'),
     \ 'col': 0,

--- a/tests/processing.vader
+++ b/tests/processing.vader
@@ -668,7 +668,7 @@ Execute (get_list_entries: delayed for location list (but in current context)):
   AssertEqual winnr(), 1
   AssertNeomakeMessage 'Skipping cleaning of job info because of queued actions: s:ProcessEntries.', 3
   let valid = has('patch-8.0.0580')
-  AssertEqual getloclist(2), [{
+  AssertEqualQf getloclist(2), [{
   \ 'lnum': 0, 'bufnr': 0, 'col': 0, 'valid': valid, 'vcol': 0, 'nr': -1,
   \ 'type': 'W', 'pattern': '', 'text': 'slept'}]
 

--- a/tests/signs.vader
+++ b/tests/signs.vader
@@ -19,10 +19,7 @@ Execute (neomake#signs#RedefineErrorSign):
   NeomakeTestsWaitForFinishedJobs
   AssertNeomakeMessage 'Placing sign: sign place 5000 line=2 name=neomake_file_warn buffer='.bufnr('%').'.'
 
-  AssertNeomakeMessage printf("Could not place signs for 1 entries without line number: %s.",
-  \ string([{'lnum': 0, 'bufnr': bufnr, 'col': 0, 'valid': 1, 'vcol': 0,
-  \          'nr': -1, 'type': 'E', 'maker_name': 'custom_maker', 'pattern': '',
-  \          'text': 'error without line'}]))
+  AssertNeomakeMessage '\vCould not place signs for 1 entries without line number: \[.*\].', 3
 
   " Test #736.
   call neomake#signs#RedefineErrorSign({'text': 'X', 'texthl': 'ErrorMsg'})

--- a/tests/tempfiles.vader
+++ b/tests/tempfiles.vader
@@ -26,7 +26,7 @@ Execute (Neomake uses temporary file for unsaved buffer):
 
   AssertNeomakeMessage '\vSkipped 2 entries without bufnr: .*\.', 3
 
-  AssertEqual getloclist(0), [{
+  AssertEqualQf getloclist(0), [{
   \ 'lnum': 0,
   \ 'bufnr': 0,
   \ 'col': 0,
@@ -395,7 +395,7 @@ Execute (Existing bufnr is kept with tempfiles):
   NeomakeTestsWaitForFinishedJobs
 
   AssertNeomakeMessage '\v^Using tempfile for unnamed buffer: "(.*)".$'
-  AssertEqual getloclist(0), [{
+  AssertEqualQf getloclist(0), [{
   \ 'lnum': 1, 'bufnr': bufnr, 'col': 0, 'valid': 1, 'vcol': 0, 'nr': -1,
   \ 'type': 'W', 'pattern': '', 'text': 'error'}]
 
@@ -430,7 +430,7 @@ Execute (Temporary buffer is not wiped if opened):
   let unlisted_bufnr = bufnr('^another_file$')
   AssertNotEqual unlisted_bufnr, -1
 
-  AssertEqual getloclist(0), [
+  AssertEqualQf getloclist(0), [
   \ {'lnum': 1, 'bufnr': bufnr, 'col': 0, 'valid': 1, 'vcol': 0, 'nr': -1,
   \  'type': 'W', 'pattern': '', 'text': 'error'},
   \ {'lnum': 2, 'bufnr': unlisted_bufnr, 'col': 0, 'valid': 1, 'vcol': 0,
@@ -509,7 +509,7 @@ Execute (Handles tempfiles for bufnames with brackets):
   \ tempfile_bufnr, tempfile_name)
   AssertNeomakeMessage printf(
   \ 'Wiping out 1 unlisted/remapped buffers: [%d].', tempfile_bufnr)
-  AssertEqual getloclist(0), [{
+  AssertEqualQf getloclist(0), [{
   \ 'lnum': 1, 'bufnr': bufnr, 'col': 0, 'valid': 1, 'vcol': 0, 'nr': -1,
   \ 'type': 'W', 'pattern': '', 'text': 'msg'}]
 


### PR DESCRIPTION
TODO:
 - [x] Vim 8.0.1782 added %o / `module` for quickfix entries - a lot of assertions for (complete) quickfix/location lists are failing with that.