### PR TITLE
Do not trigger "No matching autocommands" messages

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -1227,11 +1227,13 @@ function! s:AddExprCallback(jobinfo, lines) abort
     let &errorformat = maker.errorformat
     try
         if file_mode
-            noautocmd laddexpr a:lines
-            let a:jobinfo._delayed_qf_autocmd = 'laddexpr'
+            let cmd = 'laddexpr'
         else
-            noautocmd caddexpr a:lines
-            let a:jobinfo._delayed_qf_autocmd = 'caddexpr'
+            let cmd = 'caddexpr'
+        endif
+        exe 'noautocmd '.cmd.' a:lines'
+        if exists('#QuickfixCmdPost')
+            let a:jobinfo._delayed_qf_autocmd = 'QuickfixCmdPost '.cmd
         endif
     finally
         let &errorformat = olderrformat
@@ -1914,7 +1916,7 @@ function! s:ProcessEntries(jobinfo, entries, ...) abort
     endif
 
     if has_key(a:jobinfo, '_delayed_qf_autocmd')
-        call neomake#compat#doautocmd('QuickfixCmdPost '.a:jobinfo._delayed_qf_autocmd)
+        call neomake#compat#doautocmd(a:jobinfo._delayed_qf_autocmd)
         unlet a:jobinfo._delayed_qf_autocmd
     endif
 

--- a/tests/cmd_neomakeinfo.vader
+++ b/tests/cmd_neomakeinfo.vader
@@ -136,7 +136,6 @@ Execute (NeomakeInfo! copies to clipboard):
     let idx = i
   endfor
 
-  let messages_lines = split(neomake#utils#redir('messages'), "\n")
   AssertEqual NeomakeTestsGetVimMessages(), [
   \ 'Copied Neomake info to clipboard ("+).']
 

--- a/tests/lists.vader
+++ b/tests/lists.vader
@@ -246,6 +246,7 @@ Execute (Goes back to original window after opening list (wincmd in postprocess)
     AssertNeomakeMessage 'action queue: processed 2 items.'
 
     Assert !exists('#neomake_event_queue#WinEnter'), 'autocmd was deleted'
+    AssertEqual s:called, 1
 
     wincmd p
     AssertEqual 1, winnr()
@@ -309,6 +310,7 @@ Execute (Goes back to original window after opening list (wincmd in process_outp
     AssertNeomakeMessage 'action queue: processed 2 items.'
 
     Assert !exists('#neomake_event_queue#WinEnter'), 'autocmd was deleted'
+    AssertEqual s:called, 0, "s:AddExprCallback is not called"
 
     wincmd p
     AssertEqual 1, winnr()
@@ -379,6 +381,7 @@ Execute (Goes back to original window after opening list (mapexpr)):
     AssertNeomakeMessage 'action queue: processed 2 items.'
 
     Assert !exists('#neomake_event_queue#WinEnter'), 'autocmd was deleted'
+    AssertEqual s:called, 1
 
     wincmd p
     AssertEqual 1, winnr()
@@ -631,3 +634,14 @@ Execute (Handles :lwindow closing the list window):
     AssertNeomakeMessage 'list window has been closed (old count: 3, new count: 2).', 3
     bwipe
   endif
+
+Execute (Quiet with no QuickfixCmdPost autocommands):
+  new
+  Assert !exists('#QuickfixCmdPost')
+  call NeomakeTestsSetVimMessagesMarker()
+
+  CallNeomake 1, [g:error_maker]
+  Assert len(getloclist(0))
+
+  AssertEqual NeomakeTestsGetVimMessages(), []
+  bwipe


### PR DESCRIPTION
Check if any `QuickfixCmdPost` autocommand exists before triggering it
delayed.