### PR TITLE
rust: cargo: use workspace_root from metadata

### DIFF
--- a/autoload/neomake/jobinfo.vim
+++ b/autoload/neomake/jobinfo.vim
@@ -68,16 +68,12 @@ function! s:jobinfo_base.cd(...) abort
 
     let cur_wd = getcwd()
     if dir !=# cur_wd
-        let cd = haslocaldir() ? 'lcd' : (exists(':tcd') == 2 && haslocaldir(-1, 0)) ? 'tcd' : 'cd'
-        try
-            exe cd.' '.fnameescape(dir)
-        catch
-            " Tests fail with E344, but in reality it is E472?!
-            " If uncaught, both are shown - let's just catch everything.
-            return v:exception
-        endtry
+        let [cd_error, cd_back_cmd] = neomake#utils#temp_cd(dir, cur_wd)
+        if !empty(cd_error)
+            return cd_error
+        endif
         let self.cwd = dir
-        let self.cd_back_cmd = cd.' '.fnameescape(cur_wd)
+        let self.cd_back_cmd = cd_back_cmd
     else
         let self.cwd = cur_wd
     endif

--- a/autoload/neomake/makers/ft/rust.vim
+++ b/autoload/neomake/makers/ft/rust.vim
@@ -47,6 +47,20 @@ function! s:get_cargo_workspace_root() abort
     return b:_neomake_cargo_workspace
 endfunction
 
+function! s:get_cargo_maker_cwd(default) abort
+    let cargo_workspace_root = s:get_cargo_workspace_root()
+    if !empty(cargo_workspace_root)
+        return cargo_workspace_root
+    endif
+
+    let cargo_toml = neomake#utils#FindGlobFile('Cargo.toml')
+    if !empty(cargo_toml)
+        return fnamemodify(cargo_toml, ':h')
+    endif
+
+    return a:default
+endfunction
+
 function! neomake#makers#ft#rust#cargo() abort
     let maker_command = get(b:, 'neomake_rust_cargo_command',
                 \ get(g:, 'neomake_rust_cargo_command', ['check']))
@@ -58,17 +72,7 @@ function! neomake#makers#ft#rust#cargo() abort
 
     function! maker.InitForJob(jobinfo) abort
         if !has_key(self, 'cwd')
-            let cargo_workspace_root = s:get_cargo_workspace_root()
-            if !empty(cargo_workspace_root)
-                let self.cwd = cargo_workspace_root
-            else
-                let cargo_toml = neomake#utils#FindGlobFile('Cargo.toml')
-                if !empty(cargo_toml)
-                    let self.cwd = fnamemodify(cargo_toml, ':h')
-                else
-                    let self.cwd = '%:p:h'
-                endif
-            endif
+            let self.cwd = s:get_cargo_maker_cwd('%:p:h')
             return self
         endif
     endfunction

--- a/autoload/neomake/utils.vim
+++ b/autoload/neomake/utils.vim
@@ -578,3 +578,28 @@ else
         return len(getbufline(a:bufnr, 1, '$'))
     endfunction
 endif
+
+" Returns: [error, cd_back_cmd]
+function! neomake#utils#temp_cd(dir, ...) abort
+    if a:dir ==# '.'
+        return ['', '']
+    endif
+    if a:0
+        let cur_wd = a:1
+    else
+        let cur_wd = getcwd()
+        if cur_wd ==# a:dir
+            " No need to change directory.
+            return ['', '']
+        endif
+    endif
+    let cd = haslocaldir() ? 'lcd' : (exists(':tcd') == 2 && haslocaldir(-1, 0)) ? 'tcd' : 'cd'
+    try
+        exe cd.' '.fnameescape(a:dir)
+    catch
+        " Tests fail with E344, but in reality it is E472?!
+        " If uncaught, both are shown - let's just catch everything.
+        return [v:exception, '']
+    endtry
+    return ['', cd.' '.fnameescape(cur_wd)]
+endfunction

--- a/tests/ft_rust.vader
+++ b/tests/ft_rust.vader
@@ -96,3 +96,13 @@ Execute (rust: cargo: handles cd'ing before querying workspace_root metadata):
   let maker = maker.InitForJob(NeomakeTestsFakeJobinfo())
   AssertEqual maker.cwd, tempdir
   bwipe
+
+Execute (rust: cargo: logs error when cd'ing fails):
+  new
+  file /doesnotexist/fake.rs
+
+  let maker = neomake#makers#ft#rust#cargo()
+  let maker = maker.InitForJob(NeomakeTestsFakeJobinfo())
+  AssertNeomakeMessage '\Vs:get_cargo_workspace_root: failed to cd to buffer directory: Vim(cd):E344: ', 3
+  AssertEqual maker.cwd, '%:p:h'
+  bwipe

--- a/tests/ft_rust.vader
+++ b/tests/ft_rust.vader
@@ -54,8 +54,12 @@ Execute (cargo: uses primary span):
   bwipe
 
 Execute (rust: cargo: uses directory with Cargo.toml as cwd):
+  new
   let maker = neomake#makers#ft#rust#cargo()
+  Assert !has_key(maker, 'cwd')
+  let maker = maker.InitForJob(NeomakeTestsFakeJobinfo())
   AssertEqual maker.cwd, '%:p:h'
+  AssertNeomakeMessage "Failed to get cargo metadata for workspace using 'cargo metadata --no-deps --format-version 1'.", 3
 
   let tempdir = tempname()
   let slash = neomake#utils#Slash()
@@ -64,8 +68,31 @@ Execute (rust: cargo: uses directory with Cargo.toml as cwd):
   let cargo_toml = tempdir . slash . 'Cargo.toml'
   call writefile([], cargo_toml)
 
-  new
   exe 'lcd' subdir
   let maker = neomake#makers#ft#rust#cargo()
+  let maker = maker.InitForJob(NeomakeTestsFakeJobinfo())
+  AssertEqual maker.cwd, tempdir
+  bwipe
+
+Execute (rust: cargo: uses cargo workspace_root as cwd):
+  new
+  call g:NeomakeTestsCreateExe('cargo', [
+  \ 'echo ''{"workspace_root": "/cargo_workspace_root"}'''])
+  let maker = neomake#makers#ft#rust#cargo()
+  let maker = maker.InitForJob(NeomakeTestsFakeJobinfo())
+  AssertEqual maker.cwd, '/cargo_workspace_root'
+  bwipe
+
+Execute (rust: cargo: handles cd'ing before querying workspace_root metadata):
+  new
+  let tempdir = tempname()
+  call mkdir(tempdir)
+  exe printf('file %s/fake.rs', fnameescape(tempdir))
+
+  call g:NeomakeTestsCreateExe('cargo', [
+  \ printf('[ "$PWD" = "%s" ] && echo ''{"workspace_root": "%s"}''',
+  \ tempdir, tempdir)])
+  let maker = neomake#makers#ft#rust#cargo()
+  let maker = maker.InitForJob(NeomakeTestsFakeJobinfo())
   AssertEqual maker.cwd, tempdir
   bwipe

--- a/tests/utils.vader
+++ b/tests/utils.vader
@@ -866,3 +866,25 @@ Execute (neomake#utils#get_buf_line_count: unloaded buffer):
   bp
   bwipe
   exe unlisted_bufnr.'bwipe'
+
+Execute (neomake#utils#temp_cd):
+  let cwd = getcwd()
+  try
+    AssertEqual neomake#utils#temp_cd('.'), ['', '']
+    AssertEqual neomake#utils#temp_cd(cwd), ['', '']
+
+    " If cur_wd gets passed in the caller is responsible if cd'ing should not get done.
+    AssertEqual neomake#utils#temp_cd(cwd, cwd), ['', 'cd '.fnameescape(cwd)]
+
+    let tempdir = tempname()
+    AssertEqual neomake#utils#temp_cd(cwd, tempdir), ['', 'cd '.fnameescape(tempdir)]
+    let [cd_error, cd_back_cmd] = neomake#utils#temp_cd(tempdir, cwd)
+    Assert !empty(cd_error)
+    AssertEqual cd_back_cmd, ''
+
+    call mkdir(tempdir)
+    AssertEqual neomake#utils#temp_cd(cwd, tempdir), ['', 'cd '.fnameescape(tempdir)]
+    AssertEqual neomake#utils#temp_cd(tempdir, cwd), ['', 'cd '.fnameescape(cwd)]
+  finally
+    exe 'cd '.fnameescape(cwd)
+  endtry


### PR DESCRIPTION
Includes https://github.com/neomake/neomake/pull/2082.

/cc @dpc 