### PR TITLE
process_output/mapexpr: use job's cwd

### DIFF
--- a/doc/neomake.txt
+++ b/doc/neomake.txt
@@ -319,8 +319,8 @@ The following variables are available in the `mapexpr`:
  - `neomake_output_source`: either "stderr" or "stdout", depending on
    where the output is coming from. This will be "stdout" always for
    non-async Vim.
- - `neomake_bufname` and `neomake_bufdir`: the buffer's name (|bufname()|) and
-   directory, respectively.
+ - `neomake_bufname` and `neomake_bufdir`: the buffer's absolute path
+   (|bufname()|) and directory, respectively.
 
 The `mapexpr` itself gets evaluated in the context of the affected buffer in
 file mode, and in the context of the buffer that is current when the maker

--- a/tests/cwd.vader
+++ b/tests/cwd.vader
@@ -324,8 +324,23 @@ Execute (process_output: filename with cwd):
   \ 'type': 'E',
   \ 'pattern': '',
   \ 'text': 'error message'}]
-
   bwipe
+
+Execute (process_output: gets executed in maker cwd):
+  let s:called = 0
+  let s:cwd = tempname()
+  call mkdir(s:cwd)
+
+  let maker = copy(g:error_maker)
+  let maker.cwd = s:cwd
+  function! maker.process_output(context)
+    let s:called = 1
+    AssertEqual getcwd(), s:cwd
+    return []
+  endfunction
+
+  CallNeomake 0, [maker]
+  AssertEqual s:called, 1
 
 Execute (legacy errorformat maker: filename with cwd):
   let tempdir = tempname()

--- a/tests/mapexpr.vader
+++ b/tests/mapexpr.vader
@@ -15,12 +15,13 @@ Execute (mapexpr: file mode vars):
   let maker = neomake#utils#MakerFromCommand('echo on_stdout')
   new
   edit tests/fixtures/errors.sh
+  let bufname = expand('%:p')
+  let bufdir = fnamemodify(bufname, ':h')
   let maker.mapexpr = "printf('%s (%s): %s', neomake_bufname, neomake_bufdir, v:val)"
-  call neomake#Make(0, [maker])
-  NeomakeTestsWaitForFinishedJobs
+  CallNeomake 0, [maker]
 
   AssertEqual map(getqflist(), 'v:val.text'), [
-    \ 'tests/fixtures/errors.sh (tests/fixtures): on_stdout']
+    \ printf('%s (%s): on_stdout', bufname, bufdir)]
   bwipe
 
 Execute (mapexpr: file mode vars with cd):
@@ -33,15 +34,15 @@ Execute (mapexpr: file mode vars with cd):
     let start_cwd = getcwd()
     let maker.append_file = 0
     call neomake#Make(1, [maker])
-    cd build
+    lcd build
     NeomakeTestsWaitForFinishedJobs
-    cd -
+    lcd -
 
     AssertEqual map(getloclist(0), 'v:val.text'), [
       \ printf('[bufname:%s, bufdir:%s, cwd: %s]: %s',
           \ start_cwd.'/tests/fixtures/errors.sh',
           \ start_cwd.'/tests/fixtures',
-          \ getcwd().'/build',
+          \ start_cwd,
           \ 'on_stdout')]
     bwipe
   endif


### PR DESCRIPTION
Relevant for cargo (ref https://github.com/rust-lang/rust.vim/pull/261).