### PR TITLE
Only use default_entry_type for valid entries

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -1485,7 +1485,7 @@ function! s:AddExprCallback(jobinfo, prev_list) abort
             endif
         endif
 
-        if empty(entry.type)
+        if empty(entry.type) && entry.valid
             if default_type ==# 'unset'
                 let default_type = neomake#utils#GetSetting('default_entry_type', maker, 'W', a:jobinfo.ft, a:jobinfo.bufnr)
             endif

--- a/tests/list-entries.vader
+++ b/tests/list-entries.vader
@@ -1,0 +1,13 @@
+Include: include/setup.vader
+
+Execute (default_entry_type is only used for valid/recognized entries):
+  let maker = {'exe': 'printf', 'args': ['%s\n', 'errorfile:msg', 'info']}
+  let maker.remove_invalid_entries = 0
+  let maker.errorformat = '%f:%m'
+
+  CallNeomake 0, [maker]
+  AssertEqual map(getqflist(), '[v:val.text, v:val.type]'), [
+  \ ['msg', 'W'],
+  \ ['info', '']]
+
+  bwipe errorfile

--- a/tests/main.vader
+++ b/tests/main.vader
@@ -25,6 +25,7 @@ Include (Integration tests): integration.vader
 Include (Jobinfo): jobinfo.vader
 Include (JSON): json.vader
 Include (Lists): lists.vader
+Include (List entries): list-entries.vader
 Include (Logging): log.vader
 Include (Makeprg): makeprg.vader
 Include (Maker args): args.vader

--- a/tests/makers.vader
+++ b/tests/makers.vader
@@ -782,7 +782,7 @@ Execute (Maker can pass opts for jobstart/job_start):
       CallNeomake 0, [maker]
       AssertEqualQf getqflist(), [
       \ {'lnum': 0, 'bufnr': 0, 'col': 0, 'valid': 0, 'vcol': 0, 'nr': -1,
-      \  'type': 'W', 'pattern': '', 'text': 'custom-term'}]
+      \  'type': '', 'pattern': '', 'text': 'custom-term'}]
     endif
   endif
 


### PR DESCRIPTION
This is important for e.g. using makeprg=make, which typically has a lot
of invalid/unrecognized entries.