### PR TITLE
c: cppcheck: use custom template for columns

### DIFF
--- a/autoload/neomake/makers/ft/c.vim
+++ b/autoload/neomake/makers/ft/c.vim
@@ -92,10 +92,16 @@ function! neomake#makers#ft#c#checkpatch() abort
 endfunction
 
 function! neomake#makers#ft#c#cppcheck() abort
+    " Uses --force to avoid:
+    " nofile:0:0:information:Too many #ifdef configurations - cppcheck only checks 12 configurations.
     return {
-        \ 'args': '--quiet --language=c --enable=warning',
+        \ 'args': '--quiet --language=c --enable=warning --force --template="{file}:{line}:{column}:{severity}:{message}"',
         \ 'errorformat':
-            \ '[%f:%l]: (%trror) %m,' .
-            \ '[%f:%l]: (%tarning) %m',
+            \ 'nofile:0:0:%trror:%m,' .
+            \ '%f:%l:%c:%trror:%m,' .
+            \ 'nofile:0:0:%tarning:%m,'.
+            \ '%f:%l:%c:%tarning:%m,'.
+            \ 'nofile:0:0:%tnformation:%m,'.
+            \ '%f:%l:%c:%tnformation:%m',
         \ }
 endfunction

--- a/autoload/neomake/makers/ft/c.vim
+++ b/autoload/neomake/makers/ft/c.vim
@@ -94,8 +94,11 @@ endfunction
 function! neomake#makers#ft#c#cppcheck() abort
     " Uses --force to avoid:
     " nofile:0:0:information:Too many #ifdef configurations - cppcheck only checks 12 configurations.
+    " NOTE: '--language=c' should be the first args, it gets replaced in
+    "       neomake#makers#ft#cpp#cppcheck.
     return {
-        \ 'args': '--quiet --language=c --enable=warning --force --template="{file}:{line}:{column}:{severity}:{message}"',
+        \ 'args': ['--language=c', '--quiet', '--enable=warning', '--force',
+        \          '--template="{file}:{line}:{column}:{severity}:{message}"'],
         \ 'errorformat':
             \ 'nofile:0:0:%trror:%m,' .
             \ '%f:%l:%c:%trror:%m,' .

--- a/autoload/neomake/makers/ft/cpp.vim
+++ b/autoload/neomake/makers/ft/cpp.vim
@@ -29,12 +29,9 @@ function! neomake#makers#ft#cpp#clangcheck() abort
 endfunction
 
 function! neomake#makers#ft#cpp#cppcheck() abort
-    return {
-        \ 'args': '--quiet --language=c++ --enable=warning',
-        \ 'errorformat':
-            \ '[%f:%l]: (%trror) %m,' .
-            \ '[%f:%l]: (%tarning) %m',
-        \ }
+    let maker = neomake#makers#ft#c#cppcheck()
+    let maker.args[0] = '--language=c++'
+    return maker
 endfunction
 
 function! neomake#makers#ft#cpp#cpplint() abort


### PR DESCRIPTION
@miedzinski 
Does this make sense?

I also wonder if `cppcheck` adds anything over `clang-check` (if both are available)?
I've noticed that it is more picky when using e.g. `%d` for unsigned ints in `printf`.

I plan to only enable `clang-check` (fast) by default, if there is a compilation database (`compile_commands.json`), and then `cppcheck` would not be enabled by default.

TODO:

- [ ] there is also `neomake#makers#ft#cpp#cppcheck`