### PR TITLE
Docker/tests: add nvim 0.3.1, remove others

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 
 common: &common
   docker:
-    - image: neomake/vims-for-tests:28@sha256:293549b1df6771c5a59b3a82f29c27c5342d421c4ebe49de9421de40bf5ac2e9
+    - image: neomake/vims-for-tests:29@sha256:4645fac4f6d962749665b0582fd1b0177d18764f27a821189d3f445c4e04335c
   working_directory: ~/repo
   steps:
     - checkout
@@ -18,42 +18,22 @@ common: &common
             -n "$CIRCLE_JOB" -F ${CIRCLE_JOB%%-*},${CIRCLE_JOB//[-.]/}
           set +x
 jobs:
-  nvim-master:
+  nvim-031:
     <<: *common
     environment:
-      TEST_VIM=/vim-build/bin/neovim-master
+      TEST_VIM=/vim-build/bin/neovim-v0.3.1
   nvim-017:
     <<: *common
     environment:
       TEST_VIM=/vim-build/bin/neovim-v0.1.7
-  nvim-020:
+  vim-81:
     <<: *common
     environment:
-      TEST_VIM=/vim-build/bin/neovim-v0.2.0
-  nvim-021:
+      TEST_VIM=/vim-build/bin/vim81
+  vim-80:
     <<: *common
     environment:
-      TEST_VIM=/vim-build/bin/neovim-v0.2.1
-  nvim-022:
-    <<: *common
-    environment:
-      TEST_VIM=/vim-build/bin/neovim-v0.2.2
-  nvim-030:
-    <<: *common
-    environment:
-      TEST_VIM=/vim-build/bin/neovim-v0.3.0
-  vim-master:
-    <<: *common
-    environment:
-      TEST_VIM=/vim-build/bin/vim-master
-  vim-8.0.1832:
-    <<: *common
-    environment:
-      TEST_VIM=/vim-build/bin/vim-8.0.1832
-  vim-8.0.586:
-    <<: *common
-    environment:
-      TEST_VIM=/vim-build/bin/vim-8.0.586
+      TEST_VIM=/vim-build/bin/vim80
   vim-74-xenial:
     <<: *common
     environment:
@@ -77,15 +57,10 @@ workflows:
   version: 2
   test:
     jobs:
-      - nvim-030
-      - nvim-022
-      - nvim-master
-      - nvim-021
-      - nvim-020
+      - nvim-031
       - nvim-017
-      - vim-8.0.1832
-      - vim-8.0.586
-      - vim-master
+      - vim-81
+      - vim-80
       - vim-74-xenial
       - vim-74-trusty
       - vim-73

--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -1,5 +1,5 @@
 # From https://github.com/tweekmonster/vim-testbed.
-FROM testbed/vim:10@sha256:be6e7e3b7b424671da955ccc71a980f329ec10b773cbae001e696429148ed391
+FROM testbed/vim:11@sha256:eb8309ee34ecd3f95c27eefc8720dd6446ff00c026fbb41b172ea2777330af5e
 
 # Currently tested versions:
 #  - v7.3.429 (Ubuntu Precise, 12.04LTS)
@@ -10,21 +10,13 @@ FROM testbed/vim:10@sha256:be6e7e3b7b424671da955ccc71a980f329ec10b773cbae001e696
 RUN install_vim -tag v7.3.429 -name vim73 --with-features=huge -build \
                 -tag v7.4.052 -name vim74-trusty --with-features=huge -build \
                 -tag v7.4.1689 -name vim74-xenial --with-features=huge -build \
-                -tag v8.0.0586 -name vim-8.0.586 -py2 -build \
-                -tag v8.0.1832 -name vim-8.0.1832 -build \
+                -tag v8.0.0586 -name vim80 -py2 -build \
+                -tag v8.1.0129 -name vim81 -build \
                 -tag neovim:v0.1.7 -build \
-                -tag neovim:v0.2.0 -build \
-                -tag neovim:v0.2.1 -build \
-                -tag neovim:v0.2.2 -build \
-                -tag neovim:v0.3.0 -py3 -build \
+                -tag neovim:v0.3.1 -py3 -build \
   && rm -rf /vim-build/vim/vim/*/share/vim/*/tutor
 
-ENV NEOMAKE_DOCKERFILE_UPDATE=2018-06-26
-
-# Git master in a separate layer, since the above is meant to be stable.
-RUN install_vim -tag master -build \
-                -tag neovim:master -build \
-  && rm -rf /vim-build/vim/vim/*/share/vim/*/tutor
+ENV NEOMAKE_DOCKERFILE_UPDATE=2018-07-23
 
 # Install bash and make for running tests.
 RUN apk --no-cache add bash make
@@ -49,7 +41,7 @@ RUN chmod +x /usr/local/bin/vimlint
 
 # Install covimerage and vint.
 RUN apk --no-cache add curl python3 \
-  && pip3 install --no-cache-dir covimerage==0.0.7 vim-vint \
+  && pip3 install --no-cache-dir covimerage==0.0.9 vim-vint \
   && rm -rf /usr/include /usr/lib/python*/turtle* /usr/lib/python*/tkinter \
   && pip3 uninstall --yes pip \
   && curl https://codecov.io/bash -o /usr/bin/codecov \

--- a/Makefile
+++ b/Makefile
@@ -180,7 +180,7 @@ vimhelplint: | $(if $(VIMHELPLINT_DIR),,build/vimhelplint)
 
 # Run tests in dockerized Vims.
 DOCKER_REPO:=neomake/vims-for-tests
-DOCKER_TAG:=28
+DOCKER_TAG:=29
 NEOMAKE_DOCKER_IMAGE?=
 DOCKER_IMAGE:=$(if $(NEOMAKE_DOCKER_IMAGE),$(NEOMAKE_DOCKER_IMAGE),$(DOCKER_REPO):$(DOCKER_TAG))
 DOCKER_STREAMS:=-ti
@@ -212,8 +212,8 @@ docker_update_image:
 	make docker_test DOCKER_VIM=neovim-master
 	@echo "Done.  Use 'make docker_push' to push it, and then update .circleci/config.yml."
 
-DOCKER_VIMS:=vim73 vim74-trusty vim74-xenial vim-8.0.586 vim-8.0.1832 vim-master \
-  neovim-v0.1.7 neovim-v0.2.0 neovim-v0.2.1 neovim-v0.2.2 neovim-v0.3.0 neovim-master
+DOCKER_VIMS:=vim73 vim74-trusty vim74-xenial vim80 vim81 \
+  neovim-v0.1.7 neovim-v0.3.1
 _DOCKER_VIM_TARGETS:=$(addprefix docker_test-,$(DOCKER_VIMS))
 
 docker_test_all: $(_DOCKER_VIM_TARGETS)

--- a/tests/cwd.vader
+++ b/tests/cwd.vader
@@ -132,6 +132,9 @@ Execute (cwd handles fugitive buffer):
   \ expected_cwd, fnamemodify(tempfile_name, ':t')]
   bwipe
   bwipe autoload/neomake/debug.vim
+  if exists('*VimFtpluginUndo')
+    delfunction VimFtpluginUndo
+  endif
 
 Execute (cwd gets expanded correctly: relative and in another buffer):
   if NeomakeAsyncTestsSetup()


### PR DESCRIPTION
vim-master appears to segfault because of https://github.com/vim/vim/commit/ad6480961080f80a455b2394f27b02935a2ded52#commitcomment-29794285.