### PR TITLE
Use relative filename in args

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -1767,8 +1767,8 @@ endfunction
 function! s:cd_to_jobs_cwd(jobinfo) abort
     if !has_key(a:jobinfo, 'cwd')
         let maker = a:jobinfo.maker
-        let cwd = neomake#utils#GetSetting('cwd', maker, g:neomake#config#undefined, a:jobinfo.ft, a:jobinfo.bufnr, 1)
-        if cwd isnot# g:neomake#config#undefined
+        let cwd = neomake#utils#GetSetting('cwd', maker, '', a:jobinfo.ft, a:jobinfo.bufnr, 1)
+        if cwd !=# ''
             if cwd[0:1] ==# '%:'
                 let cwd = neomake#utils#fnamemodify(a:jobinfo.bufnr, cwd[1:])
             else

--- a/autoload/neomake/core.vim
+++ b/autoload/neomake/core.vim
@@ -66,6 +66,7 @@ endfunction
 
 " Base class for command makers.
 let g:neomake#core#command_maker_base = {}
+
 function! g:neomake#core#command_maker_base._get_fname_for_args(jobinfo) abort dict
     " Append file?  (defaults to jobinfo.file_mode, project/global makers should set it to 0)
     let append_file = neomake#utils#GetSetting('append_file', self, a:jobinfo.file_mode, a:jobinfo.ft, a:jobinfo.bufnr)
@@ -78,4 +79,8 @@ function! g:neomake#core#command_maker_base._get_fname_for_args(jobinfo) abort d
         endif
     endif
     return ''
+endfunction
+
+function! g:neomake#core#command_maker_base._get_argv(jobinfo) abort dict
+    return neomake#compat#get_argv(self.exe, self.args, type(self.args) == type([]))
 endfunction

--- a/autoload/neomake/core.vim
+++ b/autoload/neomake/core.vim
@@ -81,6 +81,8 @@ function! g:neomake#core#command_maker_base._get_fname_for_args(jobinfo) abort d
     return ''
 endfunction
 
+" @vimlint(EVL103, 1, a:jobinfo)
 function! g:neomake#core#command_maker_base._get_argv(jobinfo) abort dict
     return neomake#compat#get_argv(self.exe, self.args, type(self.args) == type([]))
 endfunction
+" @vimlint(EVL103, 0, a:jobinfo)

--- a/autoload/neomake/makers/ft/python.vim
+++ b/autoload/neomake/makers/ft/python.vim
@@ -119,7 +119,10 @@ function! neomake#makers#ft#python#flake8() abort
 
     " @vimlint(EVL103, 1, a:jobinfo)
     function! maker.supports_stdin(jobinfo) abort
-        let self.args += ['--stdin-display-name', '%:p']
+        let self.args += ['--stdin-display-name', '%:.']
+        if !has_key(self, 'cwd')
+            let self.cwd = expand('%:h')
+        endif
         return 1
     endfunction
     " @vimlint(EVL103, 0, a:jobinfo)

--- a/autoload/neomake/makers/ft/python.vim
+++ b/autoload/neomake/makers/ft/python.vim
@@ -119,7 +119,7 @@ function! neomake#makers#ft#python#flake8() abort
 
     " @vimlint(EVL103, 1, a:jobinfo)
     function! maker.supports_stdin(jobinfo) abort
-        let self.args += ['--stdin-display-name', '%:p']
+        let self.args += ['--stdin-display-name', '%:.']
         if !has_key(self, 'cwd')
             let self.cwd = expand('%:h')
         endif

--- a/autoload/neomake/makers/ft/python.vim
+++ b/autoload/neomake/makers/ft/python.vim
@@ -119,7 +119,7 @@ function! neomake#makers#ft#python#flake8() abort
 
     " @vimlint(EVL103, 1, a:jobinfo)
     function! maker.supports_stdin(jobinfo) abort
-        let self.args += ['--stdin-display-name', '%:.']
+        let self.args += ['--stdin-display-name', '%:p']
         if !has_key(self, 'cwd')
             let self.cwd = expand('%:h')
         endif

--- a/autoload/neomake/utils.vim
+++ b/autoload/neomake/utils.vim
@@ -323,7 +323,7 @@ function! neomake#utils#ExpandArgs(args) abort
     " % must be followed with an expansion keyword
     let ret = map(copy(a:args),
                 \ 'substitute(v:val, '
-                \ . '''\(\%(\\\@<!\\\)\@<!%\%(%\|\%(:[phtre]\+\)*\)\ze\)\w\@!'', '
+                \ . '''\(\%(\\\@<!\\\)\@<!%\%(%\|\%(:[phtre.]\+\)*\)\ze\)\w\@!'', '
                 \ . '''\=(submatch(1) == "%%" ? "%" : expand(submatch(1)))'', '
                 \ . '''g'')')
     let ret = map(ret,

--- a/autoload/neomake/utils.vim
+++ b/autoload/neomake/utils.vim
@@ -106,8 +106,8 @@ function! s:command_maker.fn(jobinfo) dict abort
 endfunction
 
 " @vimlint(EVL103, 1, a:jobinfo)
-function! s:command_maker._get_argv(jobinfo) abort dict
-    return neomake#compat#get_argv(self.exe, self.args, 1)
+function! s:command_maker._get_exe_and_args(jobinfo) abort dict
+    return [self.exe, self.args]
 endfunction
 " @vimlint(EVL103, 0, a:jobinfo)
 

--- a/doc/neomake.txt
+++ b/doc/neomake.txt
@@ -393,8 +393,7 @@ You can specify the default for this via |g:neomake_remove_invalid_entries|.
 
                                                           *neomake-makers-cwd*
 The working directory of a maker defaults to the current working directory
-of the make run (|getcwd()|), or the buffer's directory in case of using stdin
-(see |neomake-makers-supports_stdin|).
+of the make run (|getcwd()|).
 The `cwd` property overrides this, and gets expanded in the context of the
 current buffer. Special buffers (like fugitive blobs) get handled for values
 starting with `%:` (typically used in this context), falling back to
@@ -435,6 +434,8 @@ current jobinfo as its argument, and should return 1 or 0.
 This function can change `self.args`, which is useful to append options like
 e.g. "['--stdin-display-name', '%:p']".
 You can also change `self.tempfile_name` therein.
+Often it can be useful to also change `self.cwd`, e.g. when a maker does not
+use its `--stdin-display-name` (or similar) option to look for its config.
 
 Global Options                                               *neomake-options*
 

--- a/tests/args.vader
+++ b/tests/args.vader
@@ -11,12 +11,12 @@ Execute (maker.args as list gets escaped):
   let fname = 'tests/fixtures/a filename with spaces'
   new
   edit tests/fixtures/a\ filename\ with\ spaces
-  let fname_abs = expand('%:p')
+  let fname = bufname('%')
 
   call neomake#Make(1, [maker])
   NeomakeTestsWaitForFinishedJobs
   AssertEqual map(getloclist(0), 'v:val.text'),
-    \ ['1', '2', '3a 3b', fname_abs]
+    \ ['1', '2', '3a 3b', fname]
   bwipe
 
 Execute (maker.args as string gets not escaped):
@@ -30,10 +30,10 @@ Execute (maker.args as string gets not escaped):
   let fname = 'tests/fixtures/a filename with spaces'
   new
   edit tests/fixtures/a\ filename\ with\ spaces
-  let fname_abs = expand('%:p')
+  let fname = expand('%')
 
   call neomake#Make(1, [maker])
   NeomakeTestsWaitForFinishedJobs
   AssertEqual map(getloclist(0), 'v:val.text'),
-    \ ['1', '2', '3a 3b', '4', fname_abs]
+    \ ['1', '2', '3a 3b', '4', fname]
   bwipe

--- a/tests/cwd.vader
+++ b/tests/cwd.vader
@@ -136,7 +136,7 @@ Execute (cwd gets expanded correctly: relative and in another buffer):
     new
     edit tests/fixtures/errors.py
     let b:neomake_serialize = 1
-    let bufname = expand('%:p')
+    let bufname = expand('%:.')
     let expected_cwd = fnamemodify(bufname, ':p:h')
 
     let jobinfo = neomake#Make(1, [g:sleep_maker, maker])[0]

--- a/tests/env.vader
+++ b/tests/env.vader
@@ -63,7 +63,7 @@ Execute (NEOMAKE_FILE with real file):
   \ 'errorformat': '%m'}
   new
   edit tests/fixtures/a\ filename\ with\ spaces
-  let fname = expand('%:p')
+  let fname = expand('%')
   let b:neomake_tempfile_enabled = 0
 
   call neomake#Make(1, [maker])

--- a/tests/integration.vader
+++ b/tests/integration.vader
@@ -751,7 +751,7 @@ Execute (Neomake: append_file from settings and empty entry type):
   set ft=myft
 
   call neomake#Make(1, [maker])
-  let bufname = expand('%:p')
+  let bufname = bufname('%')
   NeomakeTestsWaitForFinishedJobs
   AssertEqualQf getloclist(0),
     \ [{'lnum': 0, 'bufnr': 0, 'col': 0, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'output '.bufname}]

--- a/tests/makers.vader
+++ b/tests/makers.vader
@@ -628,11 +628,12 @@ Execute (Neomake/Neomake! run ft maker in project mode):
   new
   edit tests/fixtures/a\ filename\ with\ spaces
   set ft=neomake_tests
+  let fname = bufname('%')
 
   Neomake echo_args
   NeomakeTestsWaitForFinishedJobs
   AssertNeomakeMessage 'Running makers: echo_args.'
-  AssertEqual map(getloclist(0), 'v:val.text'), [expand('%:p')]
+  AssertEqual map(getloclist(0), 'v:val.text'), [fname]
 
   Neomake! echo_args
   NeomakeTestsWaitForFinishedJobs
@@ -643,9 +644,9 @@ Execute (Neomake/Neomake! run ft maker in project mode):
   CallNeomake 0, ['echo_args']
   AssertNeomakeMessage 'Running makers: echo_args.'
   AssertNeomakeMessage "Using setting append_file=1 from 'buffer'.", 3
-  AssertEqual map(getqflist(), 'v:val.text'), [expand('%:p')]
+  AssertEqual map(getqflist(), 'v:val.text'), [fname]
 
-  AssertEqual map(getloclist(0), 'v:val.text'), [expand('%:p')]
+  AssertEqual map(getloclist(0), 'v:val.text'), [fname]
 
   AssertEqual map(copy(g:neomake_test_jobfinished), 'v:val.jobinfo.file_mode'), [1, 0, 0]
   bwipe

--- a/tests/stdin.vader
+++ b/tests/stdin.vader
@@ -8,12 +8,11 @@ Execute (stdin maker):
   normal! ifile1.test:line1
   normal! ofile1.test:line2
   call neomake#Make(1, [maker])
-  AssertNeomakeMessage "Using buffer's directory for cwd with uses_stdin.", 3
   if neomake#has_async_support()
     AssertNeomakeMessage "Starting async job: cat -.", 2
     NeomakeTestsWaitForFinishedJobs
   endif
-  AssertNeomakeMessage 'cwd: .', 3
+  AssertNeomakeMessage 'cwd: '.getcwd().'.', 3
   AssertNeomakeMessage '\mstdout: unnamed_maker: [''file1.test:line1.*'
   AssertNeomakeMessage '\vUsed bufnr from stdin buffer (\d+) \(file1.test\) for 2 entries: 1, 2.'
   let tempbuf = g:neomake_test_matchlist[1]
@@ -175,17 +174,17 @@ Execute (stdin maker: uses neomake#utils#get_buffer_lines for buffer_lines):
   AssertEqual map(getloclist(0), 'v:val.text'), ['', '']
   bwipe
 
-Execute (stdin maker: uses buffer's cwd by default):
+Execute (stdin maker: does not use buffer's cwd by default):
   let maker = {'exe': 'true', 'supports_stdin': 1}
   let fname = tempname()
   new
   exe 'file '.fname
 
   CallNeomake 1, [maker]
-  AssertNeomakeMessage printf('cwd: %s (changed).', fnamemodify(fname, ':h')), 3
+  AssertNeomakeMessage printf('cwd: %s.', getcwd()), 3
 
   CallNeomake 0, [extend(copy(maker), {'uses_filename': 1})]
-  AssertNeomakeMessage printf('cwd: %s (changed).', fnamemodify(fname, ':h')), 3
+  AssertNeomakeMessage printf('cwd: %s.', getcwd()), 3
 
   let maker.cwd = '.'
   CallNeomake 1, [maker]

--- a/tests/stdin.vader
+++ b/tests/stdin.vader
@@ -190,3 +190,37 @@ Execute (stdin maker: does not use buffer's cwd by default):
   CallNeomake 1, [maker]
   AssertNeomakeMessage printf('cwd: %s.', getcwd()), 3
   bwipe
+
+Execute (stdin maker: can use buffer's cwd):
+  let maker = {'exe': 'true', 'name': 'flake8'}
+  function maker.supports_stdin(jobinfo) abort
+    if !has_key(self, 'cwd')
+      let self.cwd = expand('%:h')
+    endif
+    return 1
+  endfunction
+  let fname = tempname()
+  new
+  exe 'file '.fname
+
+  CallNeomake 1, [maker]
+  AssertNeomakeMessage printf('cwd: %s (changed).', fnamemodify(fname, ':h')), 3
+
+  CallNeomake 0, [extend(copy(maker), {'uses_filename': 1})]
+  AssertNeomakeMessage printf('cwd: %s (changed).', fnamemodify(fname, ':h')), 3
+
+  " Can be set using config.
+  let b:neomake_flake8_cwd = '.'
+  CallNeomake 1, [maker]
+  AssertNeomakeMessage printf('cwd: %s.', getcwd()), 3
+
+  " Overridden by conf.
+  let maker.cwd = '..'
+  CallNeomake 1, [maker]
+  AssertNeomakeMessage printf('cwd: %s.', getcwd()), 3
+
+  unlet b:neomake_flake8_cwd
+  let maker.cwd = '.'
+  CallNeomake 1, [maker]
+  AssertNeomakeMessage printf('cwd: %s.', getcwd()), 3
+  bwipe

--- a/tests/tempfiles.vader
+++ b/tests/tempfiles.vader
@@ -125,7 +125,7 @@ Execute (Maker can specify temporary file to use via fn):
   call maker.fn(jobinfo)
 
   AssertEqual maker.args, []
-  call maker._get_argv(jobinfo)
+  call maker._get_exe_and_args(jobinfo)
   AssertEqual maker.args, []
   AssertEqual maker.tempfile_name, g:neomake_test_tempfile
   AssertNeomakeMessage '\m^Using tempfile for modified buffer: "'.g:neomake_test_tempfile.'"', 3, {'jobinfo': jobinfo, 'make_id': jobinfo.make_id, 'bufnr': bufnr}
@@ -178,24 +178,24 @@ Execute (maker._get_argv uses jobinfo for bufnr):
   let b:neomake_tempfile_enabled = 1
   let bufnr = bufnr('%')
   let jobinfo = NeomakeTestsFakeJobinfo()
-  call maker._get_argv(jobinfo)
+  call maker._get_exe_and_args(jobinfo)
   let make_info = values(neomake#GetStatus().make_info)[0]
   Assert !empty(make_info.tempfiles), 'make_info has tempfiles'
 
   let jobinfo = NeomakeTestsFakeJobinfo()
   let maker = neomake#GetMaker({'name': 'my_maker', 'append_file': 1})
   edit tests/fixtures/errors.py
-  call maker._get_argv(jobinfo)
+  call maker._get_exe_and_args(jobinfo)
   Assert !has_key(jobinfo, 'tempfile_name')
 
   wincmd p
   let jobinfo = NeomakeTestsFakeJobinfo()
   let jobinfo.bufnr = bufnr
-  let expected = ['my_maker', fnameescape(fnamemodify(bufname(bufnr), ':.'))]
+  let expected = ['my_maker', [fnameescape(fnamemodify(bufname(bufnr), ':.'))]]
   if neomake#has_async_support()
-    AssertEqual expected, maker._get_argv(jobinfo)
+    AssertEqual expected, maker._get_exe_and_args(jobinfo)
   else
-    AssertEqual join(expected), maker._get_argv(jobinfo)
+    AssertEqual join(expected), maker._get_exe_and_args(jobinfo)
   endif
 
   wincmd p

--- a/tests/tempfiles.vader
+++ b/tests/tempfiles.vader
@@ -191,11 +191,17 @@ Execute (maker._get_argv uses jobinfo for bufnr):
   wincmd p
   let jobinfo = NeomakeTestsFakeJobinfo()
   let jobinfo.bufnr = bufnr
-  let expected = ['my_maker', [fnameescape(fnamemodify(bufname(bufnr), ':.'))]]
+
+  let [exe, args] = maker._get_exe_and_args(jobinfo)
+  AssertEqual [exe, args],
+  \ ['my_maker', [fnameescape(fnamemodify(bufname(bufnr), ':.'))]]
+
+  let [maker.exe, maker.args] = [exe, args]
+  let expected = [exe] + args
   if neomake#has_async_support()
-    AssertEqual expected, maker._get_exe_and_args(jobinfo)
+    AssertEqual expected, maker._get_argv(jobinfo)
   else
-    AssertEqual join(expected), maker._get_exe_and_args(jobinfo)
+    AssertEqual join(expected), maker._get_argv(jobinfo)
   endif
 
   wincmd p

--- a/tests/tempfiles.vader
+++ b/tests/tempfiles.vader
@@ -63,7 +63,6 @@ Execute (Uses temporary file for unreadable buffer):
   let b:neomake_neomake_tests_enabled_makers = ['true']
   let b:neomake_neomake_tests_true_tempfile_enabled = 1
 
-  let fname = fnamemodify(bufname('%'), ':p')
   RunNeomake
 
   let bufnr = bufnr('%')
@@ -71,8 +70,7 @@ Execute (Uses temporary file for unreadable buffer):
   let tempfile_name = g:neomake_test_matchlist[1]
   AssertEqual fnamemodify(tempfile_name, ':t'), printf(
   \ '.doesnotexist@neomake_%d_%d', getpid(), neomake#GetStatus().last_make_id)
-  let cwd = getcwd()
-  AssertEqual tempfile_name[0:len(cwd)-1], cwd
+  AssertEqual fnamemodify(tempfile_name, ':h'), '.'
   bwipe
 
 Execute (2nd maker uses temporary file):
@@ -193,7 +191,7 @@ Execute (maker._get_argv uses jobinfo for bufnr):
   wincmd p
   let jobinfo = NeomakeTestsFakeJobinfo()
   let jobinfo.bufnr = bufnr
-  let expected = ['my_maker', fnameescape(fnamemodify(bufname(bufnr), ':p'))]
+  let expected = ['my_maker', fnameescape(fnamemodify(bufname(bufnr), ':.'))]
   if neomake#has_async_support()
     AssertEqual expected, maker._get_argv(jobinfo)
   else
@@ -501,7 +499,7 @@ Execute (Handles tempfiles for bufnames with brackets):
 
   AssertNeomakeMessage '\v^Using tempfile for unreadable buffer: "(.*)".$'
   let tempfile_name = g:neomake_test_matchlist[1]
-  Assert stridx(tempfile_name, getcwd().neomake#utils#Slash().'.[fname-with-brackets]') == 0, 'tempfile_name is correct'
+  Assert stridx(tempfile_name, '.'.neomake#utils#Slash().'.[fname-with-brackets]') == 0, 'tempfile_name is correct'
   let tempfile_bufnr = bufnr+1
 
   AssertNeomakeMessage printf(

--- a/tests/utils.vader
+++ b/tests/utils.vader
@@ -404,7 +404,7 @@ Execute (neomake#utils#MakerFromCommand appends args for file_mode (string)):
   let jobinfo = {'file_mode': 0, 'bufnr': bufnr('%'), 'ft': ''}
   let shell_argv = split(&shell) + split(&shellcmdflag)
   AssertEqual maker.fn(jobinfo), {
-  \ '_get_argv': get(maker, '_get_argv'),
+  \ '_get_exe_and_args': get(maker, '_get_exe_and_args'),
   \ '_get_fname_for_args': get(maker, '_get_fname_for_args'),
   \ 'args': shell_argv[1:] + ['echo "%" 1'],
   \ 'exe': shell_argv[0],
@@ -439,7 +439,7 @@ Execute (neomake#utils#MakerFromCommand appends args for file_mode (list)):
   let jobinfo = {'file_mode': 0, 'bufnr': bufnr('%'), 'ft': ''}
 
   AssertEqual maker.fn(jobinfo), {
-  \ '_get_argv': get(maker, '_get_argv'),
+  \ '_get_exe_and_args': get(maker, '_get_exe_and_args'),
   \ '_get_fname_for_args': get(maker, '_get_fname_for_args'),
   \ 'args': ['%', '1'],
   \ 'exe': 'echo',

--- a/tests/utils.vader
+++ b/tests/utils.vader
@@ -410,7 +410,7 @@ Execute (neomake#utils#MakerFromCommand appends args for file_mode (string)):
   \ 'exe': shell_argv[0],
   \ 'remove_invalid_entries': 0}
 
-  let fname = expand('%:p')
+  let fname = bufname('%')
   let jobinfo = NeomakeTestsFakeJobinfo()
   let jobinfo.maker = maker
   let bound_maker = neomake#GetMaker(maker).fn(jobinfo)
@@ -447,7 +447,7 @@ Execute (neomake#utils#MakerFromCommand appends args for file_mode (list)):
 
   new
   edit tests/fixtures/a\ filename\ with\ spaces
-  let fname = expand('%:p')
+  let fname = bufname('%')
   let jobinfo = NeomakeTestsFakeJobinfo()
   let jobinfo.maker = maker
   let bound_maker = neomake#GetMaker(maker).fn(jobinfo)

--- a/tests/utils.vader
+++ b/tests/utils.vader
@@ -279,6 +279,8 @@ Execute (neomake#utils#ExpandArgs):
   \ 'C:\\%:r\\',
   \ '~',
   \ '\~',
+  \ '%:.',
+  \ '%:,',
   \ ]
   let expected_args = [
   \ 'file1.ext',
@@ -300,6 +302,8 @@ Execute (neomake#utils#ExpandArgs):
   \ 'C:\\file1\\',
   \ '/home/sweet',
   \ '\~',
+  \ 'file1.ext',
+  \ 'file1.ext:,',
   \ ]
 
   AssertEqual expected_args, neomake#utils#ExpandArgs(args)


### PR DESCRIPTION
This was done in d719f581 mostly, which says that flake8 requires it.

TODO:

- [x] evaluate, fix flake8 maker eventually / +tests?

Fixes https://github.com/neomake/neomake/issues/1979.
Fixes https://github.com/neomake/neomake/issues/774.