### PR TITLE
[proto.prototool] Add proto maker

### DIFF
--- a/autoload/neomake/makers/ft/proto.vim
+++ b/autoload/neomake/makers/ft/proto.vim
@@ -1,0 +1,11 @@
+function! neomake#makers#ft#proto#EnabledMakers() abort
+    return ['prototool']
+endfunction
+
+function! neomake#makers#ft#proto#prototool() abort
+    return {
+                \ 'exe': 'prototool',
+                \ 'args': ['lint'],
+                \ 'errorformat': '%f:%l:%c:%m',
+                \ }
+endfunction


### PR DESCRIPTION
This adds a Protocol Buffers (*.proto) maker and introduces Uber's prototool as the default maker.