### PR TITLE
tests: set NVIM_LOG_FILE in environment instead of vimrc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,8 @@ testnvimx: testnvim
 testvimx: override VADER_OPTIONS+=-x
 testvimx: testvim
 
+# Set Neovim logfile destination to prevent `.nvimlog` being created.
+testnvim: export NVIM_LOG_FILE:=/dev/stderr
 testnvim: TEST_VIM:=nvim
 # Neovim needs a valid HOME (https://github.com/neovim/neovim/issues/5277).
 testnvim: build/neovim-test-home

--- a/tests/vim/vimrc
+++ b/tests/vim/vimrc
@@ -77,6 +77,3 @@ set nomore
 if expand('$NEOMAKE_TEST_NO_COLORSCHEME') !=# '1'
   colorscheme default
 endif
-
-" Set Neovim logfile destination to prevent `.nvimlog` being created.
-let $NVIM_LOG_FILE='/dev/stderr'


### PR DESCRIPTION
Fixes https://github.com/neovim/neovim/commit/8fa0b8051dbe2f4e4a00c162913886a34bf78bfa#commitcomment-28909322.