### PR TITLE
neomake#compat#restore_prev_windows: use noautocmd

### DIFF
--- a/autoload/neomake/compat.vim
+++ b/autoload/neomake/compat.vim
@@ -278,9 +278,9 @@ if exists('*win_getid')
         elseif winnr() != pw
             let aw = win_id2win(aw_id)
             if aw
-                exec aw . 'wincmd w'
+                noautocmd exec aw . 'wincmd w'
             endif
-            exec pw . 'wincmd w'
+            noautocmd exec pw . 'wincmd w'
         endif
     endfunction
 else
@@ -297,9 +297,9 @@ else
                   \ pw, winnr('$')))
         elseif winnr() != pw
             if aw
-                exec aw . 'wincmd w'
+                noautocmd exec aw . 'wincmd w'
             endif
-            exec pw . 'wincmd w'
+            noautocmd exec pw . 'wincmd w'
         endif
     endfunction
 endif

--- a/tests/processing.vader
+++ b/tests/processing.vader
@@ -948,8 +948,6 @@ Execute (neomake#Make ignores calls during autocommands):
   AssertNeomakeMessage 'process_output_error: processing 1 lines of output.', 3
   AssertNeomakeMessage 'Handling location list: executing lwindow.', 3
   AssertNeomakeMessage 'Ignoring Make through autocommand due to s:ignore_automake_events=1.', 3, {'winnr': 3}
-  AssertNeomakeMessage 'Ignoring Make through autocommand due to s:ignore_automake_events=1.', 3, {'winnr': 1}
-  AssertNeomakeMessage 'Ignoring Make through autocommand due to s:ignore_automake_events=1.', 3, {'winnr': 2}
 
   AssertEqual len(g:neomake_test_finished), 1
   AssertEqual len(g:neomake_test_jobfinished), 1


### PR DESCRIPTION
This avoids internal action queue processing for WinEnter when a
location list window has been opened.