### PR TITLE
[php.phpcs] disable phpcs progress

### DIFF
--- a/autoload/neomake/makers/ft/php.vim
+++ b/autoload/neomake/makers/ft/php.vim
@@ -20,7 +20,7 @@ function! neomake#makers#ft#php#php() abort
 endfunction
 
 function! neomake#makers#ft#php#phpcs() abort
-    let l:args = ['--report=csv']
+    let l:args = ['--report=csv', '-q']
 
     "Add standard argument if one is set.
     if exists('g:neomake_php_phpcs_args_standard')


### PR DESCRIPTION
particularly when no errors found, phpcs would output it's progress unnecessary polluting location list