### PR TITLE
Fix args/append_file for various makers

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -710,7 +710,7 @@ function! s:command_maker_base._get_argv(jobinfo) abort dict
     let filename = self._get_fname_for_args(a:jobinfo)
     let args_is_list = type(self.args) == type([])
     if args_is_list
-        let args = neomake#utils#ExpandArgs(self.args)
+        let args = neomake#utils#ExpandArgs(self.args, a:jobinfo)
         if !empty(filename)
             call add(args, filename)
         endif

--- a/autoload/neomake/makers/ft/bib.vim
+++ b/autoload/neomake/makers/ft/bib.vim
@@ -9,6 +9,7 @@ function! neomake#makers#ft#bib#bibtex() abort
                 \ 'exe': 'bibtex',
                 \ 'args': ['-terse', '%:r'],
                 \ 'append_file': 0,
+                \ 'uses_filename': 0,
                 \ 'errorformat': '%E%m---line %l of file %f',
                 \ 'cwd': '%:p:h'
                 \ }

--- a/autoload/neomake/makers/ft/c.vim
+++ b/autoload/neomake/makers/ft/c.vim
@@ -30,7 +30,6 @@ endfunction
 function! neomake#makers#ft#c#clangcheck() abort
     return {
         \ 'exe': 'clang-check',
-        \ 'args': ['%:p'],
         \ 'errorformat':
             \ '%-G%f:%s:,' .
             \ '%f:%l:%c: %trror: %m,' .
@@ -72,7 +71,6 @@ endfunction
 function! neomake#makers#ft#c#clangtidy() abort
     return {
         \ 'exe': 'clang-tidy',
-        \ 'args': ['%:p'],
         \ 'errorformat':
             \ '%E%f:%l:%c: fatal error: %m,' .
             \ '%E%f:%l:%c: error: %m,' .

--- a/autoload/neomake/makers/ft/cf3.vim
+++ b/autoload/neomake/makers/ft/cf3.vim
@@ -7,8 +7,7 @@ endfunction
 function! neomake#makers#ft#cf3#cfpromises() abort
     return {
         \ 'exe': 'cf-promises',
-        \ 'args': ['-cf', '%:p'],
-        \ 'append_file': 0,
+        \ 'args': ['-cf'],
         \ 'errorformat':
             \ '%E%f:%l:%c: error: %m',
         \ }

--- a/autoload/neomake/makers/ft/javascript.vim
+++ b/autoload/neomake/makers/ft/javascript.vim
@@ -74,7 +74,7 @@ endfunction
 function! neomake#makers#ft#javascript#rjsx() abort
     return {
         \ 'exe': 'emacs',
-        \ 'args': ['%','--quick','--batch','--eval='
+        \ 'args': ['%t','--quick','--batch','--eval='
         \ .'(progn(setq package-load-list ''((js2-mode t)(rjsx-mode t)))(package-initialize)(require ''rjsx-mode)'
         \ .'  (setq js2-include-node-externs t js2-include-rhino-externs t js2-include-browser-externs t js2-strict-missing-semi-warning nil)'
         \ .'  (rjsx-mode)(js2-reparse)(js2-display-error-list)'

--- a/autoload/neomake/makers/ft/moon.vim
+++ b/autoload/neomake/makers/ft/moon.vim
@@ -4,7 +4,7 @@ endfunction
 
 function! neomake#makers#ft#moon#moonc() abort
     return {
-        \ 'args': ['-l', '%:p'],
+        \ 'args': ['-l'],
         \ 'errorformat':
             \ '%-G,' .
             \ '%-G>%#,' .

--- a/autoload/neomake/makers/ft/nix.vim
+++ b/autoload/neomake/makers/ft/nix.vim
@@ -7,7 +7,7 @@ endfunction
 function! neomake#makers#ft#nix#nix_instantiate() abort
     return {
         \ 'exe': 'nix-instantiate',
-        \ 'args': ['%:p', '--parse-only'],
+        \ 'args': ['--parse-only'],
         \ 'errorformat': 'error: %m at %f:%l:%c'
         \ }
 endfunction

--- a/autoload/neomake/makers/ft/objc.vim
+++ b/autoload/neomake/makers/ft/objc.vim
@@ -41,7 +41,6 @@ endfunction
 function! neomake#makers#ft#objc#clangcheck() abort
     return {
         \ 'exe': 'clang-check',
-        \ 'args': ['%:p'],
         \ 'errorformat':
             \ '%-G%f:%s:,' .
             \ '%f:%l:%c: %trror: %m,' .

--- a/autoload/neomake/makers/ft/php.vim
+++ b/autoload/neomake/makers/ft/php.vim
@@ -37,7 +37,8 @@ endfunction
 
 function! neomake#makers#ft#php#phpmd() abort
     return {
-        \ 'args': ['%:p', 'text', 'codesize,design,unusedcode,naming'],
+        \ 'args': ['%t', 'text', 'codesize,design,unusedcode,naming'],
+        \ 'append_file': 0,
         \ 'errorformat': '%W%f:%l%\s%\s%#%m'
         \ }
 endfunction

--- a/autoload/neomake/makers/ft/r.vim
+++ b/autoload/neomake/makers/ft/r.vim
@@ -7,7 +7,8 @@ endfunction
 function! neomake#makers#ft#r#lintr() abort
     return {
         \ 'exe': 'R',
-        \ 'args': ['-e lintr::lint("%:p")'],
+        \ 'args': ['-e lintr::lint("%t")'],
+        \ 'append_file': 0,
         \ 'errorformat':
         \   '%W%f:%l:%c: style: %m,' .
         \   '%W%f:%l:%c: warning: %m,' .

--- a/autoload/neomake/makers/ft/rust.vim
+++ b/autoload/neomake/makers/ft/rust.vim
@@ -67,6 +67,7 @@ function! neomake#makers#ft#rust#cargotest() abort
         \ 'exe': 'cargo',
         \ 'args': ['test', '%:t:r', '--quiet'],
         \ 'append_file': 0,
+        \ 'uses_filename': 0,
         \ 'postprocess': copy(g:neomake#postprocess#remove_duplicates),
         \ 'errorformat':
             \ '%-G,' .

--- a/doc/neomake.txt
+++ b/doc/neomake.txt
@@ -235,28 +235,20 @@ name: >
 <
                                                            *neomake-args-file*
 When running a maker on a file with |:Neomake|, you may want to control where
-in the `args` list the file's path will appear. To do this, insert '%:p' in
-the `args` list:  >
+in the `args` list the file's path will appear. To do this, insert '%t' in
+the `args` list and use `append_file=0`:  >
     let g:neomake_c_lint_maker = {
         \ 'exe': 'lint',
-        \ 'args': ['%:p', '--option', 'x'],
+        \ 'args': ['%t', '--option', 'x'],
+        \ 'append_file': 0,
         \ 'errorformat': '%f:%l:%c: %m',
         \ }
 <
 This will cause "lint /path/to/file.c --option x" to be run instead of
 "lint --option x /path/to/file.c".
 
-The file path can be excluded from the argument list entirely by setting the
-'append_file' argument to 0. >
-    let g:neomake_c_lint_maker = {
-        \ 'exe': 'lint',
-        \ 'args': ['--option', 'x'],
-        \ 'append_file': 0,
-        \ 'errorformat': '%f:%l:%c: %m',
-        \ }
-<
-This can be useful for makers that are filetype dependent but are typically
-run on an whole project rather than a specific file.
+`%t` gets replaced with the absolute path to the file (handling any temporary
+file).
 
                                                    *neomake-makers-processing*
 A job maker's output gets processed in two ways:

--- a/tests/tempfiles.vader
+++ b/tests/tempfiles.vader
@@ -603,17 +603,19 @@ Execute (Expands % in cwd according to actual file):
   AssertEqual map(getloclist(0), 'v:val.text'), [tmpdir]
   bwipe!
 
-Execute (Expands % in args according to actual file (list)):
+Execute (Expands % in args according to actual file, and replaces %t with tempfile (list)):
   let tmpdir = tempname()
   call mkdir(tmpdir, 'p', 0550)
   new
   exe 'file '.tmpdir.'/file'
   let b:neomake_tempfile_enabled = 1
   norm! iline1
-  let maker = {'exe': 'printf', 'args': ['%s', '%:h'], 'uses_filename': 1, 'append_file': 0}
+  let maker = {'exe': 'printf', 'args': ['%s\n', '%:h', '%t'], 'uses_filename': 1, 'append_file': 0}
   CallNeomake 1, [maker]
   AssertNeomakeMessage 'Using temporary directory for non-writable parent directory.', 3
-  AssertEqual map(getloclist(0), 'v:val.text'), [tmpdir]
+  AssertNeomakeMessage '\v^Using tempfile for modified buffer: "(.*)"', 3
+  let tempfile_name = g:neomake_test_matchlist[1]
+  AssertEqual map(getloclist(0), 'v:val.text'), [tmpdir, tempfile_name]
   bwipe!
 
 Execute (Does not expand % in args as string):

--- a/tests/utils.vader
+++ b/tests/utils.vader
@@ -337,7 +337,8 @@ Execute (neomake#utils#ExpandArgs):
   \ 'file1.ext:,',
   \ ]
 
-  AssertEqual expected_args, neomake#utils#ExpandArgs(args)
+  let jobinfo = {'bufnr': bufnr('%')}
+  AssertEqual expected_args, neomake#utils#ExpandArgs(args, jobinfo)
   AssertEqual isk, &iskeyword
   bwipe
 
@@ -347,9 +348,24 @@ Execute (neomake#utils#ExpandArgs: :S):
   else
     new
     file file1.ext
-    AssertEqual neomake#utils#ExpandArgs(['%:S']), ["'file1.ext'"]
+    let jobinfo = {'bufnr': bufnr('%')}
+    AssertEqual neomake#utils#ExpandArgs(['%:S'], jobinfo), ["'file1.ext'"]
     bwipe
   endif
+
+Execute (neomake#utils#ExpandArgs: %t for temporary file):
+  new
+  let jobinfo = {'bufnr': bufnr('%')}
+  AssertEqual neomake#utils#ExpandArgs(['%t'], jobinfo), ['']
+
+  file fname.ext
+  AssertEqual neomake#utils#ExpandArgs(['%t'], jobinfo), [fnamemodify('fname.ext', ':p')]
+
+  let jobinfo.tempfile = '/some/temp.file'
+  AssertEqual neomake#utils#ExpandArgs(['%t'], jobinfo), ['/some/temp.file']
+  " Does not get fnamemodified.
+  AssertEqual neomake#utils#ExpandArgs(['%t:h'], jobinfo), ['/some/temp.file:h']
+  bwipe
 
 Execute (neomake#utils#diff_dict):
   AssertEqual neomake#utils#diff_dict({}, {}), {}


### PR DESCRIPTION
This fixes the filename being passed twice to clangtidy etc, and behaves
as documented now.