### PR TITLE
vim: vint: detect new stdin support

### DIFF
--- a/tests/isolated.vader
+++ b/tests/isolated.vader
@@ -2,6 +2,7 @@
 Include: isolated/compat-get_argv-on-emulated-windows.vader
 Include: isolated/configure.vader
 Include: isolated/ft_help.vader
+Include: isolated/ft_vim.vader
 Include: isolated/highlights.vader
 Include: isolated/logging.vader
 Include: isolated/modes.vader

--- a/tests/isolated/ft_vim.vader
+++ b/tests/isolated/ft_vim.vader
@@ -1,0 +1,30 @@
+Include: ../include/setup.vader
+
+Execute (vint: detects stdin support):
+  runtime autoload/neomake/makers/ft/vim.vim
+  function! neomake#compat#systemlist(...)
+    return ''
+  endfunction
+  let maker = neomake#GetMaker('vint', 'vim')
+  AssertEqual maker.supports_stdin({}), 0
+
+  runtime autoload/neomake/makers/ft/vim.vim
+  function! neomake#compat#systemlist(...)
+    return ['0.3.19']
+  endfunction
+  let maker = neomake#GetMaker('vint', 'vim')
+  AssertEqual maker.supports_stdin({}), 0
+  AssertEqual index(maker.args, '--stdin-display-name'), -1
+
+  runtime autoload/neomake/makers/ft/vim.vim
+  function! neomake#compat#systemlist(...)
+    return ['0.4a']
+  endfunction
+  let maker = neomake#GetMaker('vint', 'vim')
+  AssertEqual maker.supports_stdin({}), 1
+  AssertEqual maker.args[-2:], ['--stdin-display-name', '%:.']
+
+  " Restore if not run separately.
+  if fnamemodify(g:vader_file, ':t') == 'isolated.vader'
+    runtime autoload/neomake/compat.vim
+  endif


### PR DESCRIPTION
Requires vint 0.4a1+.  It was added partly in 0.3.19 already, but that
is buggy.