### PR TITLE
php: change phpstan's --errorFormat to --error-format

### DIFF
--- a/autoload/neomake/makers/ft/php.vim
+++ b/autoload/neomake/makers/ft/php.vim
@@ -46,7 +46,7 @@ endfunction
 function! neomake#makers#ft#php#phpstan() abort
     " PHPStan normally considers 0 to be the default level, so that is used here as the default:
     let maker = {
-        \ 'args': ['analyse', '--errorFormat', 'raw', '--no-progress', '--level', get(g:, 'neomake_phpstan_level', 0)],
+        \ 'args': ['analyse', '--error-format', 'raw', '--no-progress', '--level', get(g:, 'neomake_phpstan_level', 0)],
         \ 'errorformat': '%E%f:%l:%m',
         \ }
     " Check for the existence of a default PHPStan project configuration file.


### PR DESCRIPTION
The latest version of phpstan has marked the --errorFormat parameter as deprecated and recommend --error-format instead.