### PR TITLE
neomake#statusline#get: require bufnr as first arg again

### DIFF
--- a/autoload/neomake/statusline.vim
+++ b/autoload/neomake/statusline.vim
@@ -240,7 +240,7 @@ function! neomake#statusline#get_status(bufnr, options) abort
         endif
     else
         let format_loclist = get(a:options, 'format_loclist_issues',
-                    \ '%s%%#NeomakeStatReset#')
+                    \ use_highlights_with_defaults ? '%s%%#NeomakeStatReset#' : '%s')
         if !empty(format_loclist)
             let loclist = ''
             for [type, c] in items(loclist_counts)
@@ -277,7 +277,7 @@ function! neomake#statusline#get_status(bufnr, options) abort
         endif
     else
         let format_quickfix = get(a:options, 'format_quickfix_issues',
-                    \ '%s%%#NeomakeStatReset#')
+                    \ use_highlights_with_defaults ? '%s%%#NeomakeStatReset#' : '%s')
         if !empty(format_quickfix)
             let quickfix = ''
             for [type, c] in items(qflist_counts)
@@ -309,26 +309,14 @@ function! neomake#statusline#get_status(bufnr, options) abort
     return r
 endfunction
 
-function! neomake#statusline#get(...) abort
-    if a:0
-        if type(a:1) == type({})
-            let options = a:1
-            let bufnr = get(options, 'bufnr', g:actual_curbuf)
-        else
-            call neomake#log#warn_once('Please use neomake#statusline#get with a single dictionary argument.', 'statusline#get: dict-arg')
-            let bufnr = a:1
-            let options = get(a:000, 1, {})
-        endif
-    else
-        let bufnr = g:actual_curbuf
-        let options = {}
-    endif
+function! neomake#statusline#get(bufnr, ...) abort
+    let options = a:0 ? a:1 : {}
     let cache_key = string(options)
-    if !exists('s:cache[bufnr][cache_key]')
-        if !has_key(s:cache, bufnr)
-            let s:cache[bufnr] = {}
+    if !exists('s:cache[a:bufnr][cache_key]')
+        if !has_key(s:cache, a:bufnr)
+            let s:cache[a:bufnr] = {}
         endif
-        let bufnr = +bufnr
+        let bufnr = +a:bufnr
 
         " TODO: needs to go into cache key then!
         if getbufvar(bufnr, '&filetype') ==# 'qf'
@@ -362,7 +350,7 @@ function! neomake#statusline#get(...) abort
             let s:cache[bufnr][cache_key] = r
         endif
     endif
-    return s:cache[bufnr][cache_key]
+    return s:cache[a:bufnr][cache_key]
 endfunction
 
 " XXX: TODO: cleanup/doc?!

--- a/doc/neomake.txt
+++ b/doc/neomake.txt
@@ -713,7 +713,13 @@ define |g:neomake_error_sign|. >
 The main function for statusline integration is `neomake#statusline#get()`,
 which caches the information retrieved from `neomake#statusline#get_status()`.
 
-*neomake#statusline#get()* [options]
+*neomake#statusline#get()* <bufnr> [options]
+The function requires the buffer number as first argument, and an optional
+dictionary.  You might want to use |g:actual_curbuf| for bufnr, if calling
+`neomake#status#get()` from a statusline expression, but then highlights are
+not evaluated, and you typically want to use this in a statusline function
+(`'set statusline=%!MyStatusLine()'`) instead.
+
 Returns a string for a 'statusline'.
 
 The optional argument is a dictionary of options (see below).
@@ -798,7 +804,6 @@ For quickfix list items:~
 
 Advanced options:
 
-  - bufnr: the buffer number to act on, defaults to |g:actual_curbuf|.
   - use_highlights_with_defaults: include highlight attributes with default
     options (e.g. "%#NeomakeStatusGood#" with "format_loclist_ok").
     Default: 1

--- a/tests/statusline.vader
+++ b/tests/statusline.vader
@@ -96,63 +96,55 @@ Execute (neomake#statusline#get_status):
   AssertNeomakeMessage "Errors when formatting '{{foo}} {{bar}}': Unknown statusline format: {{foo}}., Unknown statusline format: {{bar}}.", 0
 
   AssertEqual neomake#statusline#get_status(bufnr, {}), '%#NeomakeStatusGood#✓'
-  Save g:actual_curbuf
-  let g:actual_curbuf = bufnr
-  AssertEqual neomake#statusline#get(), '%#NeomakeStatusGood#✓'
+  AssertEqual neomake#statusline#get(bufnr, {}), '%#NeomakeStatusGood#✓'
   call neomake#statusline#ResetCountsForBuf(bufnr)
   AssertEqual neomake#statusline#get_status(bufnr, {}), '?'
-  AssertEqual neomake#statusline#get(), '?'
+  AssertEqual neomake#statusline#get(bufnr, {}), '?'
   bwipe
 
 Execute (neomake#statusline#get: clears cache with new job (file mode)):
   new
   let bufnr = bufnr('%')
-  Save g:actual_curbuf
-  let g:actual_curbuf = bufnr
   CallNeomake {'enabled_makers': [g:error_maker]}
-  AssertEqual neomake#statusline#get(), '%#NeomakeStatColorTypeE# E:1 %#NeomakeStatReset#'
+  AssertEqual neomake#statusline#get(bufnr), '%#NeomakeStatColorTypeE# E:1 %#NeomakeStatReset#'
 
   call neomake#Make({'enabled_makers': [g:success_maker]})
   if neomake#has_async_support()
-    AssertEqual neomake#statusline#get(), '… (success-maker)'
+    AssertEqual neomake#statusline#get(bufnr), '… (success-maker)'
     NeomakeTestsWaitForFinishedJobs
   endif
-  AssertEqual neomake#statusline#get(), '%#NeomakeStatusGood#✓'
+  AssertEqual neomake#statusline#get(bufnr), '%#NeomakeStatusGood#✓'
   bwipe
 
 Execute (neomake#statusline#get: clears cache with new job (project mode)):
   new
   let bufnr = bufnr('%')
-  Save g:actual_curbuf
-  let g:actual_curbuf = bufnr
   CallNeomake {'file_mode': 0, 'enabled_makers': [g:error_maker]}
-  AssertEqual neomake#statusline#get(), '%#NeomakeStatColorQuickfixTypeE# QE:1 %#NeomakeStatReset#'
+  AssertEqual neomake#statusline#get(bufnr), '%#NeomakeStatColorQuickfixTypeE# QE:1 %#NeomakeStatReset#'
 
   call neomake#Make({'file_mode': 0, 'enabled_makers': [g:true_maker]})
   if neomake#has_async_support()
-    AssertEqual neomake#statusline#get(), '… (true-maker!)'
+    AssertEqual neomake#statusline#get(bufnr), '… (true-maker!)'
   endif
   call neomake#Make({'file_mode': 0, 'enabled_makers': [g:success_maker]})
   if neomake#has_async_support()
-    AssertEqual neomake#statusline#get(), '… (true-maker!, success-maker!)'
+    AssertEqual neomake#statusline#get(bufnr), '… (true-maker!, success-maker!)'
     NeomakeTestsWaitForFinishedJobs
   endif
   " Unknown status, only project makers have been run.
-  AssertEqual neomake#statusline#get(), '?'
+  AssertEqual neomake#statusline#get(bufnr), '?'
   bwipe
 
 Execute (neomake#statusline#get: clears cache with canceled job: keeps '?'):
   if neomake#has_async_support()
     new
     let bufnr = bufnr('%')
-    Save g:actual_curbuf
-    let g:actual_curbuf = bufnr
     call neomake#Make({'file_mode': 0, 'enabled_makers': [g:sleep_maker]})
-    AssertEqual neomake#statusline#get(), '… (sleep-maker!)'
+    AssertEqual neomake#statusline#get(bufnr), '… (sleep-maker!)'
     NeomakeCancelJobs
-    AssertEqual neomake#statusline#get(), '… (sleep-maker!)'
+    AssertEqual neomake#statusline#get(bufnr), '… (sleep-maker!)'
     NeomakeTestsWaitForFinishedJobs
-    AssertEqual neomake#statusline#get(), '?'
+    AssertEqual neomake#statusline#get(bufnr), '?'
     bwipe
   else
     NeomakeTestsSkip 'no async support.'
@@ -161,60 +153,27 @@ Execute (neomake#statusline#get: clears cache with canceled job: keeps '?'):
 Execute (neomake#statusline#get: disabling/enabling: clears cache):
   new
   let bufnr = bufnr('%')
-  Save g:actual_curbuf
-  let g:actual_curbuf = bufnr
-  AssertEqual neomake#statusline#get(), '?'
+  AssertEqual neomake#statusline#get(bufnr), '?'
   NeomakeDisableBuffer
-  AssertEqual neomake#statusline#get(), 'b- ?'
+  AssertEqual neomake#statusline#get(bufnr), 'b- ?'
   AssertNeomakeMessage "Using setting disabled=1 from 'buffer' (statusline#get).", 3, {'bufnr': bufnr}
 
   NeomakeToggleBuffer
-  AssertEqual neomake#statusline#get(), '?'
+  AssertEqual neomake#statusline#get(bufnr), '?'
 
   CallNeomake 1, [g:true_maker]
-  AssertEqual neomake#statusline#get(), '%#NeomakeStatusGood#✓'
+  AssertEqual neomake#statusline#get(bufnr), '%#NeomakeStatusGood#✓'
 
   " no-op
   NeomakeEnableBuffer
-  AssertEqual neomake#statusline#get(), '%#NeomakeStatusGood#✓'
+  AssertEqual neomake#statusline#get(bufnr), '%#NeomakeStatusGood#✓'
   bwipe
 
 Execute (neomake#statusline#get: use_highlights_with_defaults):
   new
   let bufnr = bufnr('%')
-  Save g:actual_curbuf
-  let g:actual_curbuf = bufnr
-  AssertEqual neomake#statusline#get({'use_highlights_with_defaults': 0}), '?'
+  AssertEqual neomake#statusline#get(bufnr, {'use_highlights_with_defaults': 0}), '?'
   call neomake#Make({'enabled_makers': [g:entry_maker]})
-  AssertEqual neomake#statusline#get({'use_highlights_with_defaults': 0}), '✓'
-  AssertEqual neomake#statusline#get({'use_highlights_with_defaults': 1}), '%#NeomakeStatusGood#✓'
+  AssertEqual neomake#statusline#get(bufnr, {'use_highlights_with_defaults': 0}), '✓'
+  AssertEqual neomake#statusline#get(bufnr, {'use_highlights_with_defaults': 1}), '%#NeomakeStatusGood#✓'
   bwipe
-
-Execute (neomake#statusline#get: warning with bufnr):
-  AssertEqual neomake#statusline#get(bufnr('%')), '?'
-  AssertEqual v:warningmsg, 'Please use neomake#statusline#get with a single dictionary argument.'
-  let v:warningmsg = ''
-  AssertEqual neomake#statusline#get(bufnr('%')), '?'
-  AssertEqual v:warningmsg, ''
-
-Execute (XXX: g:actual_curbuf is set in statusline expressions):
-  " This was meant to ensure that g:actual_curbuf is set in statusline
-  " expressions, but it turned out that it is not when wrapped in a function,
-  " like with Vader's tests.
-  " See https://github.com/vim/vim/issues/3279.
-  new
-
-  let s:called = 0
-  function! Statusline()
-    " Tests the current behavior.
-    Assert !exists('g:actual_curbuf')
-    let s:called = 1
-  endfunction
-
-  " NOTE: not being set with just '%!Statusline()' already.
-  setlocal statusline=%!'%{Statusline()}'
-  redraw
-
-  AssertEqual s:called, 1
-  bwipe
-  delfunction Statusline


### PR DESCRIPTION
Using g:actual_curbuf is not really an option, and only complicates
things.