### PR TITLE
markdown: do not enable writegood by default

### DIFF
--- a/autoload/neomake/makers/ft/markdown.vim
+++ b/autoload/neomake/makers/ft/markdown.vim
@@ -5,7 +5,7 @@ endfunction
 function! neomake#makers#ft#markdown#EnabledMakers() abort
     let makers = executable('mdl') ? ['mdl'] : ['markdownlint']
     if executable('vale') | let makers += ['vale'] | endif
-    return makers + ['writegood'] + neomake#makers#ft#text#EnabledMakers()
+    return makers + neomake#makers#ft#text#EnabledMakers()
 endfunction
 
 function! neomake#makers#ft#markdown#mdl() abort


### PR DESCRIPTION
It is distracting, e.g. with '"only" can weaken meaning'.