### PR TITLE
Factor out action queue processing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -208,7 +208,7 @@ docker_update_image:
 	  echo "WARN: Dockerfile.tests is not clean. Not updating."; \
 	fi
 	make docker_image
-	make docker_test DOCKER_VIM=neovim-master
+	make docker_test DOCKER_VIM=vim81
 	@echo "Done.  Use 'make docker_push' to push it, and then update .circleci/config.yml."
 
 DOCKER_VIMS:=vim73 vim74-trusty vim74-xenial vim80 vim81 \
@@ -220,7 +220,7 @@ docker_test_all: $(_DOCKER_VIM_TARGETS)
 $(_DOCKER_VIM_TARGETS):
 	$(MAKE) docker_test DOCKER_VIM=$(patsubst docker_test-%,%,$@)
 
-_docker_test: DOCKER_VIM:=vim-master
+_docker_test: DOCKER_VIM:=vim81
 _docker_test: DOCKER_MAKE_TARGET=$(DOCKER_MAKE_TEST_TARGET) \
   TEST_VIM='/vim-build/bin/$(DOCKER_VIM)' \
   VADER_OPTIONS="$(VADER_OPTIONS)" VADER_ARGS="$(VADER_ARGS)" \

--- a/Makefile
+++ b/Makefile
@@ -92,8 +92,7 @@ define func-run-vim
 	$(info Using: $(shell $(TEST_VIM_PREFIX) "$(TEST_VIM)" --version | head -n2))
 	$(_COVIMERAGE)$(if $(TEST_VIM_PREFIX),env $(TEST_VIM_PREFIX) ,)"$(TEST_VIM)" \
 	  $(if $(IS_NEOVIM),$(if $(_REDIR_STDOUT),--headless,),-X $(if $(_REDIR_STDOUT),-s /dev/null,)) \
-	  --noplugin -Nu $(TEST_VIMRC) -i NONE $(VIM_ARGS) $(_REDIR_STDOUT); \
-		ret=$$?; echo RET:$$ret; exit $$ret
+	  --noplugin -Nu $(TEST_VIMRC) -i NONE $(VIM_ARGS) $(_REDIR_STDOUT)
 endef
 
 # Interactive tests, keep Vader open.

--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -17,13 +17,6 @@ endif
 if !exists('s:map_job_ids')
     let s:map_job_ids = {}
 endif
-if !exists('s:action_queue')
-    let s:action_queue = []
-endif
-if !exists('s:action_queue_registered_events')
-    let s:action_queue_registered_events = []
-endif
-let s:action_queue_timer_timeouts = get(g:, 'neomake_action_queue_timeouts', {1: 100, 2: 200, 3: 500})
 
 " Errors by [maker_type][bufnr][lnum]
 let s:current_errors = {'project': {}, 'file': {}}
@@ -62,6 +55,17 @@ function! neomake#has_async_support() abort
     return s:async
 endfunction
 
+if has('patch-7.3.1058')
+    function! s:function(name) abort
+        return function(a:name)
+    endfunction
+else
+    " Older Vim does not handle s: function references across files.
+    function! s:function(name) abort
+      return function(substitute(a:name,'^s:',matchstr(expand('<sfile>'), '.*\zs<SNR>\d\+_'),''))
+    endfunction
+endif
+
 function! s:sort_jobs(a, b) abort
     return a:a.id - a:b.id
 endfunction
@@ -86,7 +90,7 @@ function! neomake#GetStatus() abort
     return {
                 \ 'last_make_id': s:make_id,
                 \ 'make_info': s:make_info,
-                \ 'action_queue': s:action_queue,
+                \ 'action_queue': g:neomake#action_queue#_s.action_queue,
                 \ }
 endfunction
 
@@ -148,7 +152,7 @@ function! neomake#CancelMake(make_id, ...) abort
     for job in jobs
         call neomake#CancelJob(job.id, bang)
     endfor
-    call s:clean_action_queue(make_info)
+    call neomake#action_queue#clean(make_info)
     " Ensure that make gets cleaned really, e.g. if there were no jobs yet.
     if has_key(s:make_info, a:make_id)
         call s:clean_make_info(make_info, bang)
@@ -163,19 +167,6 @@ function! neomake#CancelAllMakes(...) abort
     endfor
 endfunction
 
-" Remove any queued actions for a jobinfo or make_info object.
-function! s:clean_action_queue(job_or_make_info) abort
-    let len_before = len(s:action_queue)
-    call filter(s:action_queue, 'v:val[1][1][0] != a:job_or_make_info')
-    let removed = len_before - len(s:action_queue)
-    if removed
-        call s:clean_action_queue_augroup()
-        call neomake#log#debug(printf(
-                    \ 'Removed %d action queue entries.',
-                    \ removed), a:job_or_make_info)
-    endif
-endfunction
-
 " Returns 1 if a job was canceled, 0 otherwise.
 function! neomake#CancelJob(job_id, ...) abort
     let job_id = type(a:job_id) == type({}) ? a:job_id.id : +a:job_id
@@ -183,7 +174,7 @@ function! neomake#CancelJob(job_id, ...) abort
     let jobinfo = get(s:jobs, job_id, {})
     call neomake#log#debug('Cancelling job.', jobinfo)
 
-    call s:clean_action_queue(empty(jobinfo) ? {'id': job_id} : jobinfo)
+    call neomake#action_queue#clean(empty(jobinfo) ? {'id': job_id} : jobinfo)
 
     if empty(jobinfo)
         call neomake#log#error('CancelJob: job not found: '.job_id.'.')
@@ -1054,186 +1045,6 @@ function! neomake#_handle_list_display(jobinfo, ...) abort
     call s:HandleLoclistQflistDisplay(a:jobinfo, list, 2)
 endfunction
 
-" Queue an action to be processed later for autocmd a:event or through a timer
-" for a:event=Timer.
-" It will call a:data[0], with a:data[1] as args (where the first should be
-" a jobinfo object).  The callback should return 1 if it was successful,
-" with 0 it will be re-queued.
-" When called recursively (queueing the same event/data again, it will be
-" re-queued also).
-function! s:queue_action(events, data) abort
-    let job_or_make_info = a:data[1][0]
-    if has_key(job_or_make_info, 'make_id')
-        let jobinfo = job_or_make_info
-        let log_context = jobinfo
-    else
-        let make_info = job_or_make_info
-        let log_context = make_info.options
-    endif
-    call neomake#log#debug(printf('Queueing action: %s for %s.',
-                \ a:data[0], join(a:events, ', ')), log_context)
-
-    for event in a:events
-        if event ==# 'Timer'
-            if !exists('jobinfo.action_queue_timer_tries')
-                let job_or_make_info.action_queue_timer_tries = {'count': 1, 'data': a:data[0]}
-            else
-                let job_or_make_info.action_queue_timer_tries.count += 1
-            endif
-            if has_key(s:action_queue_timer_timeouts, job_or_make_info.action_queue_timer_tries.count)
-                let timeout = s:action_queue_timer_timeouts[job_or_make_info.action_queue_timer_tries.count]
-            else
-                throw printf('Neomake: Giving up handling Timer callbacks after %d attempts. Please report this. See :messages for more information.', len(s:action_queue_timer_timeouts))
-            endif
-            if has('timers')
-                if exists('s:action_queue_timer')
-                    call timer_stop(s:action_queue_timer)
-                endif
-                let s:action_queue_timer = timer_start(timeout, function('s:process_action_queue_timer_cb'))
-                call neomake#log#debug(printf(
-                            \ 'Retrying Timer event in %dms.', timeout), job_or_make_info)
-            else
-                call neomake#log#debug('Retrying Timer event on CursorHold(I).', job_or_make_info)
-                if !exists('#neomake_event_queue#CursorHold')
-                    let s:action_queue_registered_events += ['CursorHold', 'CursorHoldI']
-                    augroup neomake_event_queue
-                        exe 'autocmd CursorHold,CursorHoldI * call s:process_action_queue('''.event.''')'
-                    augroup END
-                endif
-            endif
-        else
-            if !exists('#neomake_event_queue#'.event)
-                let s:action_queue_registered_events += [event]
-                augroup neomake_event_queue
-                    exe 'autocmd '.event.' * call s:process_action_queue('''.event.''')'
-                augroup END
-            endif
-        endif
-    endfor
-    call add(s:action_queue, [a:events, a:data])
-endfunction
-
-function! s:process_action_queue_timer_cb(...) abort
-    call neomake#log#debug(printf(
-                \ 'action queue: callback for Timer queue (%d).', s:action_queue_timer))
-    unlet s:action_queue_timer
-    call s:process_action_queue('Timer')
-endfunction
-
-function! s:process_action_queue(event) abort
-    let queue = s:action_queue
-    let q_for_this_event = []
-    let i = 0
-    for [events, v] in queue
-        if index(events, a:event) != -1
-            call add(q_for_this_event, [i, v])
-        endif
-        let i += 1
-    endfor
-    call neomake#log#debug(printf('action queue: processing for %s (%d items, winnr: %d).',
-                \ a:event, len(q_for_this_event), winnr()), {'bufnr': bufnr('%')})
-
-    let processed = []
-    let removed = 0
-    let abort = 0
-    for [i, data] in q_for_this_event
-        let job_or_make_info = data[1][0]
-        let v = remove(queue, i - removed)
-        let removed += 1
-        if abort
-            call add(queue, v)
-            continue
-        endif
-        let log_context = has_key(job_or_make_info, 'make_id') ? job_or_make_info : job_or_make_info.options
-
-        call neomake#log#debug(printf('action queue: calling %s.',
-                    \ data[0]), log_context)
-        try
-            " Call the queued action.  On failure they should have requeued
-            " themselves already.
-            let rv = call(data[0], data[1])
-        catch /^Neomake: /
-            let error = substitute(v:exception, '^Neomake: ', '', '')
-            call neomake#log#exception(error, log_context)
-
-            " Cancel job in case its action failed to get re-queued after X
-            " attempts.
-            if has_key(job_or_make_info, 'id')
-                call neomake#CancelJob(job_or_make_info.id)
-            endif
-            continue
-        endtry
-        if rv is# 1
-            let processed += [data]
-        elseif a:event !=# 'Timer' && has_key(job_or_make_info, 'action_queue_timer_tries')
-            call neomake#log#debug('s:process_action_queue: decrementing timer tries for non-Timer event.', job_or_make_info)
-            let job_or_make_info.action_queue_timer_tries.count -= 1
-        endif
-    endfor
-    call neomake#log#debug(printf('action queue: processed %d items.',
-                \ len(processed)), {'bufnr': bufnr('%')})
-
-    call s:clean_action_queue_augroup()
-endfunction
-
-
-if has('timers')
-    function! s:get_left_events() abort
-        let r = {}
-        for [events, _] in s:action_queue
-            for event in events
-                let r[event] = 1
-            endfor
-        endfor
-        return keys(r)
-    endfunction
-else
-    function! s:get_left_events() abort
-        let r = {}
-        for [events, _] in s:action_queue
-            for event in events
-                if event ==# 'Timer'
-                    let r['CursorHold'] = 1
-                    let r['CursorHoldI'] = 1
-                else
-                    let r[event] = 1
-                endif
-            endfor
-        endfor
-        return keys(r)
-    endfunction
-endif
-
-
-function! s:clean_action_queue_augroup() abort
-    if empty(s:action_queue_registered_events)
-        return
-    endif
-    let left_events = s:get_left_events()
-
-    if empty(left_events)
-        autocmd! neomake_event_queue
-        augroup! neomake_event_queue
-    else
-        let clean_events = []
-        for event in s:action_queue_registered_events
-            if index(left_events, event) == -1
-                let clean_events += [event]
-            endif
-        endfor
-        if !empty(clean_events)
-            augroup neomake_event_queue
-            for event in clean_events
-                if exists('#neomake_event_queue#'.event)
-                    exe 'au! '.event
-                endif
-            endfor
-            augroup END
-        endif
-    endif
-    let s:action_queue_registered_events = left_events
-endfunction
-
 " Get a maker for &makeprg.
 " This could be cached, but needs to take into account / set &errorformat,
 " and other settings that are handled by neomake#GetMaker.
@@ -1396,7 +1207,7 @@ endfunction
 
 function! s:AddExprCallback(jobinfo, prev_list) abort
     if s:need_to_postpone_loclist(a:jobinfo)
-        return s:queue_action(['BufEnter', 'WinEnter'], ['s:AddExprCallback',
+        return neomake#action_queue#add(['BufEnter', 'WinEnter'], [s:function('s:AddExprCallback'),
                     \ [a:jobinfo, a:prev_list] + a:000])
     endif
     let maker = a:jobinfo.maker
@@ -1571,17 +1382,6 @@ function! s:AddExprCallback(jobinfo, prev_list) abort
     return s:ProcessEntries(a:jobinfo, entries, a:prev_list)
 endfunction
 
-function! s:already_queued_actions(jobinfo) abort
-    " Check if there are any queued actions for this job.
-    let queued_actions = []
-    for [_, v] in s:action_queue
-        if v[1][0] == a:jobinfo
-            let queued_actions += [v[0]]
-        endif
-    endfor
-    return queued_actions
-endfunction
-
 function! s:CleanJobinfo(jobinfo, ...) abort
     if get(a:jobinfo, 'pending_output', 0) && !get(a:jobinfo, 'canceled', 0)
         call neomake#log#debug(
@@ -1589,12 +1389,12 @@ function! s:CleanJobinfo(jobinfo, ...) abort
         return
     endif
 
-    let queued_actions = s:already_queued_actions(a:jobinfo)
+    let queued_actions = neomake#action_queue#get_queued_actions(a:jobinfo)
     if !empty(queued_actions)
         call neomake#log#debug(printf(
                     \ 'Skipping cleaning of job info because of queued actions: %s.',
                     \ join(queued_actions, ', ')), a:jobinfo)
-        return s:queue_action(['WinEnter'], ['s:CleanJobinfo', [a:jobinfo]])
+        return neomake#action_queue#add(['WinEnter'], [s:function('s:CleanJobinfo'), [a:jobinfo]])
     endif
 
     call neomake#log#debug('Cleaning jobinfo.', a:jobinfo)
@@ -1651,7 +1451,7 @@ function! s:clean_make_info(make_info, ...) abort
     " Assert: there should be no queued actions for jobs or makes.
     if s:is_testing
         let queued = []
-        for [_, v] in s:action_queue
+        for [_, v] in g:neomake#action_queue#_s.action_queue
             if has_key(v[1][0], 'make_id')
                 let jobinfo = v[1][0]
                 if jobinfo.make_id == make_id && v[0] !=# 's:CleanJobinfo'
@@ -1775,7 +1575,7 @@ function! s:handle_locqf_list_for_finished_jobs(make_info) abort
                 call neomake#log#debug(
                             \ 'Postponing final location list handling (in another window).',
                             \ {'make_id': a:make_info.options.make_id, 'winnr': winnr()})
-                return s:queue_action(['WinEnter'], ['s:handle_locqf_list_for_finished_jobs',
+                return neomake#action_queue#add(['WinEnter'], [s:function('s:handle_locqf_list_for_finished_jobs'),
                             \ [a:make_info] + a:000])
             endif
 
@@ -1784,7 +1584,7 @@ function! s:handle_locqf_list_for_finished_jobs(make_info) abort
                 call neomake#log#debug(
                             \ 'Postponing final location list handling during completion.',
                             \ a:make_info.options)
-                return s:queue_action(['CompleteDone'], ['s:handle_locqf_list_for_finished_jobs',
+                return neomake#action_queue#add(['CompleteDone'], [s:function('s:handle_locqf_list_for_finished_jobs'),
                             \ [a:make_info] + a:000])
             endif
             let mode = neomake#compat#get_mode()
@@ -1792,7 +1592,7 @@ function! s:handle_locqf_list_for_finished_jobs(make_info) abort
                 call neomake#log#debug(printf(
                             \ 'Postponing final location list handling for mode "%s".', mode),
                             \ a:make_info.options)
-                return s:queue_action(['Timer'], ['s:handle_locqf_list_for_finished_jobs',
+                return neomake#action_queue#add(['Timer'], [s:function('s:handle_locqf_list_for_finished_jobs'),
                             \ [a:make_info] + a:000])
             endif
         endif
@@ -1897,7 +1697,7 @@ function! s:pcall(fn, args) abort
         call neomake#log#debug('Error during pcall: '.v:exception.'.', jobinfo)
         call neomake#log#debug(printf('(in %s)', v:throwpoint), jobinfo)
         " Might throw in case of X failed attempts.
-        call s:queue_action(['Timer', 'WinEnter'], [a:fn, a:args])
+        call neomake#action_queue#add(['Timer', 'WinEnter'], [s:function(a:fn), a:args])
     endtry
     return 0
 endfunction
@@ -1913,7 +1713,7 @@ let s:needs_to_replace_qf_for_lwindow = has('patch-7.4.379')
 
 function! s:ProcessEntries(jobinfo, entries, ...) abort
     if s:need_to_postpone_loclist(a:jobinfo)
-        return s:queue_action(['BufEnter', 'WinEnter'], ['s:ProcessEntries',
+        return neomake#action_queue#add(['BufEnter', 'WinEnter'], [s:function('s:ProcessEntries'),
                     \ [a:jobinfo, a:entries] + a:000])
     endif
     if !a:0 || type(a:[len(a:000)]) != 0
@@ -2095,7 +1895,7 @@ endfunction
 
 function! s:ProcessJobOutput(jobinfo, lines, source, ...) abort
     if s:need_to_postpone_loclist(a:jobinfo)
-        return s:queue_action(['BufEnter', 'WinEnter'], ['s:ProcessJobOutput',
+        return neomake#action_queue#add(['BufEnter', 'WinEnter'], [s:function('s:ProcessJobOutput'),
                     \ [a:jobinfo, a:lines, a:source]])
     endif
     if !a:0
@@ -2223,7 +2023,7 @@ function! s:process_pending_output(jobinfo, lines, source, ...) abort
         endif
     endif
     let a:jobinfo.pending_output = 1
-    call s:queue_action(retry_events, ['s:process_pending_output', [a:jobinfo, a:lines, a:source, retry_events]])
+    call neomake#action_queue#add(retry_events, [s:function('s:process_pending_output'), [a:jobinfo, a:lines, a:source, retry_events]])
 endfunction
 
 function! s:ProcessPendingOutput(jobinfo, lines, source) abort
@@ -2699,7 +2499,7 @@ function! s:handle_next_job(prev_jobinfo) abort
     endwhile
 
     " Cleanup make info, but only if there are no queued actions.
-    for [_, v] in s:action_queue
+    for [_, v] in g:neomake#action_queue#_s.action_queue
         if v[1][0] == make_info
             call neomake#log#debug('Skipping cleaning of make info for queued actions.', make_info)
             return {}

--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -2109,11 +2109,6 @@ function! s:need_to_postpone_output_processing(jobinfo) abort
         call neomake#log#debug('Not processing output from command-line window "'.getcmdwintype().'".', a:jobinfo)
         return ['InsertLeave', 'CursorHold', 'CursorHoldI']
     endif
-    " TODO: should be done in neomake#utils#hook directly instead, involves refactoring.
-    if exists('g:neomake_hook_context')
-        call neomake#log#debug('Not processing output during active hook processing.', a:jobinfo)
-        return ['Timer', 'BufEnter', 'WinEnter', 'InsertLeave', 'CursorHold', 'CursorHoldI']
-    endif
     return []
 endfunction
 

--- a/autoload/neomake/action_queue.vim
+++ b/autoload/neomake/action_queue.vim
@@ -194,9 +194,9 @@ endif
 function! neomake#action_queue#get_queued_actions(jobinfo) abort
     " Check if there are any queued actions for this job.
     let queued_actions = []
-    for [_, v] in s:action_queue
+    for [events, v] in s:action_queue
         if v[1][0] == a:jobinfo
-            let queued_actions += [s:actionname(v[0])]
+            let queued_actions += [[s:actionname(v[0]), events]]
         endif
     endfor
     return queued_actions

--- a/autoload/neomake/action_queue.vim
+++ b/autoload/neomake/action_queue.vim
@@ -1,0 +1,220 @@
+if !exists('s:action_queue')
+    let s:action_queue = []
+endif
+if !exists('s:action_queue_registered_events')
+    let s:action_queue_registered_events = []
+endif
+let s:action_queue_timer_timeouts = get(g:, 'neomake_action_queue_timeouts', {1: 100, 2: 200, 3: 500})
+
+let g:neomake#action_queue#_s = s:
+
+function! s:actionname(funcref) abort
+    let s = string(a:funcref)
+    let r = matchstr(s, '\v^^function\(''\zs.*\ze''\)$')
+    if empty(r)
+        return s
+    endif
+    return substitute(r, '\v^(\<SNR\>\d+_|s:)', '', '')
+endfunction
+
+" Queue an action to be processed later for autocmd a:event or through a timer
+" for a:event=Timer.
+" It will call a:data[0], with a:data[1] as args (where the first should be
+" a jobinfo object).  The callback should return 1 if it was successful,
+" with 0 it will be re-queued.
+" When called recursively (queueing the same event/data again, it will be
+" re-queued also).
+function! neomake#action_queue#add(events, data) abort
+    let job_or_make_info = a:data[1][0]
+    if has_key(job_or_make_info, 'make_id')
+        let jobinfo = job_or_make_info
+        let log_context = jobinfo
+    else
+        let make_info = job_or_make_info
+        let log_context = make_info.options
+    endif
+    call neomake#log#debug(printf('Queuing action %s for %s.',
+                \ s:actionname(a:data[0]), join(a:events, ', ')), log_context)
+
+    for event in a:events
+        if event ==# 'Timer'
+            if !exists('jobinfo.action_queue_timer_tries')
+                let job_or_make_info.action_queue_timer_tries = {'count': 1, 'data': a:data[0]}
+            else
+                let job_or_make_info.action_queue_timer_tries.count += 1
+            endif
+            if has_key(s:action_queue_timer_timeouts, job_or_make_info.action_queue_timer_tries.count)
+                let timeout = s:action_queue_timer_timeouts[job_or_make_info.action_queue_timer_tries.count]
+            else
+                throw printf('Neomake: Giving up handling Timer callbacks after %d attempts. Please report this. See :messages for more information.', len(s:action_queue_timer_timeouts))
+            endif
+            if has('timers')
+                if exists('s:action_queue_timer')
+                    call timer_stop(s:action_queue_timer)
+                endif
+                let s:action_queue_timer = timer_start(timeout, function('s:process_action_queue_timer_cb'))
+                call neomake#log#debug(printf(
+                            \ 'Retrying Timer event in %dms.', timeout), job_or_make_info)
+            else
+                call neomake#log#debug('Retrying Timer event on CursorHold(I).', job_or_make_info)
+                if !exists('#neomake_event_queue#CursorHold')
+                    let s:action_queue_registered_events += ['CursorHold', 'CursorHoldI']
+                    augroup neomake_event_queue
+                        exe 'autocmd CursorHold,CursorHoldI * call s:process_action_queue('''.event.''')'
+                    augroup END
+                endif
+            endif
+        else
+            if !exists('#neomake_event_queue#'.event)
+                let s:action_queue_registered_events += [event]
+                augroup neomake_event_queue
+                    exe 'autocmd '.event.' * call s:process_action_queue('''.event.''')'
+                augroup END
+            endif
+        endif
+    endfor
+    call add(s:action_queue, [a:events, a:data])
+endfunction
+
+" Remove any queued actions for a jobinfo or make_info object.
+function! neomake#action_queue#clean(job_or_make_info) abort
+    let len_before = len(s:action_queue)
+    call filter(s:action_queue, 'v:val[1][1][0] != a:job_or_make_info')
+    let removed = len_before - len(s:action_queue)
+    if removed
+        call s:clean_action_queue_augroup()
+        call neomake#log#debug(printf(
+                    \ 'Removed %d action queue entries.',
+                    \ removed), a:job_or_make_info)
+    endif
+endfunction
+
+function! s:process_action_queue_timer_cb(...) abort
+    call neomake#log#debug(printf(
+                \ 'action queue: callback for Timer queue (%d).', s:action_queue_timer))
+    unlet s:action_queue_timer
+    call s:process_action_queue('Timer')
+endfunction
+
+function! s:process_action_queue(event) abort
+    let queue = s:action_queue
+    let q_for_this_event = []
+    let i = 0
+    for [events, v] in queue
+        if index(events, a:event) != -1
+            call add(q_for_this_event, [i, v])
+        endif
+        let i += 1
+    endfor
+    call neomake#log#debug(printf('action queue: processing for %s (%d items, winnr: %d).',
+                \ a:event, len(q_for_this_event), winnr()), {'bufnr': bufnr('%')})
+
+    let processed = []
+    let removed = 0
+    let abort = 0
+    for [i, data] in q_for_this_event
+        let job_or_make_info = data[1][0]
+        let v = remove(queue, i - removed)
+        let removed += 1
+        if abort
+            call add(queue, v)
+            continue
+        endif
+        let log_context = has_key(job_or_make_info, 'make_id') ? job_or_make_info : job_or_make_info.options
+
+        call neomake#log#debug(printf('action queue: calling %s.',
+                    \ s:actionname(data[0])), log_context)
+        try
+            " Call the queued action.  On failure they should have requeued
+            " themselves already.
+            let rv = call(data[0], data[1])
+        catch /^Neomake: /
+            let error = substitute(v:exception, '^Neomake: ', '', '')
+            call neomake#log#exception(error, log_context)
+
+            " Cancel job in case its action failed to get re-queued after X
+            " attempts.
+            if has_key(job_or_make_info, 'id')
+                call neomake#CancelJob(job_or_make_info.id)
+            endif
+            continue
+        endtry
+        if rv is# 1
+            let processed += [data]
+        elseif a:event !=# 'Timer' && has_key(job_or_make_info, 'action_queue_timer_tries')
+            call neomake#log#debug('s:process_action_queue: decrementing timer tries for non-Timer event.', job_or_make_info)
+            let job_or_make_info.action_queue_timer_tries.count -= 1
+        endif
+    endfor
+    call neomake#log#debug(printf('action queue: processed %d items.',
+                \ len(processed)), {'bufnr': bufnr('%')})
+
+    call s:clean_action_queue_augroup()
+endfunction
+
+if has('timers')
+    function! s:get_left_events() abort
+        let r = {}
+        for [events, _] in s:action_queue
+            for event in events
+                let r[event] = 1
+            endfor
+        endfor
+        return keys(r)
+    endfunction
+else
+    function! s:get_left_events() abort
+        let r = {}
+        for [events, _] in s:action_queue
+            for event in events
+                if event ==# 'Timer'
+                    let r['CursorHold'] = 1
+                    let r['CursorHoldI'] = 1
+                else
+                    let r[event] = 1
+                endif
+            endfor
+        endfor
+        return keys(r)
+    endfunction
+endif
+
+function! neomake#action_queue#get_queued_actions(jobinfo) abort
+    " Check if there are any queued actions for this job.
+    let queued_actions = []
+    for [_, v] in s:action_queue
+        if v[1][0] == a:jobinfo
+            let queued_actions += [s:actionname(v[0])]
+        endif
+    endfor
+    return queued_actions
+endfunction
+
+function! s:clean_action_queue_augroup() abort
+    if empty(s:action_queue_registered_events)
+        return
+    endif
+    let left_events = s:get_left_events()
+
+    if empty(left_events)
+        autocmd! neomake_event_queue
+        augroup! neomake_event_queue
+    else
+        let clean_events = []
+        for event in s:action_queue_registered_events
+            if index(left_events, event) == -1
+                let clean_events += [event]
+            endif
+        endfor
+        if !empty(clean_events)
+            augroup neomake_event_queue
+            for event in clean_events
+                if exists('#neomake_event_queue#'.event)
+                    exe 'au! '.event
+                endif
+            endfor
+            augroup END
+        endif
+    endif
+    let s:action_queue_registered_events = left_events
+endfunction

--- a/autoload/neomake/action_queue.vim
+++ b/autoload/neomake/action_queue.vim
@@ -111,15 +111,10 @@ function! s:process_action_queue(event) abort
 
     let processed = []
     let removed = 0
-    let abort = 0
     for [i, data] in q_for_this_event
         let job_or_make_info = data[1][0]
         let v = remove(queue, i - removed)
         let removed += 1
-        if abort
-            call add(queue, v)
-            continue
-        endif
         let log_context = has_key(job_or_make_info, 'make_id') ? job_or_make_info : job_or_make_info.options
 
         call neomake#log#debug(printf('action queue: calling %s.',

--- a/autoload/neomake/action_queue.vim
+++ b/autoload/neomake/action_queue.vim
@@ -26,7 +26,9 @@ endfunction
 " re-queued also).
 function! neomake#action_queue#add(events, data) abort
     let job_or_make_info = a:data[1][0]
-    if has_key(job_or_make_info, 'make_id')
+    if empty(job_or_make_info)
+        let log_context = {}
+    elseif has_key(job_or_make_info, 'make_id')
         let jobinfo = job_or_make_info
         let log_context = jobinfo
     else
@@ -115,8 +117,14 @@ function! s:process_action_queue(event) abort
         let job_or_make_info = data[1][0]
         let v = remove(queue, i - removed)
         let removed += 1
-        let log_context = has_key(job_or_make_info, 'make_id') ? job_or_make_info : job_or_make_info.options
 
+        if has_key(job_or_make_info, 'make_id')
+            let log_context = job_or_make_info
+        elseif has_key(job_or_make_info, 'options')
+            let log_context = job_or_make_info.options
+        else
+            let log_context = {}
+        endif
         call neomake#log#debug(printf('action queue: calling %s.',
                     \ s:actionname(data[0])), log_context)
         try

--- a/autoload/neomake/utils.vim
+++ b/autoload/neomake/utils.vim
@@ -374,6 +374,7 @@ function! s:handle_hook(jobinfo, event, context) abort
     finally
         unlet g:neomake_hook_context
     endtry
+    return g:neomake#action_queue#processed
 endfunction
 
 function! neomake#utils#hook(event, context, ...) abort

--- a/autoload/neomake/utils.vim
+++ b/autoload/neomake/utils.vim
@@ -327,44 +327,45 @@ function! neomake#utils#ExpandArgs(args) abort
 endfunction
 
 function! neomake#utils#hook(event, context, ...) abort
-    if exists('#User#'.a:event)
-        let jobinfo = a:0 ? a:1 : (
-                    \ has_key(a:context, 'jobinfo') ? a:context.jobinfo : {})
-
-        let context_str = string(map(copy(a:context),
-                    \ "v:key ==# 'jobinfo' ? '…'"
-                    \ .": (v:key ==# 'finished_jobs' ? map(copy(v:val), 'v:val.as_string()') : v:val)"))
-        let args = [printf('Calling User autocmd %s with context: %s.',
-                    \ a:event, context_str)]
-        if !empty(jobinfo)
-            let args += [jobinfo]
-        endif
-        call call('neomake#log#info', args)
-
-        if exists('g:neomake_hook_context')
-            throw printf('Neomake internal error: hook invocation must not be nested: %s.', a:event)
-        endif
-        unlockvar g:neomake_hook_context
-        let g:neomake_hook_context = a:context
-        lockvar 1 g:neomake_hook_context
-        try
-            if v:version >= 704 || (v:version == 703 && has('patch442'))
-                exec 'doautocmd <nomodeline> User ' . a:event
-            else
-                exec 'doautocmd User ' . a:event
-            endif
-        catch
-            let error = v:exception
-            if error[-1:] !=# '.'
-                let error .= '.'
-            endif
-            call neomake#log#exception(printf(
-                        \ 'Error during User autocmd for %s: %s',
-                        \ a:event, error), jobinfo)
-        finally
-            unlet g:neomake_hook_context
-        endtry
+    if !exists('#User#'.a:event)
+        return
     endif
+    let jobinfo = a:0 ? a:1 : (
+                \ has_key(a:context, 'jobinfo') ? a:context.jobinfo : {})
+
+    let context_str = string(map(copy(a:context),
+                \ "v:key ==# 'jobinfo' ? '…'"
+                \ .": (v:key ==# 'finished_jobs' ? map(copy(v:val), 'v:val.as_string()') : v:val)"))
+    let args = [printf('Calling User autocmd %s with context: %s.',
+                \ a:event, context_str)]
+    if !empty(jobinfo)
+        let args += [jobinfo]
+    endif
+    call call('neomake#log#info', args)
+
+    if exists('g:neomake_hook_context')
+        throw printf('Neomake internal error: hook invocation must not be nested: %s.', a:event)
+    endif
+    unlockvar g:neomake_hook_context
+    let g:neomake_hook_context = a:context
+    lockvar 1 g:neomake_hook_context
+    try
+        if v:version >= 704 || (v:version == 703 && has('patch442'))
+            exec 'doautocmd <nomodeline> User ' . a:event
+        else
+            exec 'doautocmd User ' . a:event
+        endif
+    catch
+        let error = v:exception
+        if error[-1:] !=# '.'
+            let error .= '.'
+        endif
+        call neomake#log#exception(printf(
+                    \ 'Error during User autocmd for %s: %s',
+                    \ a:event, error), jobinfo)
+    finally
+        unlet g:neomake_hook_context
+    endtry
 endfunction
 
 function! neomake#utils#diff_dict(old, new) abort

--- a/autoload/neomake/utils.vim
+++ b/autoload/neomake/utils.vim
@@ -326,26 +326,34 @@ function! neomake#utils#ExpandArgs(args) abort
     return ret
 endfunction
 
-function! neomake#utils#hook(event, context, ...) abort
-    if !exists('#User#'.a:event)
-        return
+if has('patch-7.3.1058')
+    function! s:function(name) abort
+        return function(a:name)
+    endfunction
+else
+    " Older Vim does not handle s: function references across files.
+    function! s:function(name) abort
+      return function(substitute(a:name,'^s:',matchstr(expand('<sfile>'), '.*\zs<SNR>\d\+_'),''))
+    endfunction
+endif
+
+function! s:handle_hook(jobinfo, event, context) abort
+    if exists('g:neomake_hook_context')
+        return neomake#action_queue#add(
+                    \ ['Timer', 'BufEnter', 'WinEnter', 'InsertLeave', 'CursorHold', 'CursorHoldI'],
+                    \ [s:function('s:handle_hook'), [a:jobinfo, a:event, a:context]])
     endif
-    let jobinfo = a:0 ? a:1 : (
-                \ has_key(a:context, 'jobinfo') ? a:context.jobinfo : {})
 
     let context_str = string(map(copy(a:context),
                 \ "v:key ==# 'jobinfo' ? '…'"
                 \ .": (v:key ==# 'finished_jobs' ? map(copy(v:val), 'v:val.as_string()') : v:val)"))
     let args = [printf('Calling User autocmd %s with context: %s.',
                 \ a:event, context_str)]
-    if !empty(jobinfo)
-        let args += [jobinfo]
+    if !empty(a:jobinfo)
+        let args += [a:jobinfo]
     endif
     call call('neomake#log#info', args)
 
-    if exists('g:neomake_hook_context')
-        throw printf('Neomake internal error: hook invocation must not be nested: %s.', a:event)
-    endif
     unlockvar g:neomake_hook_context
     let g:neomake_hook_context = a:context
     lockvar 1 g:neomake_hook_context
@@ -362,10 +370,18 @@ function! neomake#utils#hook(event, context, ...) abort
         endif
         call neomake#log#exception(printf(
                     \ 'Error during User autocmd for %s: %s',
-                    \ a:event, error), jobinfo)
+                    \ a:event, error), a:jobinfo)
     finally
         unlet g:neomake_hook_context
     endtry
+endfunction
+
+function! neomake#utils#hook(event, context, ...) abort
+    if exists('#User#'.a:event)
+        let jobinfo = a:0 ? a:1 : (
+                    \ has_key(a:context, 'jobinfo') ? a:context.jobinfo : {})
+        return s:handle_hook(jobinfo, a:event, a:context)
+    endif
 endfunction
 
 function! neomake#utils#diff_dict(old, new) abort

--- a/contrib/highlight-log
+++ b/contrib/highlight-log
@@ -9,8 +9,10 @@
 #
 #     tail -f /tmp/neomake.log | /path/to/neomake/contrib/highlight-log
 
-# Use 256-color mode for dark grey.
-debug_color='[38;5;8m'
+debug_color="[2m"  # $(tput dim), does not work in urxvt (although in infocmp/terminfo).
+error_color="[33;1m"
+bold="[1m"  # $(tput bold)
+coloroff="[0m"
 
 compact=0
 quiet=0
@@ -33,18 +35,15 @@ if [ "$1" = vader ]; then
     # sed: add coloring to Vader's output:
     # 1. failures (includes pending) in red "(X)"
     # 2. test case header in bold "(2/2)"
-    # 3. Neomake's debug log messages in less intense grey
-    # 4. non-Neomake log lines (e.g. from :Log) in bold/bright yellow.
+    # 3. Neomake's error log messages
+    # 4. Neomake's debug log messages
+    # 5. non-Neomake log lines (e.g. from :Log)
     sed -e 's/^ \+([ [:digit:]]\+\/[[:digit:]]\+) \[[ [:alpha:]]\+\] (X).*/[31m[1m\0[0m/' \
-      -e 's/^ \+([ [:digit:]]\+\/[[:digit:]]\+)/[1m\0[0m/' \
-      -e 's/^ \+> \[\(debug  \|D +[.[:digit:]]\+\)\]: .*/'"$debug_color"'\0[0m/' \
-      -e '/\[\(verbose\|warning\|error  \|\(\(V\|W\|\E\) +[.[:digit:]]\+\)\)\]/! s/^ \+> .*/[33;1m\0[0m/'
+      -e 's/^ \+([ [:digit:]]\+\/[[:digit:]]\+)/'"$bold"'\0'"$coloroff"'/' \
+      -e 's/^ \+> \[\(error  \|E +[.[:digit:]]\+\)\]: .*/'"$bold"'\0'"$coloroff"'/' \
+      -e 's/^ \+> \[\(debug  \|D +[.[:digit:]]\+\)\]: .*/'"$debug_color"'\0'"$coloroff"'/' \
+      -e '/\[\(verbose\|warning\|error  \|\(\(V\|W\|\E\) +[.[:digit:]]\+\)\)\]/! s/^ \+> .*/'"$error_color"'\0'"$coloroff"'/'
   }
-
-  if [ -n "$CI" ]; then
-    # Travis does not seem to understand 256 color mode; use bright black.
-    debug_color='[30;1m'
-  fi
 
   if ((quiet || compact)); then
     spinner_chars='/-\|'

--- a/tests/cancellation.vader
+++ b/tests/cancellation.vader
@@ -200,7 +200,7 @@ Execute (neomake#CancelJob empties action queue):
     if has('patch-7.4.2299')
       NeomakeTestsWaitForFinishedJobs
       AssertNeomakeMessage 'Queuing action AddExprCallback for BufEnter, WinEnter.'
-      AssertNeomakeMessage 'Skipping cleaning of job info because of queued actions: AddExprCallback.'
+      AssertNeomakeMessage "Skipping cleaning of job info because of queued actions: ['AddExprCallback', ['BufEnter', 'WinEnter']].", 3
       AssertNeomakeMessage 'Queuing action CleanJobinfo for WinEnter.'
     endif
     call neomake#CancelJob(job_id)

--- a/tests/cancellation.vader
+++ b/tests/cancellation.vader
@@ -174,7 +174,7 @@ Execute (neomake#CancelMake removes queued actions):
     NeomakeTestsWaitForFinishedJobs
     AssertNeomakeMessage 'Cleaning jobinfo.', 3
     AssertNeomakeMessage 'Postponing final location list handling (in another window).', 3
-    AssertNeomakeMessage 'Queueing action: s:handle_locqf_list_for_finished_jobs for WinEnter.', 3
+    AssertNeomakeMessage 'Queuing action handle_locqf_list_for_finished_jobs for WinEnter.', 3
 
     let log_context = neomake#GetStatus().make_info[jobinfo.make_id]
     let log_context.make_id = jobinfo.make_id
@@ -199,9 +199,9 @@ Execute (neomake#CancelJob empties action queue):
     let job_id = jobinfo.id
     if has('patch-7.4.2299')
       NeomakeTestsWaitForFinishedJobs
-      AssertNeomakeMessage 'Queueing action: s:AddExprCallback for BufEnter, WinEnter.'
-      AssertNeomakeMessage 'Skipping cleaning of job info because of queued actions: s:AddExprCallback.'
-      AssertNeomakeMessage 'Queueing action: s:CleanJobinfo for WinEnter.'
+      AssertNeomakeMessage 'Queuing action AddExprCallback for BufEnter, WinEnter.'
+      AssertNeomakeMessage 'Skipping cleaning of job info because of queued actions: AddExprCallback.'
+      AssertNeomakeMessage 'Queuing action CleanJobinfo for WinEnter.'
     endif
     call neomake#CancelJob(job_id)
     if has('patch-7.4.2299')
@@ -242,7 +242,7 @@ Execute (neomake#CancelJob clears action queue for get_list_entries maker):
     endfunction
 
     let jobinfo = neomake#Make({'enabled_makers': [maker]})[0]
-    AssertNeomakeMessage 'Queueing action: s:handle_get_list_entries for Timer, WinEnter.'
+    AssertNeomakeMessage 'Queuing action handle_get_list_entries for Timer, WinEnter.'
 
     " CancelJob returns 0, since it is processed directly.
     AssertEqual neomake#CancelJob(jobinfo), 0

--- a/tests/cwd.vader
+++ b/tests/cwd.vader
@@ -69,7 +69,7 @@ Execute (tcd is handled properly):
 
       NeomakeTestsWaitForFinishedJobs
       AssertNeomakeMessage 'Postponing final location list handling (in another window).'
-      AssertNeomakeMessage 'Queueing action: s:handle_locqf_list_for_finished_jobs for WinEnter.', 3
+      AssertNeomakeMessage 'Queuing action handle_locqf_list_for_finished_jobs for WinEnter.', 3
 
       exe 'tabnext' tab1
       AssertNeomakeMessage 'Cleaning make info.', 3

--- a/tests/hooks-queue.vader
+++ b/tests/hooks-queue.vader
@@ -118,7 +118,7 @@ Execute (Does not nest hooks / User autocommands):
       let jobinfo = g:neomake_hook_context.jobinfo
       if jobinfo.maker.name == 'maker1'
         NeomakeTestsWaitForMessage 'Not processing output during active hook processing.', 3
-        AssertNeomakeMessage 'Queueing action: s:process_pending_output for Timer, BufEnter, WinEnter, InsertLeave, CursorHold, CursorHoldI.', 3
+        AssertNeomakeMessage 'Queuing action process_pending_output for Timer, BufEnter, WinEnter, InsertLeave, CursorHold, CursorHoldI.', 3
         NeomakeTestsWaitForMessage 'Retrying Timer event in 10ms.', 3
       endif
       " call neomake#log#debug('OnNeomakeJobFinished finished.')

--- a/tests/hooks-queue.vader
+++ b/tests/hooks-queue.vader
@@ -85,8 +85,12 @@ Execute (Nested neomake#utils#hook must not be nested (directly)):
   augroup END
   call neomake#utils#hook('Event1', {'context': 1})
   AssertNeomakeMessage "Calling User autocmd Event1 with context: {'context': 1}.", 2
+  AssertNeomakeMessage 'Queuing action handle_hook for Timer, BufEnter, WinEnter, InsertLeave, CursorHold, CursorHoldI.', 3
+  doautocmd InsertLeave
   AssertNeomakeMessage "Calling User autocmd Event2 with context: {'context': 2}.", 2
-  AssertNeomakeMessage 'Error during User autocmd for Event1: Neomake internal error: hook invocation must not be nested: Event2.', 0
+  AssertNeomakeMessage 'Queuing action handle_hook for Timer, BufEnter, WinEnter, InsertLeave, CursorHold, CursorHoldI.', 3
+  doautocmd InsertLeave
+  AssertNeomakeMessage "Calling User autocmd Event3 with context: {'context': 3}.", 2
 
 Execute (neomake#utils#hook: reports exception):
   augroup neomake_tests

--- a/tests/hooks-queue.vader
+++ b/tests/hooks-queue.vader
@@ -121,9 +121,9 @@ Execute (Does not nest hooks / User autocommands):
     function! s:OnNeomakeJobFinished() abort
       let jobinfo = g:neomake_hook_context.jobinfo
       if jobinfo.maker.name == 'maker1'
-        NeomakeTestsWaitForMessage 'Not processing output during active hook processing.', 3
-        AssertNeomakeMessage 'Queuing action process_pending_output for Timer, BufEnter, WinEnter, InsertLeave, CursorHold, CursorHoldI.', 3
-        NeomakeTestsWaitForMessage 'Retrying Timer event in 10ms.', 3
+        NeomakeTestsWaitForMessage '\v^Queueing User autocmd NeomakeCountsChanged for nested invocation ', 3
+        AssertNeomakeMessage 'Queuing action handle_hook for Timer, BufEnter, WinEnter, InsertLeave, CursorHold, CursorHoldI.', 3
+        AssertNeomakeMessage 'Retrying Timer event in 10ms.', 3
       endif
       " call neomake#log#debug('OnNeomakeJobFinished finished.')
     endfunction
@@ -135,10 +135,16 @@ Execute (Does not nest hooks / User autocommands):
 
     CallNeomake 1, [maker1, maker2]
 
-    AssertEqual map(getloclist(0), 'v:val.text'), ['error1']
-    NeomakeTestsWaitForMessage 'Processed pending output.', 3
-
     AssertEqual map(getloclist(0), 'v:val.text'), ['error1', 'error2']
-    AssertNeomakeMessage 'action queue: processed 1 items.'
+
+    doautocmd WinEnter
+    AssertNeomakeMessage 'action queue: calling handle_hook.'
+    AssertNeomakeMessage '\VCalling User autocmd NeomakeCountsChanged with context: ', 2
+    AssertNeomakeMessage 'action queue: calling CleanJobinfo.', 3
+    AssertNeomakeMessage 'Cleaning jobinfo.', 3
+    AssertNeomakeMessage '\VCalling User autocmd NeomakeJobFinished with context: ', 2
+    AssertNeomakeMessage '\VCalling User autocmd NeomakeFinished with context: ', 2
+    AssertNeomakeMessage 'Cleaning make info.'
+
     bwipe
   endif

--- a/tests/include/init.vim
+++ b/tests/include/init.vim
@@ -508,6 +508,10 @@ function! s:After()
     endtry
   endif
 
+  if exists('g:neomake#action_queue#_s.action_queue_timer')
+    call add(errors, printf('action_queue_timer exists: %s', string(g:neomake#action_queue#_s)))
+  endif
+
   if exists('#neomake_tests')
     autocmd! neomake_tests
     augroup! neomake_tests

--- a/tests/integration.vader
+++ b/tests/integration.vader
@@ -183,7 +183,7 @@ Execute (Neomake: handle result for current window):
   if neomake#has_async_support()
     new
     NeomakeTestsWaitForFinishedJobs
-    AssertNeomakeMessage "Queueing action: s:process_pending_output for BufEnter, WinEnter.", 3
+    AssertNeomakeMessage 'Queuing action process_pending_output for BufEnter, WinEnter.', 3
     AssertEqual len(g:neomake_test_countschanged), 0
     AssertEqual len(g:neomake_test_finished), 0, "output pending"
     AssertEqual map(getloclist(0), 'v:val.text'), []
@@ -468,7 +468,7 @@ Execute (NeomakeListJobs with job cancellation):
     AssertNeomakeMessage 'Cleaning jobinfo.', 3, job3, {'ignore_order': 1}
     let log_context = {'make_id': job3.make_id, 'bufnr': bufnr('%')}
     AssertNeomakeMessage 'Postponing final location list handling for mode "V".', 3, log_context
-    AssertNeomakeMessage 'Queueing action: s:handle_locqf_list_for_finished_jobs for Timer.', 3, log_context
+    AssertNeomakeMessage 'Queuing action handle_locqf_list_for_finished_jobs for Timer.', 3, log_context
     AssertNeomakeMessage 'Skipping cleaning of make info for queued actions.', 3
 
     doautocmd CursorHold

--- a/tests/isolated/highlights.vader
+++ b/tests/isolated/highlights.vader
@@ -107,7 +107,7 @@ Execute (get_list_entries: based on example from doc):
       \ ]
   endfunction
   call neomake#Make(1, [maker])
-  AssertNeomakeMessage 'Queueing action: s:ProcessEntries for BufEnter, WinEnter.'
+  AssertNeomakeMessage 'Queuing action ProcessEntries for BufEnter, WinEnter.'
   AssertEqual {}, g:neomake_tests_highlight_lengths, 'No highlights have been added yet'
   AssertEqual [], getloclist(0)
 

--- a/tests/lists.vader
+++ b/tests/lists.vader
@@ -321,7 +321,7 @@ Execute (Goes back to original window after opening list (wincmd in autocmd)):
     AssertNeomakeMessage 'action queue: calling AddExprCallback.'
     AssertNeomakeMessage 'Postponing location list processing.'
     AssertNeomakeMessage 'Queuing action AddExprCallback for BufEnter, WinEnter.'
-    AssertNeomakeMessage 'Skipping cleaning of job info because of queued actions: AddExprCallback.'
+    AssertNeomakeMessage "Skipping cleaning of job info because of queued actions: ['AddExprCallback', ['BufEnter', 'WinEnter']].", 3
     AssertNeomakeMessage 'Queuing action CleanJobinfo for WinEnter.'
     AssertNeomakeMessage 'action queue: processed 0 items.'
     exe winnr.'wincmd w'

--- a/tests/lists.vader
+++ b/tests/lists.vader
@@ -313,27 +313,27 @@ Execute (Goes back to original window after opening list (wincmd in autocmd)):
 
     AssertNotEqual wincount + 1, winnr('$'), 'Location list has not appeared yet'
     Assert exists('#neomake_event_queue#WinEnter'), 'autocmd was setup'
-    AssertNeomakeMessage 'Queueing action: s:AddExprCallback for BufEnter, WinEnter.'
+    AssertNeomakeMessage 'Queuing action AddExprCallback for BufEnter, WinEnter.'
 
     " Go to first window for wincmd-p check.
     1wincmd w
     AssertNeomakeMessage 'action queue: processing for WinEnter (2 items, winnr: 1).'
-    AssertNeomakeMessage 'action queue: calling s:AddExprCallback.'
+    AssertNeomakeMessage 'action queue: calling AddExprCallback.'
     AssertNeomakeMessage 'Postponing location list processing.'
-    AssertNeomakeMessage 'Queueing action: s:AddExprCallback for BufEnter, WinEnter.'
-    AssertNeomakeMessage 'Skipping cleaning of job info because of queued actions: s:AddExprCallback.'
-    AssertNeomakeMessage 'Queueing action: s:CleanJobinfo for WinEnter.'
+    AssertNeomakeMessage 'Queuing action AddExprCallback for BufEnter, WinEnter.'
+    AssertNeomakeMessage 'Skipping cleaning of job info because of queued actions: AddExprCallback.'
+    AssertNeomakeMessage 'Queuing action CleanJobinfo for WinEnter.'
     AssertNeomakeMessage 'action queue: processed 0 items.'
     exe winnr.'wincmd w'
     AssertNeomakeMessage 'action queue: processing for WinEnter (2 items, winnr: 3).'
     AssertEqual wincount + 1, winnr('$'), 'Location list has appeared'
 
-    AssertNeomakeMessage 'action queue: calling s:AddExprCallback.', 3
+    AssertNeomakeMessage 'action queue: calling AddExprCallback.', 3
     AssertNeomakeMessage 'Processing 1 entries.', 3
     AssertNeomakeMessage 'Handling location list: executing lwindow.', 3, jobinfo
     AssertNeomakeMessage 'action queue: processed 1 items.'
     doautocmd WinEnter
-    AssertNeomakeMessage 'action queue: calling s:CleanJobinfo.', 3, jobinfo
+    AssertNeomakeMessage 'action queue: calling CleanJobinfo.', 3, jobinfo
     Assert !exists('#neomake_event_queue#WinEnter'), 'autocmd was deleted'
     AssertNeomakeMessage 'action queue: processed 1 items.'
 

--- a/tests/makers.vader
+++ b/tests/makers.vader
@@ -740,7 +740,7 @@ Execute (pcall aborts after 3 attempts per job):
   endif
 
   NeomakeTestsWaitForMessage 'Giving up handling Timer callbacks after 3 attempts. Please report this. See :messages for more information.', 0, jobs[0]
-  AssertNeomakeMessage '\m^(in function .*queue_action.*)$', 3
+  AssertNeomakeMessage '\m^(in function .*neomake#action_queue#add,.*)$', 3
   AssertNeomakeMessage 'Processing 1 entries.', 3, jobs[1]
   AssertEqual len(g:neomake_test_finished), 1
   AssertEqual map(copy(g:neomake_test_jobfinished), 'v:val.jobinfo.maker.name'), ['maker2']
@@ -748,7 +748,7 @@ Execute (pcall aborts after 3 attempts per job):
   AssertEqual map(getloclist(0), 'v:val.text'), ['error']
 
   let vim_msgs = NeomakeTestsGetVimMessages()
-  Assert vim_msgs[-1] =~# '\vNeomake error in: function .*_queue_action, line \d+'
+  Assert vim_msgs[-1] =~# '\vNeomake error in: function .*neomake#action_queue#add, line \d+'
   AssertEqual len(vim_msgs), 1
   bwipe
 

--- a/tests/processing.vader
+++ b/tests/processing.vader
@@ -91,7 +91,7 @@ Execute (Location list handling is postponed with visible popup menu):
 
     function! s:close_pum(...)
       NeomakeTestsWaitForMessage 'Postponing final location list handling during completion.', 3
-      AssertNeomakeMessage 'Queueing action: s:handle_locqf_list_for_finished_jobs for CompleteDone.'
+      AssertNeomakeMessage 'Queuing action handle_locqf_list_for_finished_jobs for CompleteDone.'
       call neomake#log#debug('tests: closing popupmenu.')
       call feedkeys("\<esc>")
     endfunction
@@ -129,7 +129,7 @@ Execute (Location list is only cleared in normal/insert mode on success):
     AssertNeomakeMessage 'Cleaning jobinfo.', 3
     AssertNeomakeMessage 'File-level errors cleaned.', 3
     AssertNeomakeMessage 'Postponing final location list handling for mode "V".'
-    AssertNeomakeMessage 'Queueing action: s:handle_locqf_list_for_finished_jobs for Timer.'
+    AssertNeomakeMessage 'Queuing action handle_locqf_list_for_finished_jobs for Timer.'
 
     AssertEqual mode(), 'V'
     exe "norm! \<Esc>"
@@ -177,7 +177,7 @@ Execute (Location list is not cleared in operator-pending mode (Vim)):
     AssertNeomakeMessage 'File-level errors cleaned.', 3
     AssertNeomakeMessage 'Postponing final location list handling for mode "no".'
     AssertEqual b:cb_called, 'no'
-    AssertNeomakeMessage 'Queueing action: s:handle_locqf_list_for_finished_jobs for Timer.'
+    AssertNeomakeMessage 'Queuing action handle_locqf_list_for_finished_jobs for Timer.'
 
     AssertEqual len(g:neomake_test_countschanged), 0
     AssertEqual len(g:neomake_test_finished), 0
@@ -208,7 +208,7 @@ Execute (Location list is only cleared in same window on success):
     AssertEqual map(getloclist(win2), 'v:val.text'), ['init2'], 'Location list has not been updated'
     AssertNeomakeMessage 'Cleaning jobinfo.', 3
     AssertNeomakeMessage 'Postponing final location list handling (in another window).'
-    AssertNeomakeMessage 'Queueing action: s:handle_locqf_list_for_finished_jobs for WinEnter.'
+    AssertNeomakeMessage 'Queuing action handle_locqf_list_for_finished_jobs for WinEnter.'
     AssertEqual len(g:neomake_test_countschanged), 0
     AssertEqual len(g:neomake_test_finished), 0
 
@@ -667,7 +667,7 @@ Execute (get_list_entries: delayed for location list (but in current context)):
   AssertNeomakeMessage 'Postponing location list processing.', 3
   AssertEqual getloclist(0), []
   AssertEqual winnr(), 2
-  AssertNeomakeMessage 'Skipping cleaning of job info because of queued actions: s:ProcessEntries.', 3
+  AssertNeomakeMessage 'Skipping cleaning of job info because of queued actions: ProcessEntries.', 3
   let valid = has('patch-8.0.0580')
   AssertEqualQf getloclist(3), [{
   \ 'lnum': 0, 'bufnr': 0, 'col': 0, 'valid': valid, 'vcol': 0, 'nr': -1,
@@ -803,7 +803,7 @@ Execute (action queue handles E48 in process_output):
   AssertNeomakeMessage 'exit: unnamed_maker: 0.'
   AssertNeomakeMessage 'unnamed_maker: processing 1 lines of output.'
   AssertNeomakeMessage 'Error during pcall: Vim(bprevious):E48: Not allowed in sandbox:   sandbox bprevious.', 3
-  AssertNeomakeMessage 'Queueing action: s:ProcessJobOutput for Timer, WinEnter.'
+  AssertNeomakeMessage 'Queuing action ProcessJobOutput for Timer, WinEnter.'
   if has('timers')
     AssertNeomakeMessage 'Retrying Timer event in 10ms.'
   else
@@ -812,18 +812,18 @@ Execute (action queue handles E48 in process_output):
   if async
     AssertNeomakeMessage 'unnamed_maker: completed with exit code 0.'
   endif
-  AssertNeomakeMessage 'Skipping cleaning of job info because of queued actions: s:ProcessJobOutput.'
-  AssertNeomakeMessage 'Queueing action: s:CleanJobinfo for WinEnter.'
+  AssertNeomakeMessage 'Skipping cleaning of job info because of queued actions: ProcessJobOutput.'
+  AssertNeomakeMessage 'Queuing action CleanJobinfo for WinEnter.'
 
   bwipe
 
   AssertNeomakeMessage 'action queue: processing for WinEnter (2 items, winnr: 1).', 3
-  AssertNeomakeMessage 'action queue: calling s:ProcessJobOutput.', 3
+  AssertNeomakeMessage 'action queue: calling ProcessJobOutput.', 3
   AssertNeomakeMessage 'Postponing location list processing.', 3
-  AssertNeomakeMessage 'Queueing action: s:ProcessJobOutput for BufEnter, WinEnter.', 3
-  AssertNeomakeMessage 'action queue: calling s:CleanJobinfo.', 3
-  AssertNeomakeMessage 'Skipping cleaning of job info because of queued actions: s:ProcessJobOutput.', 3
-  AssertNeomakeMessage 'Queueing action: s:CleanJobinfo for WinEnter.', 3
+  AssertNeomakeMessage 'Queuing action ProcessJobOutput for BufEnter, WinEnter.', 3
+  AssertNeomakeMessage 'action queue: calling CleanJobinfo.', 3
+  AssertNeomakeMessage 'Skipping cleaning of job info because of queued actions: ProcessJobOutput.', 3
+  AssertNeomakeMessage 'Queuing action CleanJobinfo for WinEnter.', 3
   AssertNeomakeMessage 'action queue: processed 0 items.', 3
   AssertNeomakeMessage 'action queue: processing for BufEnter (1 items, winnr: 1).', 3
 
@@ -856,21 +856,21 @@ Execute (job finishes while in tabline function):
 
     NeomakeTestsWaitForMessage 'Error during pcall: Vim(laddexpr):E523: Not allowed here:                 laddexpr a:lines.', 3
     AssertNeomakeMessage '\v\(in function .*\.\.\<SNR\>\d+_NeomakeTestTabline\[\d+\]\.\..*\)', 3
-    AssertNeomakeMessage 'Queueing action: s:ProcessJobOutput for Timer, WinEnter.', 3
+    AssertNeomakeMessage 'Queuing action ProcessJobOutput for Timer, WinEnter.', 3
 
-    AssertNeomakeMessage 'Skipping cleaning of job info because of queued actions: s:ProcessJobOutput.'
-    AssertNeomakeMessage 'Queueing action: s:CleanJobinfo for WinEnter.'
+    AssertNeomakeMessage 'Skipping cleaning of job info because of queued actions: ProcessJobOutput.'
+    AssertNeomakeMessage 'Queuing action CleanJobinfo for WinEnter.'
     AssertNeomakeMessage 'tabline_end.', 3
     sleep 20m
     AssertNeomakeMessage 'action queue: processing for Timer (1 items, winnr: 2).', 3
-    AssertNeomakeMessage 'action queue: calling s:ProcessJobOutput.', 3
+    AssertNeomakeMessage 'action queue: calling ProcessJobOutput.', 3
 
     " Restore here already for vim8090 (E117: Unknown function: s:NeomakeTestTabline)
     Restore &tabline
     doautocmd WinEnter
     AssertNeomakeMessage 'action queue: processing for WinEnter (1 items, winnr: 2).', 3
     AssertNeomakeMessageAbsent 'action queue: processing for Timer (0 items, winnr: 2).', 3
-    AssertNeomakeMessage 'action queue: calling s:CleanJobinfo.', 3
+    AssertNeomakeMessage 'action queue: calling CleanJobinfo.', 3
 
     AssertEqual map(getloclist(0), 'v:val.text'), ['finished_in_tabline']
     bwipe

--- a/tests/processing.vader
+++ b/tests/processing.vader
@@ -667,7 +667,7 @@ Execute (get_list_entries: delayed for location list (but in current context)):
   AssertNeomakeMessage 'Postponing location list processing.', 3
   AssertEqual getloclist(0), []
   AssertEqual winnr(), 2
-  AssertNeomakeMessage 'Skipping cleaning of job info because of queued actions: ProcessEntries.', 3
+  AssertNeomakeMessage "Skipping cleaning of job info because of queued actions: ['ProcessEntries', ['BufEnter', 'WinEnter']].", 3
   let valid = has('patch-8.0.0580')
   AssertEqualQf getloclist(3), [{
   \ 'lnum': 0, 'bufnr': 0, 'col': 0, 'valid': valid, 'vcol': 0, 'nr': -1,
@@ -812,7 +812,7 @@ Execute (action queue handles E48 in process_output):
   if async
     AssertNeomakeMessage 'unnamed_maker: completed with exit code 0.'
   endif
-  AssertNeomakeMessage 'Skipping cleaning of job info because of queued actions: ProcessJobOutput.'
+  AssertNeomakeMessage "Skipping cleaning of job info because of queued actions: ['ProcessJobOutput', ['Timer', 'WinEnter']].", 3
   AssertNeomakeMessage 'Queuing action CleanJobinfo for WinEnter.'
 
   bwipe
@@ -822,7 +822,7 @@ Execute (action queue handles E48 in process_output):
   AssertNeomakeMessage 'Postponing location list processing.', 3
   AssertNeomakeMessage 'Queuing action ProcessJobOutput for BufEnter, WinEnter.', 3
   AssertNeomakeMessage 'action queue: calling CleanJobinfo.', 3
-  AssertNeomakeMessage 'Skipping cleaning of job info because of queued actions: ProcessJobOutput.', 3
+  AssertNeomakeMessage "Skipping cleaning of job info because of queued actions: ['ProcessJobOutput', ['BufEnter', 'WinEnter']].", 3
   AssertNeomakeMessage 'Queuing action CleanJobinfo for WinEnter.', 3
   AssertNeomakeMessage 'action queue: processed 0 items.', 3
   AssertNeomakeMessage 'action queue: processing for BufEnter (1 items, winnr: 1).', 3
@@ -858,7 +858,7 @@ Execute (job finishes while in tabline function):
     AssertNeomakeMessage '\v\(in function .*\.\.\<SNR\>\d+_NeomakeTestTabline\[\d+\]\.\..*\)', 3
     AssertNeomakeMessage 'Queuing action ProcessJobOutput for Timer, WinEnter.', 3
 
-    AssertNeomakeMessage 'Skipping cleaning of job info because of queued actions: ProcessJobOutput.'
+    AssertNeomakeMessage "Skipping cleaning of job info because of queued actions: ['ProcessJobOutput', ['Timer', 'WinEnter']]."
     AssertNeomakeMessage 'Queuing action CleanJobinfo for WinEnter.'
     AssertNeomakeMessage 'tabline_end.', 3
     sleep 20m

--- a/tests/processing.vader
+++ b/tests/processing.vader
@@ -368,16 +368,16 @@ Execute (Sleep in postprocess gets handled correctly):
     AssertNeomakeMessage 'unnamed_maker: processing 1 lines of output.', 3, jobinfo
     if !has('nvim-0.2.0')
       AssertNeomakeMessage 'exit (delayed): unnamed_maker: 0.', 3, jobinfo
-      AssertNeomakeMessage "Calling User autocmd NeomakeCountsChanged with context: {'jobinfo': '…', 'reset': 0}."
+      AssertNeomakeMessage '\VCalling User autocmd NeomakeCountsChanged with context:', 2
     endif
 
     AssertNeomakeMessage "stdout: unnamed_maker: ['out-22', ''].", 3, jobinfo
     AssertNeomakeMessage 'unnamed_maker: processing 1 lines of output.', 3, jobinfo
-    AssertNeomakeMessage "Calling User autocmd NeomakeCountsChanged with context: {'jobinfo': '…', 'reset': 0}."
+    AssertNeomakeMessage '\VCalling User autocmd NeomakeCountsChanged with context:', 2
 
     AssertNeomakeMessage "stdout: unnamed_maker: ['out-333', ''].", 3, jobinfo
     AssertNeomakeMessage 'unnamed_maker: processing 1 lines of output.', 3, jobinfo
-    AssertNeomakeMessage "Calling User autocmd NeomakeCountsChanged with context: {'jobinfo': '…', 'reset': 0}."
+    AssertNeomakeMessage '\VCalling User autocmd NeomakeCountsChanged with context:', 2
 
     if !has('nvim-0.2.0')
       AssertNeomakeMessage 'Trigger delayed exit.', 3, jobinfo
@@ -676,7 +676,7 @@ Execute (get_list_entries: delayed for location list (but in current context)):
   3wincmd w
   AssertNeomakeMessage 'action queue: processing for WinEnter (2 items, winnr: 3).'
   AssertNeomakeMessage 'Cleaning jobinfo.'
-  AssertNeomakeMessage "Calling User autocmd NeomakeJobFinished with context: {'jobinfo': '…'}.", 2
+  AssertNeomakeMessage '\VCalling User autocmd NeomakeJobFinished with context:', 2
 
   AssertEqual winnr(), 2
   AssertEqual map(getloclist(3), '[v:val.bufnr, v:val.text, v:val.type]'), [


### PR DESCRIPTION
TODO:

- [x] ensure actions are not tried via timers forever (https://ci.appveyor.com/project/blueyed/neomake/build/1.0.180/job/ck150swnuyeuaw2e) - should be done ("pcall aborts after 3 attempts per job")
- ~~[ ] fix coverage for s:function (https://codecov.io/gh/neomake/neomake/compare/9423dc2a8a3999d138f3a4cd8bdfc2750d1087d8...9ffd3376526feccc392e22a033e1de612d8035be/diff#D9-58). Needs https://github.com/vim/vim/pull/3362 and covimerage using it.~~  Postponing.