### PR TITLE
enable typescript compiler to javascript files

### DIFF
--- a/autoload/neomake/makers/ft/javascript.vim
+++ b/autoload/neomake/makers/ft/javascript.vim
@@ -6,6 +6,10 @@ function! neomake#makers#ft#javascript#EnabledMakers() abort
                 \]
 endfunction
 
+function! neomake#makers#ft#javascript#tsc() abort
+    return neomake#makers#ft#typescript#tsc()
+endfunction
+
 function! neomake#makers#ft#javascript#gjslint() abort
     return {
         \ 'args': ['--nodebug_indentation', '--nosummary', '--unix_mode', '--nobeep'],

--- a/tests/filetypes.vader
+++ b/tests/filetypes.vader
@@ -19,11 +19,11 @@ Execute (GetEnabledMakers for jsx):
 
 Execute (GetMakers for javascript.jsx):
   AssertEqual neomake#GetMakers('javascript.jsx'),
-  \ ['eslint', 'eslint_d', 'flow', 'gjslint', 'jscs', 'jshint', 'rjsx', 'semistandard', 'standard', 'stylelint', 'xo', 'jsxhint']
+  \ ['eslint', 'eslint_d', 'flow', 'gjslint', 'jscs', 'jshint', 'rjsx', 'semistandard', 'standard', 'stylelint', 'tsc', 'xo', 'jsxhint']
 
 Execute (GetMakers for jsx.javascript):
   " jsxhint comes first, since it is defined in jsx.vim.
-  let expected = ['jsxhint', 'stylelint', 'eslint', 'eslint_d', 'flow', 'gjslint', 'jscs', 'jshint', 'rjsx', 'semistandard', 'standard', 'xo']
+  let expected = ['jsxhint', 'stylelint', 'eslint', 'eslint_d', 'flow', 'gjslint', 'jscs', 'jshint', 'rjsx', 'semistandard', 'standard', 'tsc', 'xo']
   AssertEqual neomake#GetMakers('jsx.javascript'), expected
 
   Save b:neomake_jsx_javascript_foo_maker
@@ -32,7 +32,7 @@ Execute (GetMakers for jsx.javascript):
 
 Execute (GetMakers for javascript):
   AssertEqual neomake#GetMakers('javascript'),
-  \ ['eslint', 'eslint_d', 'flow', 'gjslint', 'jscs', 'jshint', 'rjsx', 'semistandard', 'standard', 'stylelint', 'xo']
+  \ ['eslint', 'eslint_d', 'flow', 'gjslint', 'jscs', 'jshint', 'rjsx', 'semistandard', 'standard', 'stylelint', 'tsc', 'xo']
 
 Execute (GetMakers for jsx):
   AssertEqual neomake#GetMakers('jsx'), ['jsxhint', 'stylelint'] + filter(neomake#GetMakers('javascript'), "v:val != 'stylelint'")


### PR DESCRIPTION
typescript compiler can run in javascript project or files when is configured with "allowjs" and "checkjs" in tsconfig.json


