### PR TITLE
Add SwiftPM errorformat

### DIFF
--- a/autoload/neomake/makers/ft/swift.vim
+++ b/autoload/neomake/makers/ft/swift.vim
@@ -28,6 +28,7 @@ function! neomake#makers#ft#swift#swiftpmtest() abort
         \ 'args': ['test'],
         \ 'append_file': 0,
         \ 'errorformat':
+            \ '%E%f:%l:%c: error: %m,' .
             \ '%E%f:%l: error: %m,' .
             \ '%W%f:%l:%c: warning: %m,' .
             \ '%Z%\s%#^~%#,' .


### PR DESCRIPTION
This command can produce normal errors with a column, but also those
without, so we need both formats.