### PR TITLE
Fix neomake#compat#restore_prev_window

### DIFF
--- a/autoload/neomake/compat.vim
+++ b/autoload/neomake/compat.vim
@@ -271,7 +271,11 @@ if exists('*win_getid')
         " Go back, maintaining the '#' window (CTRL-W_p).
         let [aw_id, pw_id] = remove(s:prev_windows, 0)
         let pw = win_id2win(pw_id)
-        if pw && winnr() != pw
+        if !pw
+            call neomake#log#debug(printf(
+                  \ 'Cannot restore previous windows (previous window with ID %d not found).',
+                  \ pw_id))
+        elseif winnr() != pw
             let aw = win_id2win(aw_id)
             if aw
                 exec aw . 'wincmd w'
@@ -287,7 +291,11 @@ else
     function! neomake#compat#restore_prev_windows() abort
         " Go back, maintaining the '#' window (CTRL-W_p).
         let [aw, pw] = remove(s:prev_windows, 0)
-        if winnr() != pw
+        if pw > winnr('$')
+            call neomake#log#debug(printf(
+                  \ 'Cannot restore previous windows (%d > %d).',
+                  \ pw, winnr('$')))
+        elseif winnr() != pw
             if aw
                 exec aw . 'wincmd w'
             endif

--- a/tests/compat.vader
+++ b/tests/compat.vader
@@ -160,3 +160,18 @@ Execute (neomake#compat#glob_list):
   let &wildignore = '*.vader'
   AssertEqual fnamemodify(g:vader_file, ':e'), 'vader'
   AssertEqual neomake#compat#glob_list(g:vader_file), [g:vader_file]
+
+Execute (neomake#compat#restore_prev_windows handles removed windows):
+  new
+  new
+  if exists('*win_getid')
+    let expected_msg = printf('Cannot restore previous windows (previous window with ID %d not found).',
+    \ win_getid())
+  else
+    let expected_msg = 'Cannot restore previous windows (3 > 2).'
+  endif
+  call neomake#compat#save_prev_windows()
+  bwipe
+  call neomake#compat#restore_prev_windows()
+  AssertNeomakeMessage expected_msg, 3
+  bwipe


### PR DESCRIPTION
Fixes handling of removed windows without win_getid().