### PR TITLE
vimlint: use -e 'EVL103.a:_.*=1' to ignore unused args

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,7 +159,7 @@ build/vimlint: | build
 	git clone -q --depth=1 https://github.com/syngan/vim-vimlint $@
 build/vimlparser: | build
 	git clone -q --depth=1 https://github.com/ynkdir/vim-vimlparser $@
-VIMLINT_OPTIONS=-u -e EVL102.l:_=1
+VIMLINT_OPTIONS=-u -e EVL102.l:_=1 -e 'EVL103.a:_.*=1'
 vimlint: | $(firstword $(VIMLINT_BIN))
 	$(VIMLINT_BIN) $(VIMLINT_OPTIONS) $(LINT_ARGS)
 vimlint-errors: | $(firstword VIMLINT_BIN)

--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -2296,8 +2296,7 @@ else
         endif
     endfunction
 
-    " @vimlint(EVL103, 1, a:timer)
-    function! s:nvim_output_handler_cb(timer) abort
+    function! s:nvim_output_handler_cb(_timer) abort
         while !empty(s:nvim_output_handler_queue)
             let args = remove(s:nvim_output_handler_queue, 0)
             let jobinfo = args[0]
@@ -2315,13 +2314,11 @@ else
         endwhile
         unlet! s:nvim_output_handler_timer
     endfunction
-    " @vimlint(EVL103, 0, a:timer)
 endif
 
 " Exit handler for buffered output with Neovim.
 " In this case the output gets stored on the jobstart-options dict.
-" @vimlint(EVL103, 1, a:event_type)
-function! s:nvim_exit_handler_buffered(job_id, data, event_type) abort
+function! s:nvim_exit_handler_buffered(job_id, data, _event_type) abort
     let jobinfo = get(s:jobs, get(s:map_job_ids, a:job_id, -1), {})
     if empty(jobinfo)
         call neomake#log#debug(printf('exit: job not found: %d.', a:job_id))
@@ -2337,10 +2334,8 @@ function! s:nvim_exit_handler_buffered(job_id, data, event_type) abort
 
     call s:exit_handler(jobinfo, a:data)
 endfunction
-" @vimlint(EVL103, 0, a:event_type)
 
-" @vimlint(EVL103, 1, a:event_type)
-function! s:nvim_exit_handler(job_id, data, event_type) abort
+function! s:nvim_exit_handler(job_id, data, _event_type) abort
     let jobinfo = get(s:jobs, get(s:map_job_ids, a:job_id, -1), {})
     if empty(jobinfo)
         call neomake#log#debug(printf('exit: job not found: %d.', a:job_id))
@@ -2348,7 +2343,6 @@ function! s:nvim_exit_handler(job_id, data, event_type) abort
     endif
     call s:exit_handler(jobinfo, a:data)
 endfunction
-" @vimlint(EVL103, 0, a:event_type)
 
 function! s:exit_handler(jobinfo, data) abort
     let jobinfo = a:jobinfo

--- a/autoload/neomake/core.vim
+++ b/autoload/neomake/core.vim
@@ -81,8 +81,6 @@ function! g:neomake#core#command_maker_base._get_fname_for_args(jobinfo) abort d
     return ''
 endfunction
 
-" @vimlint(EVL103, 1, a:jobinfo)
-function! g:neomake#core#command_maker_base._get_argv(jobinfo) abort dict
+function! g:neomake#core#command_maker_base._get_argv(_jobinfo) abort dict
     return neomake#compat#get_argv(self.exe, self.args, type(self.args) == type([]))
 endfunction
-" @vimlint(EVL103, 0, a:jobinfo)

--- a/autoload/neomake/makers/ft/haskell.vim
+++ b/autoload/neomake/makers/ft/haskell.vim
@@ -142,18 +142,11 @@ function! neomake#makers#ft#haskell#liquid() abort
       \ })
 endfunction
 
-" @vimlint(EVL103, 1, a.job_id)
-" @vimlint(EVL103, 1, a.event)
-" @vimlint(EVL101, 1, l.self)
-" vint: -ProhibitUsingUndeclaredVariable
-function! s:CheckStackMakerAsync(job_id, data, event) dict abort
+function! s:CheckStackMakerAsync(_job_id, data, _event) dict abort
     if a:data == 0
         call add(s:makers, substitute(self.command, '-', '', 'g'))
     endif
 endfunction
-" vint: +ProhibitUsingUndeclaredVariable
-" @vimlint(EVL101, 0)
-" @vimlint(EVL103, 0)
 
 function! s:TryStack(maker) abort
     if executable('stack')

--- a/autoload/neomake/makers/ft/java.vim
+++ b/autoload/neomake/makers/ft/java.vim
@@ -119,8 +119,7 @@ function! s:AddToClasspath(classpath, path) abort
     return (a:classpath !=# '') ? a:classpath . s:ClassSep() . a:path : a:path
 endfunction
 
-" @vimlint(EVL103, 1, a:classpathFile)
-function! s:ReadClassPathFile(classpathFile) abort
+function! s:ReadClassPathFile(_classpathFile) abort
     let cp = ''
     let file = g:neomake_java_checker_home. s:psep. 'java'. s:psep.  'classpath.py'
     if has('python3')
@@ -134,7 +133,6 @@ function! s:ReadClassPathFile(classpathFile) abort
     endif
     return cp
 endfunction
-" @vimlint(EVL103, 0)
 
 function! neomake#makers#ft#java#EnabledMakers() abort
     let makers = []

--- a/autoload/neomake/makers/ft/javascript.vim
+++ b/autoload/neomake/makers/ft/javascript.vim
@@ -45,13 +45,11 @@ function! neomake#makers#ft#javascript#eslint() abort
         \ 'output_stream': 'stdout',
         \ }
 
-    " @vimlint(EVL103, 1, a:jobinfo)
-    function! maker.supports_stdin(jobinfo) abort
+    function! maker.supports_stdin(_jobinfo) abort
         let self.args += ['--stdin', '--stdin-filename=%:p']
         let self.tempfile_name = ''
         return 1
     endfunction
-    " @vimlint(EVL103, 0, a:jobinfo)
 
     return maker
 endfunction

--- a/autoload/neomake/makers/ft/vim.vim
+++ b/autoload/neomake/makers/ft/vim.vim
@@ -25,7 +25,6 @@ function! neomake#makers#ft#vim#vint() abort
         \   'pattern': '\v%(^:|%([^:]+: ))\zs(\S+)',
         \ }}
 
-    " @vimlint(EVL103, 1, a:_jobinfo)
     function! maker.supports_stdin(_jobinfo) abort
         let exe = exists('*exepath') ? exepath(self.exe) : self.exe
         let support = get(s:vint_supports_stdin, exe, -1)
@@ -45,7 +44,6 @@ function! neomake#makers#ft#vim#vint() abort
         endif
         return support
     endfunction
-    " @vimlint(EVL103, 0, a:_jobinfo)
     return maker
 endfunction
 

--- a/autoload/neomake/utils.vim
+++ b/autoload/neomake/utils.vim
@@ -83,8 +83,7 @@ endfunction
 let s:maker_from_command = extend(copy(g:neomake#core#command_maker_base), {
             \ 'remove_invalid_entries': 0,
             \ })
-" @vimlint(EVL103, 1, a:options)
-function! s:maker_from_command.fn(options) dict abort
+function! s:maker_from_command.fn(_options) dict abort
     " Return a cleaned up copy of self.
     let maker = filter(deepcopy(self), "v:key !~# '^__' && v:key !=# 'fn'")
 
@@ -101,7 +100,6 @@ function! s:maker_from_command.fn(options) dict abort
     endif
     return maker
 endfunction
-" @vimlint(EVL103, 0, a:options)
 
 function! s:maker_from_command._get_argv(jobinfo) abort dict
     let args = self.args


### PR DESCRIPTION
Via https://github.com/syngan/vim-vimlint/issues/101#issuecomment-402725362.