### PR TITLE
Add support for always using stdin

### DIFF
--- a/doc/neomake.txt
+++ b/doc/neomake.txt
@@ -443,6 +443,12 @@ to look for its config.  Use the jobinfo's `cd` method for this: >
         return 1
     endfunction
 <
+                                                   *neomake-makers-uses_stdin*
+Default: 0
+`uses_stdin = 1` can be used to always use stdin for file arguments,
+regardless of if a temporary file / stdin is required to be used.
+It uses "-" as the default for "tempfile_name".
+
 Global Options                                               *neomake-options*
 
 *g:neomake_<name>_maker*

--- a/tests/include/init.vim
+++ b/tests/include/init.vim
@@ -318,7 +318,14 @@ endfunction
 
 function! NeomakeTestsFakeJobinfo() abort
   let make_id = -42
-  let jobinfo = {'file_mode': 1, 'bufnr': bufnr('%'), 'ft': '', 'make_id': make_id}
+  let jobinfo = copy(g:neomake#jobinfo#base)
+  call extend(jobinfo, {
+        \ 'file_mode': 1,
+        \ 'bufnr': bufnr('%'),
+        \ 'ft': '',
+        \ 'make_id': make_id,
+        \ 'maker': {},
+        \ })
   let make_info = neomake#GetStatus().make_info
   let make_info[make_id] = {
         \ 'options': jobinfo,

--- a/tests/stdin.vader
+++ b/tests/stdin.vader
@@ -297,16 +297,19 @@ Execute (stdin maker: can always use stdin):
   AssertEqual map(getloclist(0), 'v:val.text'), []
 
   " tempfile_name can be changed via settings.
+  " NOTE: vim81 fails with "Vim(call):E631: ch_sendraw(): write failed" if the
+  " process does not have stdin open.
   call neomake#config#set('b:uses_stdin', 1)
-  call neomake#config#set('b:tempfile_name', 'custom')
+  call neomake#config#set('b:tempfile_name', '-')
+  call neomake#config#set('b:stdin_maker.exe', 'cat')
   CallNeomake 1, [maker]
   AssertNeomakeMessage 'Using uses_stdin (1) from setting.', 3
-  AssertNeomakeMessage "Using setting tempfile_name='custom' from 'buffer'.", 3
+  AssertNeomakeMessage "Using setting tempfile_name='-' from 'buffer'.", 3
   if neomake#has_async_support()
-    AssertNeomakeMessage "Starting async job: true custom.", 2
+    AssertNeomakeMessage 'Starting async job: cat -.', 2
   else
-    AssertNeomakeMessage "Starting [string]: true custom.", 2
+    AssertNeomakeMessage "Starting [string]: cat -.", 2
   endif
-  AssertEqual map(getloclist(0), 'v:val.text'), []
+  AssertEqual map(getloclist(0), 'v:val.text'), ['line1', 'line2']
 
   bwipe!

--- a/tests/stdin.vader
+++ b/tests/stdin.vader
@@ -259,3 +259,54 @@ Execute (stdin maker: can use buffer's cwd):
   CallNeomake 1, [maker]
   AssertNeomakeMessage printf('cwd: %s.', getcwd()), 3
   bwipe
+
+Execute (stdin maker: can always use stdin):
+  let maker = {
+  \ 'name': 'stdin_maker',
+  \ 'exe': 'cat',
+  \ 'uses_stdin': 1,
+  \ 'errorformat': '%f:%m'}
+  new
+  call setline(1, ['file1.test:line1', 'file1.test:line2'])
+
+  CallNeomake 1, [maker]
+
+  AssertNeomakeMessage 'Using uses_stdin (1) from setting.', 3
+
+  if neomake#has_async_support()
+    AssertNeomakeMessage "Starting async job: cat -.", 2
+    NeomakeTestsWaitForFinishedJobs
+  endif
+  AssertNeomakeMessage 'cwd: '.getcwd().'.', 3
+  AssertNeomakeMessage '\mstdout: stdin_maker: [''file1.test:line1.*'
+  AssertNeomakeMessage '\vUsed bufnr from stdin buffer (\d+) \(file1.test\) for 2 entries: 1, 2.'
+  let tempbuf = g:neomake_test_matchlist[1]
+  AssertEqual map(getloclist(0), 'v:val.text'), ['line1', 'line2']
+  AssertNeomakeMessage "Wiping out 1 unlisted/remapped buffers: ['".tempbuf."']."
+
+  " uses_stdin can be changed via settings.
+  call neomake#config#set('b:uses_stdin', 0)
+  call neomake#config#set('b:stdin_maker.exe', 'true')
+  CallNeomake 1, [maker]
+  AssertNeomakeMessage 'Using uses_stdin (0) from setting.', 3
+  if neomake#has_async_support()
+    AssertNeomakeMessage "Starting async job: true.", 2
+  else
+    AssertNeomakeMessage "Starting [string]: true.", 2
+  endif
+  AssertEqual map(getloclist(0), 'v:val.text'), []
+
+  " tempfile_name can be changed via settings.
+  call neomake#config#set('b:uses_stdin', 1)
+  call neomake#config#set('b:tempfile_name', 'custom')
+  CallNeomake 1, [maker]
+  AssertNeomakeMessage 'Using uses_stdin (1) from setting.', 3
+  AssertNeomakeMessage "Using setting tempfile_name='custom' from 'buffer'.", 3
+  if neomake#has_async_support()
+    AssertNeomakeMessage "Starting async job: true custom.", 2
+  else
+    AssertNeomakeMessage "Starting [string]: true custom.", 2
+  endif
+  AssertEqual map(getloclist(0), 'v:val.text'), []
+
+  bwipe!


### PR DESCRIPTION
`uses_stdin` can be set on the maker or via settings unconditionally.