### PR TITLE
Move expanding args to _get_argv, skip filename

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -698,16 +698,18 @@ function! s:command_maker_base._bind_args() abort dict
 endfunction
 
 function! s:command_maker_base._get_argv(jobinfo) abort dict
-    let args = self.args
-    let args_is_list = type(self.args) == type([])
     let filename = self._get_fname_for_args(a:jobinfo)
-    if !empty(filename)
-        let args = copy(args)
-        if args_is_list
+    let args_is_list = type(self.args) == type([])
+    if args_is_list
+        let args = neomake#utils#ExpandArgs(self.args)
+        if !empty(filename)
             call add(args, filename)
-        else
-            let args .= (empty(args) ? '' : ' ').fnameescape(filename)
         endif
+    elseif !empty(filename)
+        let args = copy(self.args)
+        let args .= (empty(args) ? '' : ' ').neomake#utils#shellescape(filename)
+    else
+        let args = self.args
     endif
     return neomake#compat#get_argv(self.exe, args, args_is_list)
 endfunction

--- a/autoload/neomake/compat.vim
+++ b/autoload/neomake/compat.vim
@@ -180,12 +180,11 @@ if neomake#utils#IsRunningWindows()
     function! neomake#compat#get_argv(exe, args, args_is_list) abort
         let prefix = &shell.' '.&shellcmdflag.' '
         if a:args_is_list
-            let args = neomake#utils#ExpandArgs(a:args)
-            if a:exe ==# &shell && get(args, 0) ==# &shellcmdflag
+            if a:exe ==# &shell && get(a:args, 0) ==# &shellcmdflag
                 " Remove already existing &shell/&shellcmdflag from e.g. NeomakeSh.
-                let argv = join(args[1:])
+                let argv = join(a:args[1:])
             else
-                let argv = join(map(copy([a:exe] + args), 'neomake#utils#shellescape(v:val)'))
+                let argv = join(map(copy([a:exe] + a:args), 'neomake#utils#shellescape(v:val)'))
             endif
         else
             let argv = a:exe . (empty(a:args) ? '' : ' '.a:args)
@@ -198,14 +197,14 @@ if neomake#utils#IsRunningWindows()
 elseif has('nvim')
     function! neomake#compat#get_argv(exe, args, args_is_list) abort
         if a:args_is_list
-            return [a:exe] + neomake#utils#ExpandArgs(a:args)
+            return [a:exe] + a:args
         endif
         return a:exe . (empty(a:args) ? '' : ' '.a:args)
     endfunction
 elseif neomake#has_async_support()  " Vim-async.
     function! neomake#compat#get_argv(exe, args, args_is_list) abort
         if a:args_is_list
-            return [a:exe] + neomake#utils#ExpandArgs(a:args)
+            return [a:exe] + a:args
         endif
         " Use a shell to handle argv properly (Vim splits at spaces).
         let argv = a:exe . (empty(a:args) ? '' : ' '.a:args)
@@ -215,8 +214,7 @@ else
     " Vim (synchronously), via system().
     function! neomake#compat#get_argv(exe, args, args_is_list) abort
         if a:args_is_list
-            let args = neomake#utils#ExpandArgs(a:args)
-            return join(map(copy([a:exe] + args), 'neomake#utils#shellescape(v:val)'))
+            return join(map(copy([a:exe] + a:args), 'neomake#utils#shellescape(v:val)'))
         endif
         return a:exe . (empty(a:args) ? '' : ' '.a:args)
     endfunction

--- a/autoload/neomake/utils.vim
+++ b/autoload/neomake/utils.vim
@@ -102,11 +102,11 @@ function! s:maker_from_command.fn(_options) dict abort
 endfunction
 
 function! s:maker_from_command._get_argv(jobinfo) abort dict
-    let args = self.args
     let fname = self._get_fname_for_args(a:jobinfo)
+    let args = neomake#utils#ExpandArgs(self.args)
     if !empty(fname)
-        let args = copy(args)
         if self.__command_is_string
+            let fname = neomake#utils#shellescape(fname)
             let args[-1] .= ' '.fname
         else
             call add(args, fname)
@@ -330,11 +330,7 @@ function! neomake#utils#ExpandArgs(args) abort
                 \ . '''\(\%(\\\@<!\\\)\@<!%\%(%\|\%(:[phtre.]\+\)*\)\ze\)\w\@!'', '
                 \ . '''\=(submatch(1) == "%%" ? "%" : expand(submatch(1)))'', '
                 \ . '''g'')')
-    let ret = map(ret,
-                \ 'substitute(v:val, '
-                \ . '''\(\%(\\\@<!\\\)\@<!\~\)'', '
-                \ . 'expand(''~''), '
-                \ . '''g'')')
+    let ret = map(ret, 'substitute(v:val, ''\v^\~\ze%(/|$)'', expand(''~''), ''g'')')
     return ret
 endfunction
 

--- a/tests/args.vader
+++ b/tests/args.vader
@@ -37,3 +37,72 @@ Execute (maker.args as string gets not escaped):
   AssertEqual map(getloclist(0), 'v:val.text'),
     \ ['1', '2', '3a 3b', '4', fname]
   bwipe
+
+Execute (fname in args gets not expanded (command maker, args as list)):
+  let maker = {
+        \ 'exe': 'printf',
+        \ 'args': ['%s'],
+        \ 'errorformat': '%m',
+        \ }
+  new
+  lcd tests/fixtures
+  edit ~
+  CallNeomake 1, [maker]
+  AssertEqual map(getloclist(0), 'v:val.text'), ['~']
+  if neomake#has_async_support()
+    AssertNeomakeMessage "Starting async job: printf '%s' '~'."
+  else
+    AssertNeomakeMessage "Starting [string]: printf '%s' '~'."
+  endif
+  bwipe
+
+Execute (fname in args gets not expanded (command maker, args as string)):
+  let maker = {
+        \ 'exe': 'printf',
+        \ 'args': '%s',
+        \ 'errorformat': '%m',
+        \ }
+  new
+  lcd tests/fixtures
+  edit ~
+  CallNeomake 1, [maker]
+  AssertEqual map(getloclist(0), 'v:val.text'), ['~']
+  if neomake#has_async_support()
+    if has('nvim')
+      AssertNeomakeMessage "Starting async job [string]: printf %s '~'."
+    endif
+  else
+    AssertNeomakeMessage "Starting [string]: printf %s '~'."
+  endif
+  bwipe
+
+Execute (fname in args gets not expanded (maker from command string)):
+  let maker = neomake#utils#MakerFromCommand('printf %s')
+  let maker.errorformat = '%m'
+  new
+  lcd tests/fixtures
+  edit ~
+  CallNeomake 1, [maker]
+  AssertEqual map(getloclist(0), 'v:val.text'), ['~']
+  let shell_argv = join(split(&shell) + split(&shellcmdflag))
+  if neomake#has_async_support()
+    AssertNeomakeMessage "Starting async job: ".shell_argv." 'printf %s '\\''~'\\'''."
+  else
+    AssertNeomakeMessage "Starting [string]: ".shell_argv." 'printf %s '\\''~'\\'''."
+  endif
+  bwipe
+
+Execute (fname in args gets not expanded (maker from command list)):
+  let maker = neomake#utils#MakerFromCommand(['printf', '%s'])
+  let maker.errorformat = '%m'
+  new
+  lcd tests/fixtures
+  edit ~
+  CallNeomake 1, [maker]
+  AssertEqual map(getloclist(0), 'v:val.text'), ['~']
+  if neomake#has_async_support()
+    AssertNeomakeMessage "Starting async job: printf '%s' '~'."
+  else
+    AssertNeomakeMessage "Starting [string]: printf '%s' '~'."
+  endif
+  bwipe

--- a/tests/fixtures/~
+++ b/tests/fixtures/~
@@ -1,0 +1,1 @@
+" Test fixture file for ':edit ~'

--- a/tests/stdin.vader
+++ b/tests/stdin.vader
@@ -30,10 +30,10 @@ Execute (stdin maker (args as string)):
   call neomake#Make(1, [maker])
   if neomake#has_async_support()
     if has('nvim')
-      AssertNeomakeMessage "Starting async job [string]: cat \\-.", 2
+      AssertNeomakeMessage "Starting async job [string]: cat -.", 2
     else
       let shell_argv = join(split(&shell) + split(&shellcmdflag))
-      AssertNeomakeMessage 'Starting async job: '.shell_argv." 'cat \\-'.", 2
+      AssertNeomakeMessage 'Starting async job: '.shell_argv." 'cat -'.", 2
     endif
     NeomakeTestsWaitForFinishedJobs
   endif
@@ -107,6 +107,34 @@ Execute (stdin maker (project mode: uses_filename)):
 Execute (stdin maker: supports_stdin can be a callback adding args):
   let maker = {'exe': 'printf', 'args': ['%s\n']}
   function maker.supports_stdin(jobinfo)
+    let self.args += ['added_arg']
+    return 1
+  endfunction
+  new
+  set buftype=nofile
+  CallNeomake 1, [maker]
+  AssertNeomakeMessage 'Using stdin for unnamed buffer (-).'
+  AssertEqual map(getloclist(0), 'v:val.text'), ['added_arg', '-']
+  bwipe
+
+Execute (stdin maker: supports_stdin can be a callback adding args (maker from command string)):
+  let maker = neomake#utils#MakerFromCommand('printf "%s\n"')
+  function maker.supports_stdin(jobinfo)
+    AssertEqual self.__command_is_string, 1
+    let self.args[-1] .= ' added_arg'
+    return 1
+  endfunction
+  new
+  set buftype=nofile
+  CallNeomake 1, [maker]
+  AssertNeomakeMessage 'Using stdin for unnamed buffer (-).'
+  AssertEqual map(getloclist(0), 'v:val.text'), ['added_arg', '-']
+  bwipe
+
+Execute (stdin maker: supports_stdin can be a callback adding args (maker from command list)):
+  let maker = neomake#utils#MakerFromCommand(['printf', '%s\n'])
+  function maker.supports_stdin(jobinfo)
+    AssertEqual self.__command_is_string, 0
     let self.args += ['added_arg']
     return 1
   endfunction

--- a/tests/utils.vader
+++ b/tests/utils.vader
@@ -279,6 +279,10 @@ Execute (neomake#utils#ExpandArgs):
   \ 'C:\\%:r\\',
   \ '~',
   \ '\~',
+  \ 't/~=+.view.vim',
+  \ '~/foo',
+  \ '~/',
+  \ '~foo',
   \ '%:.',
   \ '%:,',
   \ ]
@@ -302,6 +306,10 @@ Execute (neomake#utils#ExpandArgs):
   \ 'C:\\file1\\',
   \ '/home/sweet',
   \ '\~',
+  \ 't/~=+.view.vim',
+  \ '/home/sweet/foo',
+  \ '/home/sweet/',
+  \ '~foo',
   \ 'file1.ext',
   \ 'file1.ext:,',
   \ ]
@@ -400,43 +408,45 @@ Execute (neomake#utils#MakerFromCommand copies args):
   bwipe
 
 Execute (neomake#utils#MakerFromCommand appends args for file_mode (string)):
-  let maker = neomake#utils#MakerFromCommand('echo "%" 1')
+  let maker = neomake#utils#MakerFromCommand('printf "%s\n" "%" 1')
 
   new
   edit tests/fixtures/a\ filename\ with\ spaces
 
-  let jobinfo = {'file_mode': 0, 'bufnr': bufnr('%'), 'ft': ''}
+  let jobinfo = NeomakeTestsFakeJobinfo()
   let shell_argv = split(&shell) + split(&shellcmdflag)
   AssertEqual maker.fn(jobinfo), {
   \ '__command_is_string': 1,
   \ '_get_argv': get(maker, '_get_argv'),
   \ '_get_fname_for_args': get(maker, '_get_fname_for_args'),
-  \ 'args': shell_argv[1:] + ['echo "%" 1'],
+  \ 'args': shell_argv[1:] + ['printf "%s\n" "%" 1'],
   \ 'exe': shell_argv[0],
   \ 'remove_invalid_entries': 0}
 
   let fname = bufname('%')
-  let jobinfo = NeomakeTestsFakeJobinfo()
   let jobinfo.maker = maker
   let bound_maker = neomake#GetMaker(maker).fn(jobinfo)
-  AssertEqual bound_maker.args, shell_argv[1:] + ['echo "%" 1']
+  AssertEqual bound_maker.args, shell_argv[1:] + ['printf "%s\n" "%" 1']
   AssertEqual bound_maker.exe, shell_argv[0]
   AssertEqual bound_maker.remove_invalid_entries, 0
 
   call bound_maker._bind_args()
-  AssertEqual bound_maker.args, shell_argv[1:] + ['echo "%" 1']
+  AssertEqual bound_maker.args, shell_argv[1:] + ['printf "%s\n" "%" 1']
 
   let argv = bound_maker._get_argv(jobinfo)
   if type(argv) == type([])
-    AssertEqual argv, shell_argv + ['echo "'.bufname('%').'" 1 '.fname]
+    AssertEqual argv, shell_argv + ['printf "%s\n" "'.fname.'" 1 ''tests/fixtures/a filename with spaces''']
   else
-    AssertEqual argv, join(shell_argv)." 'echo \"".bufname('%').'" 1 '.fname."'"
+    AssertEqual argv, join(shell_argv).' ''printf "%s\n" "tests/fixtures/a filename with spaces" 1 ''\''''tests/fixtures/a filename with spaces''\'''''''
   endif
   " self.args is not changed.
-  AssertEqual bound_maker.args, shell_argv[1:] + ['echo "%" 1']
+  AssertEqual bound_maker.args, shell_argv[1:] + ['printf "%s\n" "%" 1']
 
-  CallNeomake 0, [maker]
-  AssertEqual getqflist()[0].text, 'tests/fixtures/a filename with spaces 1'
+  CallNeomake 1, [maker]
+  AssertEqual map(getloclist(0), 'v:val.text'), [
+  \ 'tests/fixtures/a filename with spaces',
+  \ '1',
+  \ 'tests/fixtures/a filename with spaces']
   bwipe
 
 Execute (neomake#utils#MakerFromCommand appends args for file_mode (list)):
@@ -463,9 +473,9 @@ Execute (neomake#utils#MakerFromCommand appends args for file_mode (list)):
 
   let argv = bound_maker._get_argv(jobinfo)
   if type(argv) == type([])
-    AssertEqual argv, ['echo', bufname('%'), '1', fname]
+    AssertEqual argv, ['echo', fname, '1', fname]
   else
-    AssertEqual argv, printf("echo '%s' 1 '%s'", bufname('%'), fname)
+    AssertEqual argv, printf("echo '%s' 1 '%s'", fname, 'tests/fixtures/a filename with spaces')
   endif
   AssertEqual bound_maker.args, ['%', '1']
 
@@ -560,7 +570,7 @@ Execute (neomake#utils#MakerFromCommand uses tempfile):
   AssertEqual bound_maker.exe, shell_argv[0]
   AssertEqual bound_maker.remove_invalid_entries, 0
 
-  call bound_maker._get_argv(jobinfo)
+  let argv = bound_maker._get_argv(jobinfo)
   let temp_file = fnamemodify(make_info.tempfiles[0], ':.')
   AssertNotEqual temp_file, fnameescape(temp_file)
 


### PR DESCRIPTION
This fixes neomake#utils#ExpandArgs for 'foo/~', but also does not use
it anymore at all for filename args.