### PR TITLE
add vale linting (process_json)

### DIFF
--- a/autoload/neomake/compat.vim
+++ b/autoload/neomake/compat.vim
@@ -65,19 +65,21 @@ else
         " The following is inspired by https://github.com/MarcWeber/vim-addon-manager and
         " http://stackoverflow.com/questions/17751186/iterating-over-a-string-in-vimscript-or-parse-a-json-file/19105763#19105763
         " A hat tip to Marc Weber for this trick
-        if substitute(a:json, '\v\"%(\\.|[^"\\])*\"|true|false|null|[+-]?\d+%(\.\d+%([Ee][+-]?\d+)?)?', '', 'g') !~# "[^,:{}[\\] \t]"
+        " Replace newlines, which eval() does not like.
+        let json = substitute(a:json, "\n", '', 'g')
+        if substitute(json, '\v\"%(\\.|[^"\\])*\"|true|false|null|[+-]?\d+%(\.\d+%([Ee][+-]?\d+)?)?', '', 'g') !~# "[^,:{}[\\] \t]"
             " JSON artifacts
             let true = g:neomake#compat#json_true
             let false = g:neomake#compat#json_false
             let null = g:neomake#compat#json_null
 
             try
-                let object = eval(a:json)
+                let object = eval(json)
             catch
-                throw 'Neomake: Failed to parse JSON input'
+                throw 'Neomake: Failed to parse JSON input: '.v:exception
             endtry
         else
-            throw 'Neomake: Failed to parse JSON input'
+            throw 'Neomake: Failed to parse JSON input: invalid input'
         endif
 
         return object

--- a/autoload/neomake/makers/ft/markdown.vim
+++ b/autoload/neomake/makers/ft/markdown.vim
@@ -1,13 +1,16 @@
 function! neomake#makers#ft#markdown#SupersetOf() abort
     return 'text'
 endfunction
+
 function! neomake#makers#ft#markdown#EnabledMakers() abort
     let makers = executable('mdl') ? ['mdl'] : ['markdownlint']
+    if executable('vale') | let makers += ['vale'] | endif
     return makers + ['writegood'] + neomake#makers#ft#text#EnabledMakers()
 endfunction
 
 function! neomake#makers#ft#markdown#mdl() abort
     return {
+        \
         \ 'errorformat':
         \   '%W%f:%l: MD%n %m,' .
         \   '%W%f:%l: %m',
@@ -17,17 +20,45 @@ endfunction
 
 function! neomake#makers#ft#markdown#markdownlint() abort
     return {
-                \ 'errorformat':
-                \ '%f: %l: %m'
-                \ }
+        \ 'errorformat': '%f: %l: %m'
+        \ }
 endfunction
 
 function! neomake#makers#ft#markdown#alex() abort
     return {
-                \ 'errorformat':
-                \ '%P%f,' .
-                \ '%-Q,' .
-                \ '%*[ ]%l:%c-%*\d:%n%*[ ]%tarning%*[ ]%m,' .
-                \ '%-G%.%#'
-                \ }
+        \ 'errorformat':
+        \   '%P%f,'
+        \   .'%-Q,'
+        \   .'%*[ ]%l:%c-%*\d:%n%*[ ]%tarning%*[ ]%m,'
+        \   .'%-G%.%#'
+        \ }
+endfunction
+
+function! neomake#makers#ft#markdown#ProcessVale(context) abort
+    let entries = []
+    for [filename, items] in items(a:context['json'])
+      for data in items
+        let entry = {
+            \ 'maker_name': 'vale',
+            \ 'filename': filename,
+            \ 'text': data.Message,
+            \ 'lnum': data.Line,
+            \ 'col': data.Span[0],
+            \ 'length': data.Span[1] - data.Span[0],
+            \ 'type': toupper(data.Severity[0])
+            \ }
+        call add(entries, entry)
+      endfor
+    endfor
+    return entries
+endfunction
+
+function! neomake#makers#ft#markdown#vale() abort
+    return {
+        \ 'args': [
+        \   '--no-wrap',
+        \   '--output', 'JSON'
+        \ ],
+        \ 'process_json': function('neomake#makers#ft#markdown#ProcessVale')
+        \ }
 endfunction

--- a/tests/compat.vader
+++ b/tests/compat.vader
@@ -54,10 +54,14 @@ Execute (neomake#compat#json_decode):
   elseif exists('*json_decode')
     let expected_exception = 'Vim(return):E474: Invalid argument'
   else
-    let expected_exception = 'Neomake: Failed to parse JSON input'
+    let expected_exception = 'Neomake: Failed to parse JSON input: invalid input'
   endif
   AssertThrows call neomake#compat#json_decode('success')
   AssertEqual g:vader_exception, expected_exception
+
+Execute (neomake#compat#json_decode: handles newlines):
+  let json = '{"foo": '."\n".'"bar"}'
+  AssertEqual neomake#compat#json_decode(json), {'foo': 'bar'}
 
 Execute (neomake#compat#json_none):
   AssertThrows call items(g:neomake#compat#json_none)

--- a/tests/ft_markdown.vader
+++ b/tests/ft_markdown.vader
@@ -1,0 +1,42 @@
+Include: include/setup.vader
+
+Execute (markdown: vale):
+  new
+  file README.md
+  let mock = [
+      \   '{',
+      \   '  "README.md": [',
+      \   '    {',
+      \   '      "Check": "vale.Hedging",',
+      \   '      "Description": "",',
+      \   '      "Line": 22,',
+      \   '      "Link": "",',
+      \   "      \"Message\": \"Consider removing 'probably'\",",
+      \   '      "Severity": "warning",',
+      \   '      "Span": [',
+      \   '        45,',
+      \   '        52',
+      \   '      ],',
+      \   '      "Hide": false,',
+      \   '      "Match": ""',
+      \   '    }',
+      \   '  ]',
+      \   '}',
+      \   '',
+      \ ]
+  let vale_maker = NeomakeTestsGetMakerWithOutput('neomake#makers#ft#markdown#vale', mock)
+  CallNeomake 1, [vale_maker]
+  AssertEqualQf getloclist(0), [
+      \   {
+      \     'lnum': 22,
+      \     'bufnr': bufnr('%'),
+      \     'col': 45,
+      \     'valid': 1,
+      \     'vcol': 0,
+      \     'nr': -1,
+      \     'type': 'W',
+      \     'pattern': '',
+      \     'text': "Consider removing 'probably'"
+      \   }
+      \ ]
+  bwipe

--- a/tests/main.vader
+++ b/tests/main.vader
@@ -53,6 +53,7 @@ Include (Go): ft_go.vader
 Include (Haskell): ft_haskell.vader
 Include (Idris): ft_idris.vader
 Include (JavaScript): ft_javascript.vader
+Include (Markdown): ft_markdown.vader
 Include (Perl): ft_perl.vader
 Include (PHP): ft_php.vader
 Include (Puppet): ft_puppet.vader

--- a/tests/makers.vader
+++ b/tests/makers.vader
@@ -517,7 +517,7 @@ Execute (Makers: process_json with invalid JSON):
   elseif exists('*json_decode')
     AssertNeomakeMessage "Failed to decode JSON: Vim(return):E474: Invalid argument (output: 'success').", 0
   else
-    AssertNeomakeMessage "Failed to decode JSON: Failed to parse JSON input (output: 'success').", 0
+    AssertNeomakeMessage "Failed to decode JSON: Failed to parse JSON input: invalid input (output: 'success').", 0
   endif
 
 Execute (Makers: process_json with non-list return value):


### PR DESCRIPTION
Request input particularly on the `let filename = buffer_name(bufnr)` line -- that can't be the best way to go through the JSON object...