### PR TITLE
Make SwiftPM build tests

### DIFF
--- a/autoload/neomake/makers/ft/swift.vim
+++ b/autoload/neomake/makers/ft/swift.vim
@@ -12,7 +12,7 @@ endfunction
 function! neomake#makers#ft#swift#swiftpm() abort
     return {
         \ 'exe': 'swift',
-        \ 'args': ['build'],
+        \ 'args': ['build', '--build-tests'],
         \ 'append_file': 0,
         \ 'errorformat':
             \ '%E%f:%l:%c: error: %m,' .


### PR DESCRIPTION
Previously building only meant building source modules. Now it also
builds tests to find compiler errors.

We might not want to make this the default, since some people might not expect this behavior. Alternatively we could expose a setting that allows users to pass more arguments to `swift build` if they'd like to.