### PR TITLE
Open cwindow botright

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -976,7 +976,7 @@ function! s:HandleLoclistQflistDisplay(jobinfo, loc_or_qflist, ...) abort
         let cmd = 'lwindow'
     else
         call neomake#log#debug('Handling quickfix list: executing cwindow.', a:jobinfo)
-        let cmd = 'cwindow'
+        let cmd = 'botright cwindow'
     endif
     if open_val == 2
         let make_id = a:jobinfo.make_id


### PR DESCRIPTION
I'm coming from using dispatch and vim-rspec where the quickfix window was always opened using botright and i find it a bit weird how neomake opens lwindow and cwindow.

This PR serves more as a question to you @blueyed. I don't actually know what `cwindow` defaults to? From my testing it seem to open under the rightmost split?

You might be more open to putting this behind a config flag instead of hardcoding it to botright?