### PR TITLE
NeomakeDisable: do not try to delete non-existing augroup

### DIFF
--- a/plugin/neomake.vim
+++ b/plugin/neomake.vim
@@ -37,8 +37,10 @@ function! s:disable(scope, disabled) abort
     call neomake#config#set_dict(a:scope, 'neomake.disabled', a:disabled)
     if a:scope is# g:
         if a:disabled
-            autocmd! neomake
-            augroup! neomake
+            if exists('#neomake')
+                autocmd! neomake
+                augroup! neomake
+            endif
         else
             call s:setup_autocmds()
         endif

--- a/tests/toggle.vader
+++ b/tests/toggle.vader
@@ -105,6 +105,8 @@ Execute (NeomakeStatus with disabling commands):
 
   NeomakeDisable
   Assert !exists('#neomake'), 'neomake augroup has been removed'
+  " Can be disabled again (no error when trying to delete augroup).
+  NeomakeDisable
   NeomakeStatus
 
   NeomakeDisableTab


### PR DESCRIPTION
Fixes:

> Vim(autocmd):E216: No such group or event: neomake

Ref: https://github.com/neomake/neomake/issues/1969.