### PR TITLE
Handle nested hook invocations via action queue

### DIFF
--- a/autoload/neomake/utils.vim
+++ b/autoload/neomake/utils.vim
@@ -344,8 +344,11 @@ function! neomake#utils#hook(event, context, ...) abort
         let jobinfo = a:0 ? a:1 : (
                     \ has_key(a:context, 'jobinfo') ? a:context.jobinfo : {})
 
+        let context_str = string(map(copy(a:context),
+                    \ "v:key ==# 'jobinfo' ? '…'"
+                    \ .": (v:key ==# 'finished_jobs' ? map(copy(v:val), 'v:val.as_string()') : v:val)"))
         let args = [printf('Calling User autocmd %s with context: %s.',
-                    \ a:event, string(map(copy(a:context), "v:key ==# 'jobinfo' ? '…' : v:val")))]
+                    \ a:event, context_str)]
         if !empty(jobinfo)
             let args += [jobinfo]
         endif

--- a/tests/hooks-queue.vader
+++ b/tests/hooks-queue.vader
@@ -32,6 +32,12 @@ Execute (hook handling gets queued for global g:neomake_hook_context):
   AssertEqual len(g:neomake_test_jobfinished), 2
   AssertEqual len(s:finished_called), 2
 
+  " Timer events do not cause it to finish, but get reset, so that no error is
+  " reported.
+  if neomake#has_async_support()
+    AssertNeomakeMessage 's:process_action_queue: decrementing timer tries for non-Timer event.', 3
+  endif
+
 Execute (hook handling gets queued for global g:neomake_hook_context (with postprocessing)):
   call g:NeomakeSetupAutocmdWrappers()
   let maker = copy(g:success_maker)
@@ -65,7 +71,7 @@ Execute (hook handling gets queued for global g:neomake_hook_context (with postp
   AssertEqual len(g:neomake_test_jobfinished), 2
   AssertEqual len(s:finished_called), 2
 
-Execute (Nested neomake#utils#hook):
+Execute (Nested neomake#utils#hook must not be nested (directly)):
   function! s:nested_hook_cb(c)
       AssertEqual g:neomake_hook_context, {'context': a:c}
       let next = a:c + 1
@@ -80,30 +86,55 @@ Execute (Nested neomake#utils#hook):
   call neomake#utils#hook('Event1', {'context': 1})
   AssertNeomakeMessage "Calling User autocmd Event1 with context: {'context': 1}.", 2
   AssertNeomakeMessage "Calling User autocmd Event2 with context: {'context': 2}.", 2
-  AssertNeomakeMessage "Calling User autocmd Event3 with context: {'context': 3}.", 2
+  AssertNeomakeMessage 'Error during User autocmd for Event1: Neomake internal error: hook invocation must not be nested: Event2.', 0
 
-Execute (Nested neomake#utils#hook with exception):
-  function! s:nested_hook_cb(c)
-    AssertEqual g:neomake_hook_context, {'context': a:c}
-    let next = a:c + 1
-    if a:c == 2
-      throw 'Exception'
-    endif
-    call neomake#utils#hook('Event'.next, {'context': next})
-  endfunction
-
+Execute (neomake#utils#hook: reports exception):
   augroup neomake_tests
-    au User Event1 call s:nested_hook_cb(1)
-    au User Event2 call s:nested_hook_cb(2)
-
-    au User Event3 let g:neomake_hook_context = 'changed'
+    au User Event1 throw 'Exception'
   augroup END
   call neomake#utils#hook('Event1', {'context': 1})
   AssertNeomakeMessage "Calling User autocmd Event1 with context: {'context': 1}.", 2
-  AssertNeomakeMessage "Calling User autocmd Event2 with context: {'context': 2}.", 2
-  AssertNeomakeMessage 'Error during User autocmd for Event2: Exception.', 0
+  AssertNeomakeMessage 'Error during User autocmd for Event1: Exception.', 0
   Assert !exists('g:neomake_hook_context'), 'g:neomake_hook_context was cleared'
 
-  call neomake#utils#hook('Event3', {'context': 'fake'})
-  AssertNeomakeMessage 'Error during User autocmd for Event3: Vim(let):E741: Value is locked: g:neomake_hook_context.', 0
+Execute (neomake#utils#hook: context is locked):
+  augroup neomake_tests
+    au User Event1 let g:neomake_hook_context = 'changed'
+  augroup END
+
+  call neomake#utils#hook('Event1', {'context': 'fake'})
+  AssertNeomakeMessage 'Error during User autocmd for Event1: Vim(let):E741: Value is locked: g:neomake_hook_context.', 0
   Assert !exists('g:neomake_hook_context'), 'g:neomake_hook_context was cleared'
+
+Execute (Does not nest hooks / User autocommands):
+  if NeomakeAsyncTestsSetup()
+    new
+
+    augroup neomake_tests
+      autocmd User NeomakeJobFinished nested call s:OnNeomakeJobFinished()
+    augroup END
+
+    function! s:OnNeomakeJobFinished() abort
+      let jobinfo = g:neomake_hook_context.jobinfo
+      if jobinfo.maker.name == 'maker1'
+        NeomakeTestsWaitForMessage 'Not processing output during active hook processing.', 3
+        AssertNeomakeMessage 'Queueing action: s:process_pending_output for Timer, BufEnter, WinEnter, InsertLeave, CursorHold, CursorHoldI.', 3
+        NeomakeTestsWaitForMessage 'Retrying Timer event in 10ms.', 3
+      endif
+      " call neomake#log#debug('OnNeomakeJobFinished finished.')
+    endfunction
+
+    let maker1 = NeomakeTestsCommandMaker('maker1', 'echo error1; exit 1')
+    let maker1.errorformat = '%E%m'
+    let maker2 = NeomakeTestsCommandMaker('maker2', 'sleep .1; echo error2; exit 2')
+    let maker2.errorformat = '%E%m'
+
+    CallNeomake 1, [maker1, maker2]
+
+    AssertEqual map(getloclist(0), 'v:val.text'), ['error1']
+    NeomakeTestsWaitForMessage 'Processed pending output.', 3
+
+    AssertEqual map(getloclist(0), 'v:val.text'), ['error1', 'error2']
+    AssertNeomakeMessage 'action queue: processed 1 items.'
+    bwipe
+  endif


### PR DESCRIPTION
This fixes a missing-make_info error in case an outer NeomakeJobFinished
hook invocation wraps the one from the following job.