### PR TITLE
[WIP] simplify s:output_handler

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -2599,11 +2599,15 @@ function! s:output_handler(jobinfo, data, event_type, trim_CR) abort
     " data is a list of 'lines' read. Each element *after* the first
     " element represents a newline.
     if has_key(jobinfo, a:event_type)
-        let lines = jobinfo[a:event_type]
-        " As per https://github.com/neovim/neovim/issues/3555
-        let jobinfo[a:event_type] = lines[:-2]
-                    \ + [lines[-1] . get(data, 0, '')]
-                    \ + data[1:]
+        " XXX: avoid / work around /improve: Neovim v0.3.1:
+        " (28/43) [EXECUTE] (X) Vim(sleep):E5210: dict key 'stdout' already set for buffered stream in channel 15
+        " let lines = jobinfo[a:event_type]
+        " " As per https://github.com/neovim/neovim/issues/3555
+        " let jobinfo[a:event_type] = lines[:-2]
+        "             \ + [lines[-1] . get(data, 0, '')]
+        "             \ + data[1:]
+        let jobinfo[a:event_type][-1] .= data[0]
+        call extend(jobinfo[a:event_type], data[1:])
     else
         let jobinfo[a:event_type] = data
     endif

--- a/tests/automake.vader
+++ b/tests/automake.vader
@@ -635,6 +635,11 @@ Execute (Automake stops previous jobs):
     doautocmd TextChanged
     NeomakeTestsWaitForMessage '\vautomake: started jobs: \[\d+\].'
     AssertNeomakeMessage '\vautomake: stopping previous make runs: '.first_make_id
+    " XXX: Neovim v0.3.1:
+    " (28/43) [EXECUTE] (X) Vim(sleep):E5210: dict key 'stdout' already set for buffered stream in channel 15
+    " 1126      > in <SNR>17_wait_for_message (line 20)
+    " 1127      >   exe 'sleep' ms.'m'
+    " 1128      > C:\projects\neomake\tests\automake.vader:636: NeomakeTestsWaitForMessage '\vautomake: started jobs: \[\d+\].'
     AssertNeomakeMessage '\vautomake: callback for timer \d+'
     let second_make_id = neomake#GetStatus().last_make_id
     Assert index(b:neomake_automake_make_ids, second_make_id) > -1, 'Second make is registered'


### PR DESCRIPTION
Initially meant to work around "E5210: dict key 'stdout' already set for buffered stream" seen with Neovim in appveyor branch.