### PR TITLE
contrib/highlight-log: match "Starting Vader:" everywhere

### DIFF
--- a/contrib/highlight-log
+++ b/contrib/highlight-log
@@ -56,7 +56,7 @@ if [ "$1" = vader ]; then
       fi
       # quiet/compact: suppress output until "Starting Vader:".
       if ! ((quiet_started)); then
-        if [[ "$REPLY" == 'Starting Vader:'* ]]; then
+        if [[ "$REPLY" == *'Starting Vader:'* ]]; then
           printf "\r" >&2
           echo "$REPLY"
           quiet_started=1


### PR DESCRIPTION
It might be after some output from ":echom" when quiet mode is used.

Ref: https://github.com/junegunn/vader.vim/pull/172