### PR TITLE
tests: coverage: use data_file=.coverage_covimerage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 
 common: &common
   docker:
-    - image: neomake/vims-for-tests:27@sha256:23daeb84b6881890b41398c7a6b7e5db508d2e69bc68a4dcb6617b77cca7ae71
+    - image: neomake/vims-for-tests:28@sha256:293549b1df6771c5a59b3a82f29c27c5342d421c4ebe49de9421de40bf5ac2e9
   working_directory: ~/repo
   steps:
     - checkout

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,7 @@
 [run]
 plugins = covimerage
-data_file = .coverage.covimerage
+data_file = .coverage_covimerage
+
 [report]
 include = autoload/*,plugin/*,syntax/*,tests/*
 omit = tests/fixtures/vim/*

--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -49,7 +49,7 @@ RUN chmod +x /usr/local/bin/vimlint
 
 # Install covimerage and vint.
 RUN apk --no-cache add curl python3 \
-  && pip3 install --no-cache-dir covimerage==0.0.6 vim-vint \
+  && pip3 install --no-cache-dir covimerage==0.0.7 vim-vint \
   && rm -rf /usr/include /usr/lib/python*/turtle* /usr/lib/python*/tkinter \
   && pip3 uninstall --yes pip \
   && curl https://codecov.io/bash -o /usr/bin/codecov \

--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,8 @@ _REDIR_STDOUT:=2>&1 </dev/null >/dev/null $(_SED_HIGHLIGHT_ERRORS)
 # > Vim: Finished.
 # For Vim `-s /dev/null` is used to skip the 2s delay with warning
 # "Vim: Warning: Output is not to a terminal".
-_COVIMERAGE=$(if $(filter-out 0,$(NEOMAKE_DO_COVERAGE)),covimerage run --append --no-report ,)
+COVERAGE_FILE:=.coverage_covimerage
+_COVIMERAGE=$(if $(filter-out 0,$(NEOMAKE_DO_COVERAGE)),covimerage run --data-file $(COVERAGE_FILE) --append --no-report ,)
 define func-run-vim
 	$(info Using: $(shell $(TEST_VIM_PREFIX) $(TEST_VIM) --version | head -n2))
 	$(_COVIMERAGE)$(if $(TEST_VIM_PREFIX),env $(TEST_VIM_PREFIX) ,)$(TEST_VIM) \
@@ -127,7 +128,7 @@ $(_TESTS_REL_AND_ABS):
 
 testcoverage: COVERAGE_VADER_ARGS:=tests/main.vader $(wildcard tests/isolated/*.vader)
 testcoverage:
-	$(RM) .coverage.covimerage
+	$(RM) $(COVERAGE_FILE)
 	@ret=0; \
 	for testfile in $(COVERAGE_VADER_ARGS); do \
 	  $(MAKE) --no-print-directory test VADER_ARGS=$$testfile NEOMAKE_DO_COVERAGE=1 || (( ++ret )); \
@@ -239,7 +240,7 @@ docker_testcoverage: DOCKER_MAKE_TEST_TARGET:=testcoverage
 docker_testcoverage: DOCKER_MAKE_TEST_ARGS:=$(if $(filter command line,$(origin COVERAGE_VADER_ARGS)),COVERAGE_VADER_ARGS="$(COVERAGE_VADER_ARGS)",$(if $(filter command line,$(origin VADER_ARGS)),COVERAGE_VADER_ARGS="$(VADER_ARGS)",))
 docker_testcoverage: DOCKER_STREAMS:=-t
 docker_testcoverage: _docker_test
-	sed -i 's~/testplugin/~$(CURDIR)/~g' .coverage.covimerage
+	sed -i 's~/testplugin/~$(CURDIR)/~g' $(COVERAGE_FILE)
 	coverage report -m
 
 docker_run: $(DEP_PLUGINS)
@@ -338,9 +339,9 @@ check:
 	tput sgr0; \
 	exit $$ret
 
-.coverage.covimerage: .coveragerc $(shell find . -name '*.vim')
+$(COVERAGE_FILE): .coveragerc $(shell find . -name '*.vim')
 	$(MAKE) testcoverage
-coverage: .coverage.covimerage
+coverage: $(COVERAGE_FILE)
 	coverage report -m
 
 NEOMAKE_LOG:=/tmp/neomake.log

--- a/Makefile
+++ b/Makefile
@@ -179,7 +179,7 @@ vimhelplint: | $(if $(VIMHELPLINT_DIR),,build/vimhelplint)
 
 # Run tests in dockerized Vims.
 DOCKER_REPO:=neomake/vims-for-tests
-DOCKER_TAG:=27
+DOCKER_TAG:=28
 NEOMAKE_DOCKER_IMAGE?=
 DOCKER_IMAGE:=$(if $(NEOMAKE_DOCKER_IMAGE),$(NEOMAKE_DOCKER_IMAGE),$(DOCKER_REPO):$(DOCKER_TAG))
 DOCKER_STREAMS:=-ti


### PR DESCRIPTION
`.coverage.covimerage` gets picked up by coveragepy when combining data,
which gets triggered through pytest-cov.