### PR TITLE
automake: do not restart timers in general if pos changed

### DIFF
--- a/autoload/neomake/configure.vim
+++ b/autoload/neomake/configure.vim
@@ -95,7 +95,7 @@ function! s:neomake_do_automake(context) abort
         let timer = timer_start(a:context.delay, function('s:automake_delayed_cb'))
         let s:timer_info[timer] = a:context
         if !has_key(a:context, 'pos')
-            let s:timer_info[timer].pos = [getpos('.'), neomake#compat#get_mode()]
+            let s:timer_info[timer].pos = s:get_position_context()
         endif
         let s:timer_by_bufnr[bufnr] = timer
         call s:debug_log(printf('started timer (%dms): %d', a:context.delay, timer),
@@ -125,6 +125,11 @@ function! s:neomake_do_automake(context) abort
         call setbufvar(bufnr, 'neomake_automake_make_ids',
               \ neomake#compat#getbufvar(bufnr, 'neomake_automake_make_ids', []) + make_ids)
     endif
+endfunction
+
+function! s:get_position_context() abort
+    let w = exists('*win_getid') ? win_getid() : winnr()
+    return [w, getpos('.'), neomake#compat#get_mode()]
 endfunction
 
 function! s:automake_delayed_cb(timer) abort
@@ -159,11 +164,12 @@ function! s:automake_delayed_cb(timer) abort
         if has_key(timer_info, 'pos')
             unlet timer_info.pos
         endif
-        let b:_neomake_postponed_automake_context = timer_info
+        let b:_neomake_postponed_automake_context = [0, timer_info]
 
         augroup neomake_automake_retry
           au! * <buffer>
-          autocmd CompleteDone <buffer> call s:do_postponed_automake()
+          autocmd CompleteDone <buffer> call s:do_postponed_automake(1)
+          autocmd InsertLeave <buffer> call s:do_postponed_automake(2)
         augroup END
         return
     endif
@@ -173,16 +179,10 @@ function! s:automake_delayed_cb(timer) abort
     "       BufWritePost/BufWinEnter?!
     " if timer_info.event !=# 'BufWritePost'
     if !empty(timer_info.pos)
-        let mode = neomake#compat#get_mode()
-        let current_context = [getpos('.'), mode]
+        let current_context = s:get_position_context()
         if current_context != timer_info.pos
             call s:debug_log(printf('context/position changed: %s => %s',
                         \ string(timer_info.pos), string(current_context)))
-            " Restart timer.
-            if !empty(timer_info.pos)
-                let timer_info.pos = [getpos('.'), mode]
-            endif
-            call s:neomake_do_automake(timer_info)
             return
         endif
     endif
@@ -193,15 +193,29 @@ function! s:automake_delayed_cb(timer) abort
     call s:neomake_do_automake(context)
 endfunction
 
-function! s:do_postponed_automake() abort
+function! s:do_postponed_automake(step) abort
     if exists('b:_neomake_postponed_automake_context')
-        call s:debug_log('re-starting postponed automake')
         let context = b:_neomake_postponed_automake_context
-        unlet b:_neomake_postponed_automake_context
-        call s:neomake_do_automake(context)
+
+        if context[0] == a:step - 1
+            if a:step == 2
+                call s:debug_log('re-starting postponed automake')
+                let context[1].pos = s:get_position_context()
+                call s:neomake_do_automake(context[1])
+            else
+                let context[0] = a:step
+                return
+            endif
+        else
+            call s:debug_log('postponed automake: unexpected step '.a:step.', cleaning up')
+        endif
+
+        " Cleanup.
         augroup neomake_automake_retry
           autocmd! CompleteDone <buffer>
+          autocmd! InsertLeave <buffer>
         augroup END
+        unlet b:_neomake_postponed_automake_context
     endif
 endfunction
 

--- a/tests/automake.vader
+++ b/tests/automake.vader
@@ -669,7 +669,7 @@ Execute (Automake for normal mode handles ciw):
   AssertEqual len(g:neomake_test_jobfinished), 1
   bwipe!
 
-Execute (Automake restarts if context changed):
+Execute (Automake stops if context changed (CursorHold)):
   if !has('timers')
     NeomakeTestsSkip 'only with timers feature'
   else
@@ -681,9 +681,7 @@ Execute (Automake restarts if context changed):
     doautocmd CursorHold
     AssertNeomakeMessage '\vautomake: started timer \(5ms\): (\d+)'
     norm! ^
-    NeomakeTestsWaitForMessage "automake: context/position changed: [[0, 1, 11, 0], 'n'] => [[0, 1, 1, 0], 'n'].", 3
-    AssertNeomakeMessage '\vautomake: started timer \(5ms\): (\d+)'
-    NeomakeCancelJobs!
+    NeomakeTestsWaitForMessage '\Vautomake: context/position changed: [\d\+, [0, 1, 11, 0], ''n''] => [\d\+, [0, 1, 1, 0], ''n''].', 3
     bwipe!
   endif
 
@@ -717,15 +715,51 @@ Execute (Automake restarts if popup menu is visible):
     " +2 since we use timer_start above.
     AssertNeomakeMessage 'automake: started timer (5ms): '.(base_timer + 2).'.'
     NeomakeTestsWaitForMessage 'automake: callback for timer '.(base_timer + 2).' (via CursorHold).'
-    AssertNeomakeMessage "automake: context/position changed: [[0, 4, 5, 0], 'i'] => [[0, 4, 4, 0], 'n']."
-    AssertNeomakeMessage 'automake: tick changed (new).'
-    AssertNeomakeMessage 'automake: started timer (5ms): '.(base_timer + 3).'.'
     AssertNeomakeMessage 'automake: neomake_do_automake: CursorHold.'
     AssertNeomakeMessage 'automake: tick changed (new).'
     AssertNeomakeMessage '\vautomake: Updating tick: \d+.'
     AssertNeomakeMessage 'automake: enabled makers: true-maker.'
 
     NeomakeTestsWaitForFinishedJobs
+
+    bwipe!
+  endif
+
+Execute (Automake cleans up buffer context when restarting after popup menu fails):
+  if !has('timers')
+    NeomakeTestsSkip 'only with timers feature'
+  else
+    new
+    file file_sleep_efm
+    set filetype=neomake_tests
+    let b:neomake_enabled_makers = [g:true_maker]
+    call append(0, ['word1', 'word2'])
+
+    function! s:close_pum(...)
+      call feedkeys("\<c-e>\<esc>")
+    endfunction
+
+    call neomake#configure#automake_for_buffer({'CursorHold': {'delay': 5}})
+    doautocmd CursorHold
+    AssertNeomakeMessage '\vautomake: started timer \(5ms\): (\d+)'
+    let base_timer = g:neomake_test_matchlist[1]
+
+    " Trigger popup menu.
+    call timer_start(100, 's:close_pum')
+    noautocmd call feedkeys("oword\<C-p>", 'x!')
+
+    AssertNeomakeMessage 'automake: callback for timer '.base_timer.' (via CursorHold).'
+    AssertNeomakeMessage 'automake: postponing automake during completion.', 3
+
+    Assert exists('#neomake_automake_retry#InsertLeave#<buffer='.bufnr('%').'>')
+    Assert exists('#neomake_automake_retry#CompleteDone#<buffer='.bufnr('%').'>')
+    Assert exists('b:_neomake_postponed_automake_context')
+    doautocmd InsertLeave
+    Assert !exists('#neomake_automake_retry#InsertLeave#<buffer='.bufnr('%').'>')
+    Assert !exists('#neomake_automake_retry#CompleteDone#<buffer='.bufnr('%').'>')
+    Assert !exists('b:_neomake_postponed_automake_context')
+
+    AssertNeomakeMessage 'automake: postponed automake: unexpected step 2, cleaning up.', 3
 
     bwipe!
   endif


### PR DESCRIPTION
Also take the window into account for the position.

It might make sense to retrigger (i.e. not forget about) events like
"TextChanged", "BufWritePost" in general though (as long as the tick matches).