### PR TITLE
markdown: vale: fix off-by-one error with length

### DIFF
--- a/autoload/neomake/makers/ft/markdown.vim
+++ b/autoload/neomake/makers/ft/markdown.vim
@@ -44,7 +44,7 @@ function! neomake#makers#ft#markdown#ProcessVale(context) abort
             \ 'text': data.Message,
             \ 'lnum': data.Line,
             \ 'col': data.Span[0],
-            \ 'length': data.Span[1] - data.Span[0],
+            \ 'length': data.Span[1] - data.Span[0] + 1,
             \ 'type': toupper(data.Severity[0])
             \ }
         call add(entries, entry)


### PR DESCRIPTION
It appears to mark the start and end column, so 1 needs to be added.