### PR TITLE
skip_job: require msg/reason

### DIFF
--- a/tests/errors.vader
+++ b/tests/errors.vader
@@ -8,7 +8,7 @@ Execute (Error with no filename):
 
   Neomake
   let make_id = neomake#GetStatus().last_make_id
-  AssertNeomakeMessage 'no file name.', 0, {'make_id': make_id}
+  AssertNeomakeMessage 'no file name.', 0
   bwipe
 
 Execute (Error with non-existing filename):
@@ -22,7 +22,7 @@ Execute (Error with non-existing filename):
   Neomake
   bwipe!
   let make_id = neomake#GetStatus().last_make_id
-  AssertNeomakeMessage 'file is not readable ('.fname.')', 0, {'make_id': make_id}
+  AssertNeomakeMessage 'file is not readable ('.fname.')', 0
 
 Execute (Error with non-existing filename for 2nd maker):
   call g:NeomakeSetupAutocmdWrappers()
@@ -48,7 +48,7 @@ Execute (Error with non-existing filename for 2nd maker):
   call neomake#Make(1, [maker1, maker2, maker3])
   let make_id = neomake#GetStatus().last_make_id
   NeomakeTestsWaitForFinishedJobs
-  AssertNeomakeMessage 'file is not readable ('.fname.')', 0, {'make_id': make_id}
+  AssertNeomakeMessage 'file is not readable ('.fname.')', 0
   AssertEqual len(g:neomake_test_finished), 1
   AssertEqual len(g:neomake_test_jobfinished), 2
   bwipe!

--- a/tests/tempfiles.vader
+++ b/tests/tempfiles.vader
@@ -278,10 +278,9 @@ Execute (_get_fname_for_buffer handles modified buffer with disabled tempfiles):
     call maker._get_fname_for_buffer(jobinfo)
   catch
     let caught = 1
-    AssertEqual v:exception, 'Neomake: skip_job'
+    AssertEqual v:exception, 'Neomake: skip_job: buffer is modified, but temporary files are disabled.'
   endtry
   AssertEqual caught, 1
-  AssertNeomakeMessage 'buffer is modified, but temporary files are disabled, skipping job.', 3
   bwipe!
 
 Execute (_get_fname_for_buffer does not add trailing newline):
@@ -664,5 +663,5 @@ Execute (Filemode maker with tempfile_enabled=0 gets not run on modified buffer)
   AssertEqual len(g:neomake_test_finished), 1
   AssertEqual len(g:neomake_test_jobfinished), 1
 
-  AssertNeomakeMessage 'buffer is modified, but temporary files are disabled, skipping job.', 3
+  AssertNeomakeMessage 'Skipping job: buffer is modified, but temporary files are disabled.', 3
   bwipe!


### PR DESCRIPTION
Also improves log context (adding job info) for generic Neomake errors.