### PR TITLE
[wip] nix: add maker that runs buildPhase

### DIFF
--- a/autoload/neomake/makers/nix-shell-maker.sh
+++ b/autoload/neomake/makers/nix-shell-maker.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+if [ -z $IN_NIX_SHELL ];
+then
+	echo "you are not in a nix-shell"
+	exit 1
+fi
+
+
+echo $stdenv
+source $stdenv/setup
+
+# doesn't seem effective in the context of quickfix
+# if there is a subfolder called "build", most likely we should run it from there
+# if [ -d "build" ]; then
+# 	echo "there is a build/ folder"
+# 	cd build
+# fi
+
+# to get gcc messages in English
+export LANG=C
+
+if [ -z "$buildPhase" ]; then
+	echo "build from function"
+	echo "CWD: $PWD"
+	buildPhase
+else
+	$buildPhase
+fi

--- a/autoload/neomake/makers/nix.vim
+++ b/autoload/neomake/makers/nix.vim
@@ -1,0 +1,26 @@
+" vim: ts=4 sw=4 et
+
+function! Check_build_folder(opts, ) abort dict
+
+  " todo check for nix-shell
+  if isdirectory("build")
+    let self.cwd = getcwd().'/build'
+  endif
+
+  if !exists("$IN_NIX_SHELL")
+    echom "You are not in a nix-shell" 
+  endif
+
+  return self
+endfunction
+
+function! neomake#makers#nix#nix() abort
+    \ 'exe': expand("%:p:h").'/nix-shell-maker.sh',
+    \ 'args': [],
+    \ 'errorformat': '%f:%l:%c: %m',
+    \ 'remove_invalid_entries': 0,
+    \ 'buffer_output': 0,
+    \ 'InitForJob': function('Check_build_folder')
+    \ }
+endfunc
+

--- a/autoload/neomake/makers/nix.vim
+++ b/autoload/neomake/makers/nix.vim
@@ -23,4 +23,3 @@ function! neomake#makers#nix#nix() abort
     \ 'InitForJob': function('Check_build_folder')
     \ }
 endfunc
-

--- a/autoload/neomake/makers/nix.vim
+++ b/autoload/neomake/makers/nix.vim
@@ -1,25 +1,27 @@
-" vim: ts=4 sw=4 et
+let s:current_file = expand('<sfile>:p:h')
 
 function! Check_build_folder(opts, ) abort dict
-
   " todo check for nix-shell
-  if isdirectory("build")
+  if isdirectory('build')
     let self.cwd = getcwd().'/build'
   endif
 
-  if !exists("$IN_NIX_SHELL")
-    echom "You are not in a nix-shell" 
+  if !exists('$IN_NIX_SHELL')
+    echom 'You are not in a nix-shell.'
   endif
 
   return self
 endfunction
 
 function! neomake#makers#nix#nix() abort
-    \ 'exe': expand("%:p:h").'/nix-shell-maker.sh',
+    return {
+    \ 'exe': s:current_file.'/scripts/nix-shell-maker.sh',
     \ 'args': [],
     \ 'errorformat': '%f:%l:%c: %m',
     \ 'remove_invalid_entries': 0,
     \ 'buffer_output': 0,
     \ 'InitForJob': function('Check_build_folder')
     \ }
-endfunc
+endfunction
+
+" vim: ts=4 sw=4 et

--- a/autoload/neomake/makers/scripts/nix-shell-maker.sh
+++ b/autoload/neomake/makers/scripts/nix-shell-maker.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 if [ -z $IN_NIX_SHELL ];
 then
-	echo "you are not in a nix-shell"
+	echo "you are not in a nix-shell" >&2
 	exit 1
 fi
 


### PR DESCRIPTION
... or eval "$buildPhase".

The user is supposed to have run the previous steps
configurePhase/patchPhase beforehand.

The maker checks for a 'build' folder to adjust the current folder so that one
can click the quickfix errors and jump to the error.

I could not test it as I am not sure how to run the maker though :s `Neomake! nix` seems useless.
