### PR TITLE
Add SwiftPM test maker

### DIFF
--- a/autoload/neomake/makers/ft/swift.vim
+++ b/autoload/neomake/makers/ft/swift.vim
@@ -22,6 +22,19 @@ function! neomake#makers#ft#swift#swiftpm() abort
         \ }
 endfunction
 
+function! neomake#makers#ft#swift#swiftpmtest() abort
+    return {
+        \ 'exe': 'swift',
+        \ 'args': ['test'],
+        \ 'append_file': 0,
+        \ 'errorformat':
+            \ '%E%f:%l: error: %m,' .
+            \ '%W%f:%l:%c: warning: %m,' .
+            \ '%Z%\s%#^~%#,' .
+            \ '%-G%.%#',
+        \ }
+endfunction
+
 function! neomake#makers#ft#swift#swiftc() abort
     " `export SDKROOT="$(xcodebuild -version -sdk macosx Path)"`
     return {


### PR DESCRIPTION
This new maker is ever on by default, but allows people to easily test
their SwiftPM projects if they enable it.