### PR TITLE
Unlet $NEOMAKE_FILE / use jobopts.env with existing Vim patches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 
 common: &common
   docker:
-    - image: neomake/vims-for-tests:26@sha256:b97157b8047309a2f58fca2c992bb4873d4ef25392b3e6ed42d6eca722d605c1
+    - image: neomake/vims-for-tests:27@sha256:23daeb84b6881890b41398c7a6b7e5db508d2e69bc68a4dcb6617b77cca7ae71
   working_directory: ~/repo
   steps:
     - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,8 +13,9 @@ common: &common
           set -x
           coverage report -m --skip-covered
           coverage xml
-          codecov -X search gcov pycov -f coverage.xml --required \
-            --name "$CIRCLE_JOB" --flags ${CIRCLE_JOB%%-*} ${CIRCLE_JOB//[-.]/}
+          # -Z: exit with 1 in case of failures.
+          codecov -Z -X search -X gcov -X pycov -f coverage.xml \
+            -n "$CIRCLE_JOB" -F ${CIRCLE_JOB%%-*},${CIRCLE_JOB//[-.]/}
           set +x
 jobs:
   nvim-master:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,10 @@ jobs:
     <<: *common
     environment:
       TEST_VIM=/vim-build/bin/vim-master
+  vim-8.0.1832:
+    <<: *common
+    environment:
+      TEST_VIM=/vim-build/bin/vim-8.0.1832
   vim-8.0.586:
     <<: *common
     environment:
@@ -78,6 +82,7 @@ workflows:
       - nvim-021
       - nvim-020
       - nvim-017
+      - vim-8.0.1832
       - vim-8.0.586
       - vim-master
       - vim-74-xenial

--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -49,7 +49,7 @@ RUN chmod +x /usr/local/bin/vimlint
 
 # Install covimerage and vint.
 RUN apk --no-cache add curl python3 \
-  && pip3 install --no-cache-dir covimerage==0.0.4 vim-vint \
+  && pip3 install --no-cache-dir covimerage==0.0.6 vim-vint \
   && rm -rf /usr/include /usr/lib/python*/turtle* /usr/lib/python*/tkinter \
   && pip3 uninstall --yes pip \
   && curl https://codecov.io/bash -o /usr/bin/codecov \

--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -47,11 +47,13 @@ RUN cd /usr/local/bin && ln -s /vim-build/bin/vim-master vim
 RUN printf '#!/bin/sh -x\n/tools/vim-vimlint/bin/vimlint.sh -l /tools/vim-vimlint -p /tools/vim-vimlparser "$@"\n' > /usr/local/bin/vimlint
 RUN chmod +x /usr/local/bin/vimlint
 
-# Install covimerage, codecov and vint.
-RUN apk --no-cache add python3 \
-  && pip3 install --no-cache-dir codecov covimerage==0.0.4 vim-vint \
+# Install covimerage and vint.
+RUN apk --no-cache add curl python3 \
+  && pip3 install --no-cache-dir covimerage==0.0.4 vim-vint \
   && rm -rf /usr/include /usr/lib/python*/turtle* /usr/lib/python*/tkinter \
   && pip3 uninstall --yes pip \
+  && curl https://codecov.io/bash -o /usr/bin/codecov \
+  && chmod +x /usr/bin/codecov \
   && cd /usr/bin && ln -s python3 python
 
 RUN adduser -D -s /bin/bash neomake

--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -11,6 +11,7 @@ RUN install_vim -tag v7.3.429 -name vim73 --with-features=huge -build \
                 -tag v7.4.052 -name vim74-trusty --with-features=huge -build \
                 -tag v7.4.1689 -name vim74-xenial --with-features=huge -build \
                 -tag v8.0.0586 -name vim-8.0.586 -py2 -build \
+                -tag v8.0.1832 -name vim-8.0.1832 -build \
                 -tag neovim:v0.1.7 -build \
                 -tag neovim:v0.2.0 -build \
                 -tag neovim:v0.2.1 -build \

--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -19,7 +19,7 @@ RUN install_vim -tag v7.3.429 -name vim73 --with-features=huge -build \
                 -tag neovim:v0.3.0 -py3 -build \
   && rm -rf /vim-build/vim/vim/*/share/vim/*/tutor
 
-ENV NEOMAKE_DOCKERFILE_UPDATE=2018-06-19
+ENV NEOMAKE_DOCKERFILE_UPDATE=2018-06-26
 
 # Git master in a separate layer, since the above is meant to be stable.
 RUN install_vim -tag master -build \

--- a/Makefile
+++ b/Makefile
@@ -208,7 +208,8 @@ docker_update_image:
 	make docker_test DOCKER_VIM=neovim-master
 	@echo "Done.  Use 'make docker_push' to push it, and then update .circleci/config.yml."
 
-DOCKER_VIMS:=vim73 vim74-trusty vim74-xenial vim-8.0.586 vim-master neovim-v0.1.7 neovim-v0.2.0 neovim-v0.2.1 neovim-v0.2.2 neovim-v0.3.0 neovim-master
+DOCKER_VIMS:=vim73 vim74-trusty vim74-xenial vim-8.0.586 vim-8.0.1832 vim-master \
+  neovim-v0.1.7 neovim-v0.2.0 neovim-v0.2.1 neovim-v0.2.2 neovim-v0.3.0 neovim-master
 _DOCKER_VIM_TARGETS:=$(addprefix docker_test-,$(DOCKER_VIMS))
 
 docker_test_all: $(_DOCKER_VIM_TARGETS)

--- a/Makefile
+++ b/Makefile
@@ -179,7 +179,7 @@ vimhelplint: | $(if $(VIMHELPLINT_DIR),,build/vimhelplint)
 
 # Run tests in dockerized Vims.
 DOCKER_REPO:=neomake/vims-for-tests
-DOCKER_TAG:=26
+DOCKER_TAG:=27
 NEOMAKE_DOCKER_IMAGE?=
 DOCKER_IMAGE:=$(if $(NEOMAKE_DOCKER_IMAGE),$(NEOMAKE_DOCKER_IMAGE),$(DOCKER_REPO):$(DOCKER_TAG))
 DOCKER_STREAMS:=-ti

--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -544,15 +544,7 @@ function! s:MakeJob(make_id, options) abort
     return jobinfo
 endfunction
 
-if s:can_use_env_in_job_opts
-    function! s:restore_env(var, value) abort
-        if a:value is s:unset
-            exe 'unlet $'.a:var
-        else
-            let $NEOMAKE_FILE = a:value
-        endif
-    endfunction
-else
+if !s:can_use_env_in_job_opts
     function! s:restore_env(var, value) abort
         " Cannot unlet environment vars without patch 8.0.1832.
         exe printf('let $%s = %s', a:var, string(a:value is s:unset ? '' : a:value))

--- a/tests/env.vader
+++ b/tests/env.vader
@@ -12,10 +12,12 @@ Execute (NEOMAKE_FILE with tempfile):
 
   call neomake#Make(1, [maker])
   AssertEqual $NEOMAKE_FILE, ''
+  if has('patch-8.0.0902')
+    Assert !exists('$NEOMAKE_FILE')
+  endif
   NeomakeTestsWaitForFinishedJobs
 
   AssertEqual map(getloclist(0), 'v:val.text'), ['line1', 'line1']
-
   bwipe!
 
 Execute (NEOMAKE_FILE with tempfile gets restored):
@@ -35,7 +37,6 @@ Execute (NEOMAKE_FILE with tempfile gets restored):
   NeomakeTestsWaitForFinishedJobs
 
   AssertEqual map(getloclist(0), 'v:val.text'), ['line1', 'line1']
-
   bwipe!
 
 Execute (NEOMAKE_FILE with tempfile gets only used with append_file):
@@ -51,9 +52,7 @@ Execute (NEOMAKE_FILE with tempfile gets only used with append_file):
   NeomakeTestsWaitForFinishedJobs
 
   AssertEqual map(getloclist(0), 'v:val.text'), ['NEOMAKE_FILE:']
-
   bwipe!
-
 
 Execute (NEOMAKE_FILE with real file):
   let maker = {
@@ -71,5 +70,4 @@ Execute (NEOMAKE_FILE with real file):
 
   AssertEqual map(getloclist(0), 'v:val.text'), [
   \ 'NEOMAKE_FILE:'.fname.' '.fname]
-
   bwipe!


### PR DESCRIPTION
Related patches:

- 8.0.1832: https://github.com/vim/vim/commit/137374fd6538cf9dee0cb22907728d8fdecb5832
- 8.0.0902: https://github.com/vim/vim/commit/05aafed54b50b602315ae55d83a7d089804cecb0