### PR TITLE
automake: work around Vim issue #2742

### DIFF
--- a/autoload/neomake/configure.vim
+++ b/autoload/neomake/configure.vim
@@ -437,6 +437,16 @@ function! s:neomake_automake(event, bufnr) abort
                     \ {'bufnr': bufnr})
         return
     endif
+
+    if a:event ==# 'TextChanged' && has('patch-8.0.1494') && !has('patch-8.0.1633')
+      " TextChanged gets triggered in this case when loading a buffer (Vim
+      " issue #2742).
+      if !getbufvar(bufnr, '_neomake_seen_TextChanged', 0)
+        call s:debug_log('Ignoring first TextChanged')
+        call setbufvar(bufnr, '_neomake_seen_TextChanged', 1)
+        return
+      endif
+    endif
     call s:debug_log(printf('handling event %s', a:event), {'bufnr': bufnr})
 
     " NOTE: Do it later for BufWinEnter again, since &ft might not be defined (startify).

--- a/tests/automake.vader
+++ b/tests/automake.vader
@@ -249,6 +249,9 @@ Execute (Automake):
 
   " Should not run without changes to the buffer.
   exe 'doautocmd' event
+  if has('patch-8.0.1494') && !has('patch-8.0.1633')
+    exe 'doautocmd' event
+  endif
   NeomakeTestsWaitForMessage 'automake: handling event '.event.'.', 3
   AssertNeomakeMessage 'automake: buffer was not changed.'
   AssertEqual len(g:neomake_test_jobfinished), 2
@@ -275,6 +278,9 @@ Execute (Automake):
 
   new
   exe 'doautocmd' event
+  if has('patch-8.0.1494') && !has('patch-8.0.1633')
+    exe 'doautocmd' event
+  endif
   AssertNeomakeMessage 'automake: configured buffer for ft= (no enabled makers).'
   AssertNeomakeMessage 'automake: no enabled makers.'
 
@@ -328,6 +334,9 @@ Execute (Automake: skips non-default buftypes):
   call g:NeomakeSetupAutocmdWrappers()
 
   exe 'doautocmd '.event
+  if has('patch-8.0.1494') && !has('patch-8.0.1633')
+    exe 'doautocmd' event
+  endif
   NeomakeTestsWaitForMessage 'automake: ignoring '.event.' for buftype=nofile.', 3
   AssertEqual len(g:neomake_test_jobfinished), 0
   bwipe!
@@ -504,6 +513,9 @@ Execute (Automake handles unchanged buffer):
     let g:neomake_test_enabledmakers = [g:sleep_maker]
     set filetype=neomake_tests
     doautocmd TextChanged
+    if has('patch-8.0.1494') && !has('patch-8.0.1633')
+      doautocmd TextChanged
+    endif
     let make_id = neomake#GetStatus().last_make_id
     NeomakeTestsWaitForMessage '\vautomake: callback for timer \d+'
     doautocmd TextChanged
@@ -602,6 +614,9 @@ Execute (Automake stops previous jobs):
 
     set filetype=neomake_tests
     doautocmd TextChanged
+    if has('patch-8.0.1494') && !has('patch-8.0.1633')
+      doautocmd TextChanged
+    endif
     NeomakeTestsWaitForMessage '\vautomake: callback for timer \d+'
     let first_make_id = neomake#GetStatus().last_make_id
     AssertEqual [first_make_id], b:neomake_automake_make_ids
@@ -760,6 +775,9 @@ Execute (Handles timeout in another buffer):
     call neomake#configure#automake({
     \ 'TextChanged': {'delay': 10}})
     doautocmd TextChanged
+    if has('patch-8.0.1494') && !has('patch-8.0.1633')
+      doautocmd TextChanged
+    endif
     AssertNeomakeMessage '\vautomake: started timer \(10ms\): (\d+)'
     let timer = g:neomake_test_matchlist[1]
     new
@@ -851,6 +869,9 @@ Execute (neomake#configure#reset_automake stops timers):
     let b:neomake_enabled_makers = [g:true_maker]
     call neomake#configure#automake({'TextChanged': {'delay': 10}})
     doautocmd TextChanged
+    if has('patch-8.0.1494') && !has('patch-8.0.1633')
+      doautocmd TextChanged
+    endif
     AssertNeomakeMessage '\vautomake: started timer \(10ms\): (\d+)'
     let timer = g:neomake_test_matchlist[1]
     call neomake#configure#reset_automake()

--- a/tests/automake.vader
+++ b/tests/automake.vader
@@ -857,3 +857,17 @@ Execute (neomake#configure#reset_automake stops timers):
     AssertNeomakeMessage 'automake: stopping timers: '.timer.'.'
     bwipe
   endif
+
+Execute (Ignores first TextChanged event (Vim issue #2742)):
+  Save g:neomake
+  if !has('patch-8.0.1494') || has('patch-8.0.1633')
+    NeomakeTestsSkip 'Only with affected patches (Vim issue #2742)'
+  else
+    call neomake#configure#automake('n')
+    new
+    doautocmd TextChanged
+    AssertNeomakeMessage 'automake: Ignoring first TextChanged.'
+    doautocmd TextChanged
+    AssertNeomakeMessage 'automake: handling event TextChanged.'
+    bwipe
+  endif


### PR DESCRIPTION
TextChanged is triggered for new buffers always in this case, which
triggers Neomake's automaking then already.

This affects Neovim 0.3.0, which has the first, but not the last patch.

Ref: https://github.com/vim/vim/pull/2742
Ref: https://github.com/neovim/neovim/pull/8582

TODO:
- [x] update Docker image for Neovim 0.3.0