### PR TITLE
tests: look for unexpected warnings

### DIFF
--- a/autoload/neomake/makers/clippy.vim
+++ b/autoload/neomake/makers/clippy.vim
@@ -1,7 +1,7 @@
 " vim: ts=4 sw=4 et
 
 " Yet to be determined
-let s:rustup_has_nightly = -1
+let s:rustup_has_nightly = get(g:, 'neomake_clippy_rustup_has_nightly', -1)
 
 function! neomake#makers#clippy#clippy() abort
     " When rustup and a nightly toolchain is installed, that is used.

--- a/tests/include/init.vim
+++ b/tests/include/init.vim
@@ -470,7 +470,8 @@ function! s:After()
   endif
 
   let unexpected_warnings = filter(copy(g:neomake_test_messages),
-        \ 'v:val[0] == 1 && index(g:_neomake_test_asserted_messages, v:val) == -1')
+        \ 'v:val[0] == 1 && v:val[1] !=# "automake: timer support is required for delayed events."'.
+        \ '&& index(g:_neomake_test_asserted_messages, v:val) == -1')
   if !empty(unexpected_warnings)
     call add(errors, 'found unexpected warning messages: '.string(unexpected_warnings))
   endif

--- a/tests/include/init.vim
+++ b/tests/include/init.vim
@@ -469,6 +469,12 @@ function! s:After()
     call add(errors, 'found unexpected error messages: '.string(unexpected_errors))
   endif
 
+  let unexpected_warnings = filter(copy(g:neomake_test_messages),
+        \ 'v:val[0] == 1 && index(g:_neomake_test_asserted_messages, v:val) == -1')
+  if !empty(unexpected_warnings)
+    call add(errors, 'found unexpected warning messages: '.string(unexpected_warnings))
+  endif
+
   let status = neomake#GetStatus()
   let make_info = status.make_info
   if has_key(make_info, -42)

--- a/tests/vim/vimrc
+++ b/tests/vim/vimrc
@@ -91,3 +91,6 @@ set nomore
 if expand('$NEOMAKE_TEST_NO_COLORSCHEME') !=# '1'
   colorscheme default
 endif
+
+" Avoid system call and warning.
+let g:neomake_clippy_rustup_has_nightly = 0


### PR DESCRIPTION
Adds g:neomake_clippy_rustup_has_nightly to allow for skipping clippy's
check (using system()!).

Ref: https://github.com/neomake/neomake/issues/1453