### PR TITLE
Improve / factor out (quickfix/location) list processing

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -1354,11 +1354,13 @@ function! s:do_clean_make_info(make_info) abort
 
     " Remove make_id from its window.
     let [t, w] = neomake#core#get_tabwin_for_makeid(make_id)
-    let make_ids = neomake#compat#gettabwinvar(t, w, 'neomake_make_ids', [])
-    let idx = index(make_ids, make_id)
-    if idx != -1
-        call remove(make_ids, idx)
-        call settabwinvar(t, w, 'neomake_make_ids', make_ids)
+    if [t, w] != [-1, -1]
+        let make_ids = neomake#compat#gettabwinvar(t, w, 'neomake_make_ids', [])
+        let idx = index(make_ids, make_id)
+        if idx != -1
+            call remove(make_ids, idx)
+            call settabwinvar(t, w, 'neomake_make_ids', make_ids)
+        endif
     endif
 
     " Clean up temporary files and buffers.

--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -1099,6 +1099,7 @@ function! s:Make(options) abort
                 \ 'options': options,
                 \ }
     let make_info = s:make_info[make_id]
+    let make_info.entries_list = neomake#list#ListForMake(make_info)
     if &verbose
         let make_info.verbosity += &verbose
         call neomake#log#debug(printf(
@@ -1214,9 +1215,6 @@ function! s:AddExprCallback(jobinfo, lines) abort
                     \ [a:jobinfo, a:lines] + a:000])
     endif
 
-    let maker = a:jobinfo.maker
-    let file_mode = a:jobinfo.file_mode
-
     " Create location/quickfix list and add lines to it.
     let cd_error = a:jobinfo.cd()
     if !empty(cd_error)
@@ -1225,191 +1223,11 @@ function! s:AddExprCallback(jobinfo, lines) abort
                     \ a:jobinfo.cd_from_setting, cd_error), a:jobinfo)
     endif
 
-    let prev_list = s:create_locqf_list(a:jobinfo)
+    let make_list = s:make_info[a:jobinfo.make_id].entries_list
+    let prev_list = copy(make_list.entries)
 
-    let olderrformat = &errorformat
-    let &errorformat = maker.errorformat
-    try
-        if file_mode
-            let cmd = 'laddexpr'
-        else
-            let cmd = 'caddexpr'
-        endif
-        exe 'noautocmd '.cmd.' a:lines'
-        let a:jobinfo._delayed_qf_autocmd = 'QuickfixCmdPost '.cmd
-    finally
-        let &errorformat = olderrformat
-        call a:jobinfo.cd_back()
-    endtry
-
-    let list = file_mode ? getloclist(0) : getqflist()
-    let prev_index = len(prev_list)
-    let index = prev_index-1
-    let Postprocess = neomake#utils#GetSetting('postprocess', maker, [], a:jobinfo.ft, a:jobinfo.bufnr)
-    if type(Postprocess) != type([])
-        let postprocessors = [Postprocess]
-    else
-        let postprocessors = Postprocess
-    endif
-    let debug = neomake#utils#get_verbosity(a:jobinfo) >= 3 || !empty(get(g:, 'neomake_logfile'))
-    let maker_name = maker.name
-    let make_info = s:make_info[a:jobinfo.make_id]
-    let default_type = 'unset'
-
-    let entries = []
-    let changed_entries = {}
-    let removed_entries = []
-    let different_bufnrs = {}
-    let llen = len(list)
-    let bufnr_from_temp = {}
-    let bufnr_from_stdin = {}
-    let tempfile_bufnrs = has_key(make_info, 'tempfiles') ? map(copy(make_info.tempfiles), 'bufnr(v:val)') : []
-    let uses_stdin = get(a:jobinfo, 'uses_stdin', 0)
-    while index < llen - 1
-        let index += 1
-        let entry = list[index]
-        let entry.maker_name = maker_name
-
-        let before = copy(entry)
-        " Handle unlisted buffers via tempfiles and uses_stdin.
-        if file_mode && entry.bufnr && entry.bufnr != a:jobinfo.bufnr
-                    \ && (!empty(tempfile_bufnrs) || uses_stdin)
-            let map_bufnr = index(tempfile_bufnrs, entry.bufnr)
-            if map_bufnr != -1
-                let entry.bufnr = a:jobinfo.bufnr
-                let map_bufnr = tempfile_bufnrs[map_bufnr]
-                if !has_key(bufnr_from_temp, map_bufnr)
-                    let bufnr_from_temp[map_bufnr] = []
-                endif
-                let bufnr_from_temp[map_bufnr] += [index+1]
-            elseif uses_stdin
-                if !buflisted(entry.bufnr) && bufexists(entry.bufnr)
-                    if !has_key(bufnr_from_stdin, entry.bufnr)
-                        let bufnr_from_stdin[entry.bufnr] = []
-                    endif
-                    let bufnr_from_stdin[entry.bufnr] += [index+1]
-                    let entry.bufnr = a:jobinfo.bufnr
-                endif
-            endif
-        endif
-        if debug && entry.bufnr && entry.bufnr != a:jobinfo.bufnr
-            if !has_key(different_bufnrs, entry.bufnr)
-                let different_bufnrs[entry.bufnr] = 1
-            else
-                let different_bufnrs[entry.bufnr] += 1
-            endif
-        endif
-        if !empty(postprocessors)
-            let g:neomake_postprocess_context = {'jobinfo': a:jobinfo}
-            try
-                for F in postprocessors
-                    if type(F) == type({})
-                        call call(F.fn, [entry], F)
-                    else
-                        call call(F, [entry], maker)
-                    endif
-                    unlet! F  " vim73
-                endfor
-            finally
-                unlet! g:neomake_postprocess_context  " Might be unset already with sleep in postprocess.
-            endtry
-        endif
-        if entry != before
-            let changed_entries[index] = entry
-            if debug
-                call neomake#log#debug(printf(
-                  \ 'Modified list entry %d (postprocess): %s.',
-                  \ index + 1,
-                  \ string(neomake#utils#diff_dict(before, entry))),
-                  \ a:jobinfo)
-            endif
-        endif
-
-        if entry.valid <= 0
-            if entry.valid < 0 || maker.remove_invalid_entries
-                call insert(removed_entries, index)
-                let entry_copy = copy(entry)
-                call neomake#log#debug(printf(
-                            \ 'Removing invalid entry: %s (%s).',
-                            \ remove(entry_copy, 'text'),
-                            \ string(entry_copy)), a:jobinfo)
-                continue
-            endif
-        endif
-
-        if empty(entry.type) && entry.valid
-            if default_type ==# 'unset'
-                let default_type = neomake#utils#GetSetting('default_entry_type', maker, 'W', a:jobinfo.ft, a:jobinfo.bufnr)
-            endif
-            if !empty(default_type)
-                let entry.type = default_type
-                let changed_entries[index] = entry
-            endif
-        endif
-        call add(entries, entry)
-    endwhile
-
-    " Add marker for custom quickfix to the first (new) entry.
-    if neomake#quickfix#is_enabled() && !empty(entries)
-        let config = {
-                    \ 'name': maker_name,
-                    \ 'short': get(a:jobinfo.maker, 'short_name', maker_name[:3]),
-                    \ }
-        let marker_entry = copy(entries[0])
-        let marker_entry.text .= printf(' nmcfg:%s', string(config))
-        let changed_entries[prev_index] = marker_entry
-    endif
-
-    if !empty(changed_entries) || !empty(removed_entries)
-        let list = file_mode ? getloclist(0) : getqflist()
-        if !empty(changed_entries)
-            for k in keys(changed_entries)
-                let list[k] = changed_entries[k]
-            endfor
-        endif
-        if !empty(removed_entries)
-            for k in removed_entries
-                call remove(list, k)
-            endfor
-        endif
-        if file_mode
-            call setloclist(0, list, 'r')
-        else
-            call setqflist(list, 'r')
-        endif
-    endif
-
-    if !empty(bufnr_from_temp) || !empty(bufnr_from_stdin)
-        if !has_key(make_info, '_wipe_unlisted_buffers')
-            let make_info._wipe_unlisted_buffers = []
-        endif
-        let make_info._wipe_unlisted_buffers += keys(bufnr_from_stdin) + keys(bufnr_from_stdin)
-        if !empty(bufnr_from_temp)
-            for [tempbuf, entries_idx] in items(bufnr_from_temp)
-                call neomake#log#debug(printf(
-                            \ 'Used bufnr from temporary buffer %d (%s) for %d entries: %s.',
-                            \ tempbuf,
-                            \ bufname(+tempbuf),
-                            \ len(entries_idx),
-                            \ join(entries_idx, ', ')), a:jobinfo)
-            endfor
-        endif
-        if !empty(bufnr_from_stdin)
-            for [tempbuf, entries_idx] in items(bufnr_from_stdin)
-                call neomake#log#debug(printf(
-                            \ 'Used bufnr from stdin buffer %d (%s) for %d entries: %s.',
-                            \ tempbuf,
-                            \ bufname(+tempbuf),
-                            \ len(entries_idx),
-                            \ join(entries_idx, ', ')), a:jobinfo)
-            endfor
-        endif
-    endif
-    if !empty(different_bufnrs)
-        call neomake#log#debug(printf('WARN: seen entries with bufnr different from jobinfo.bufnr (%d): %s, current bufnr: %d.', a:jobinfo.bufnr, string(different_bufnrs), bufnr('%')))
-    endif
-
-    return s:ProcessEntries(a:jobinfo, entries, prev_list)
+    let added_entries = make_list.add_lines_with_efm(a:lines, a:jobinfo)
+    return s:ProcessEntries(a:jobinfo, added_entries, prev_list)
 endfunction
 
 function! s:CleanJobinfo(jobinfo, ...) abort
@@ -1591,7 +1409,7 @@ endfunction
 
 function! s:handle_locqf_list_for_finished_jobs(make_info) abort
     let file_mode = a:make_info.options.file_mode
-    let create_list = !get(a:make_info, 'created_locqf_list', 0)
+    let create_list = a:make_info.entries_list.need_init
 
     let open_val = get(g:, 'neomake_open_list', 0)
     let height = open_val ? get(g:, 'neomake_list_height', 10) : 0
@@ -1672,26 +1490,6 @@ function! neomake#VimLeave() abort
     endfor
 endfunction
 
-" Create a location/quickfix list once per make run.
-" Returns the current list (empty if it was created).
-function! s:create_locqf_list(jobinfo) abort
-    let make_info = s:make_info[a:jobinfo.make_id]
-    if get(make_info, 'created_locqf_list', 0)
-        return a:jobinfo.file_mode ? getloclist(0) : getqflist()
-    endif
-    let make_info.created_locqf_list = 1
-
-    let file_mode = make_info.options.file_mode
-    if file_mode
-        call neomake#log#debug('Creating location list.', a:jobinfo)
-        call setloclist(0, [])
-    else
-        call neomake#log#debug('Creating quickfix list.', a:jobinfo)
-        call setqflist([])
-    endif
-    return []
-endfunction
-
 function! s:clean_for_new_make(make_info) abort
     if get(a:make_info, 'cleaned_for_make', 0)
         return
@@ -1742,15 +1540,6 @@ function! s:pcall(fn, args) abort
     return g:neomake#action_queue#not_processed
 endfunction
 
-" Do we need to replace (instead of append) the location/quickfix list, for
-" :lwindow to not open it with only invalid entries?!
-" Without patch-7.4.379 this does not work though, and a new list needs to
-" be created (which is not done).
-" @vimlint(EVL108, 1)
-let s:needs_to_replace_qf_for_lwindow = has('patch-7.4.379')
-            \ && (!has('patch-7.4.1752') || (has('nvim') && !has('nvim-0.2.0')))
-" @vimlint(EVL108, 0)
-
 function! s:ProcessEntries(jobinfo, entries, ...) abort
     if empty(a:entries)
         return
@@ -1767,11 +1556,13 @@ function! s:ProcessEntries(jobinfo, entries, ...) abort
     call neomake#log#debug(printf(
                 \ 'Processing %d entries.', len(a:entries)), a:jobinfo)
 
+    let make_info = s:make_info[a:jobinfo.make_id]
+    let make_list = make_info.entries_list
     let maker_name = a:jobinfo.maker.name
     if a:0 > 1
         " Via errorformat processing, where the list has been set already.
         let prev_list = a:1
-        let new_list = file_mode ? getloclist(0) : getqflist()
+        let parsed_entries = a:entries
     else
         " Fix entries with get_list_entries/process_output/process_json.
         call map(a:entries, 'extend(v:val, {'
@@ -1790,51 +1581,17 @@ function! s:ProcessEntries(jobinfo, entries, ...) abort
                         \ a:jobinfo.cd_from_setting, cd_error), a:jobinfo)
         endif
 
-        let prev_list = s:create_locqf_list(a:jobinfo)
-
+        let prev_list = file_mode ? getloclist(0) : getqflist()
         try
-            let list_entries = a:entries
-            " Add marker for custom quickfix to the first (new) entry.
-            if neomake#quickfix#is_enabled() && !empty(a:entries)
-                let config = {
-                            \ 'name': maker_name,
-                            \ 'short': get(a:jobinfo.maker, 'short_name', maker_name[:3]),
-                            \ }
-                let marker_entry = copy(a:entries[0])
-                let marker_entry.text .= printf(' nmcfg:%s', string(config))
-                let list_entries = [marker_entry] + a:entries[1:]
-            endif
-
-            if file_mode
-                if s:needs_to_replace_qf_for_lwindow
-                    call setloclist(0, prev_list + list_entries, 'r')
-                else
-                    call setloclist(0, list_entries, 'a')
-                endif
-            else
-                if s:needs_to_replace_qf_for_lwindow
-                    call setqflist(prev_list + list_entries, 'r')
-                else
-                    call setqflist(list_entries, 'a')
-                endif
+            let parsed_entries = make_list.add_entries_for_job(a:entries, a:jobinfo)
+            if exists(':Assert') && !empty(a:entries)
+                Assert get(a:entries[0], 'text', '') !~# 'nmcfg:'
             endif
         finally
             call a:jobinfo.cd_back()
         endtry
-        let new_list = file_mode ? getloclist(0) : getqflist()
-        let parsed_entries = new_list[len(prev_list):]
-        let idx = 0
-        for e in parsed_entries
-            if a:entries[idx].bufnr != e.bufnr
-                call neomake#log#debug(printf(
-                            \ 'Updating entry bufnr: %s => %s.',
-                            \ a:entries[idx].bufnr, e.bufnr))
-                let a:entries[idx].bufnr = e.bufnr
-            endif
-            let idx += 1
-        endfor
     endif
-    call s:clean_for_new_make(s:make_info[a:jobinfo.make_id])
+    call s:clean_for_new_make(make_info)
 
     let counts_changed = 0
     let maker_type = file_mode ? 'file' : 'project'
@@ -1847,7 +1604,7 @@ function! s:ProcessEntries(jobinfo, entries, ...) abort
     let skipped_without_lnum = []
 
     let idx = -1
-    for entry in a:entries
+    for entry in parsed_entries
         let idx += 1
         if !file_mode
             if neomake#statusline#AddQflistCount(entry)
@@ -1922,6 +1679,7 @@ function! s:ProcessEntries(jobinfo, entries, ...) abort
                     \ string(map(skipped_without_lnum, 'a:entries[v:val]'))), a:jobinfo)
     endif
 
+    let new_list = make_list.entries
     if !counts_changed
         let counts_changed = new_list != prev_list
     endif

--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -1535,7 +1535,7 @@ function! s:do_clean_make_info(make_info) abort
     let make_id = a:make_info.options.make_id
 
     " Remove make_id from its window.
-    let [t, w] = s:GetTabWinForMakeId(make_id)
+    let [t, w] = neomake#core#get_tabwin_for_makeid(make_id)
     let make_ids = neomake#compat#gettabwinvar(t, w, 'neomake_make_ids', [])
     let idx = index(make_ids, make_id)
     if idx != -1
@@ -2063,7 +2063,7 @@ function! s:ProcessPendingOutput(jobinfo, lines, source) abort
             if a:jobinfo.bufnr != bufnr('%')
                 call neomake#log#debug('Skipped pending job output for another buffer.', a:jobinfo)
                 return 0
-            elseif s:GetTabWinForMakeId(a:jobinfo.make_id) != [-1, -1]
+            elseif neomake#core#get_tabwin_for_makeid(a:jobinfo.make_id) != [-1, -1]
                 call neomake#log#debug('Skipped pending job output (not in origin window).', a:jobinfo)
                 return 0
             else
@@ -2101,18 +2101,6 @@ function! s:ProcessPendingOutput(jobinfo, lines, source) abort
         endif
     endif
     return 1
-endfunction
-
-" Get tabnr and winnr for a given make ID.
-function! s:GetTabWinForMakeId(make_id) abort
-    for t in [tabpagenr()] + range(1, tabpagenr()-1) + range(tabpagenr()+1, tabpagenr('$'))
-        for w in range(1, tabpagewinnr(t, '$'))
-            if index(neomake#compat#gettabwinvar(t, w, 'neomake_make_ids', []), a:make_id) != -1
-                return [t, w]
-            endif
-        endfor
-    endfor
-    return [-1, -1]
 endfunction
 
 " Do we need to postpone location list processing (creation and :laddexpr)?

--- a/autoload/neomake/compat.vim
+++ b/autoload/neomake/compat.vim
@@ -10,9 +10,15 @@ if v:version >= 704
     function! neomake#compat#getbufvar(buf, key, def) abort
         return getbufvar(a:buf, a:key, a:def)
     endfunction
+    function! neomake#compat#getwinvar(win, key, def) abort
+        return getwinvar(a:win, a:key, a:def)
+    endfunction
 else
     function! neomake#compat#getbufvar(buf, key, def) abort
         return get(getbufvar(a:buf, ''), a:key, a:def)
+    endfunction
+    function! neomake#compat#getwinvar(win, key, def) abort
+        return get(getwinvar(a:win, ''), a:key, a:def)
     endfunction
 endif
 

--- a/autoload/neomake/core.vim
+++ b/autoload/neomake/core.vim
@@ -102,3 +102,16 @@ endfunction
 function! g:neomake#core#command_maker_base._get_argv(_jobinfo) abort dict
     return neomake#compat#get_argv(self.exe, self.args, type(self.args) == type([]))
 endfunction
+
+" Get tabnr and winnr for a given make ID.
+function! neomake#core#get_tabwin_for_makeid(make_id) abort
+    let curtab = tabpagenr()
+    for t in [curtab] + range(1, curtab-1) + range(curtab+1, tabpagenr('$'))
+        for w in range(1, tabpagewinnr(t, '$'))
+            if index(neomake#compat#gettabwinvar(t, w, 'neomake_make_ids', []), a:make_id) != -1
+                return [t, w]
+            endif
+        endfor
+    endfor
+    return [-1, -1]
+endfunction

--- a/autoload/neomake/list.vim
+++ b/autoload/neomake/list.vim
@@ -1,0 +1,610 @@
+" Create a List object from a quickfix/location list.
+" TODO: (optionally?) add entries sorted?  (errors first, grouped by makers (?) etc)
+
+let s:use_efm_parsing = has('patch-8.0.1040')  " 'efm' in setqflist/getqflist
+
+function! neomake#list#ListForMake(make_info) abort
+    let type = a:make_info.options.file_mode ? 'loclist' : 'quickfix'
+    let list = neomake#list#List(type)
+    let list.make_info = a:make_info
+    if type ==# 'loclist'
+        let info = get(w:, '_neomake_info', {})
+        let info['loclist'] = list
+        let w:_neomake_info = info
+    else
+        let info = get(g:, '_neomake_info', {})
+        let info['qflist'] = list
+        let g:_neomake_info = info
+    endif
+    return list
+endfunction
+
+" a:type: "loclist" or "quickfix"
+function! neomake#list#List(type) abort
+    let list = deepcopy(s:base_list)
+    let list.type = a:type
+    if a:type ==# 'loclist'
+        if exists('*win_getid')
+            let list.winid = win_getid()
+        endif
+    endif
+    " Display debug messages about changed entries.
+    let list.debug = exists('g:neomake_test_messages')
+                \ || !empty(get(g:, 'neomake_logfile'))
+                \ || neomake#utils#get_verbosity() >= 3
+    return list
+endfunction
+
+" Internal base list implementation.
+let s:base_list = {
+            \ 'need_init': 1,
+            \ 'entries': [],
+            \ }
+
+" Do we need to replace (instead of append) the location/quickfix list, for
+" :lwindow to not open it with only invalid entries?!
+" Without patch-7.4.379 this does not work though, and a new list needs to
+" be created (which is not done).
+" @vimlint(EVL108, 1)
+let s:needs_to_replace_qf_for_lwindow = has('patch-7.4.379')
+            \ && (!has('patch-7.4.1752') || (has('nvim') && !has('nvim-0.2.0')))
+" https://github.com/vim/vim/issues/3633
+" See tests/lists.vader for patch-7.4.379.
+let s:needs_to_init_qf_for_lwindow = 1
+" @vimlint(EVL108, 0)
+
+function! s:base_list.sort_by_location() dict abort
+    let entries = get(self, '_sorted_entries_by_location', copy(self.entries))
+    let self._sorted_entries_by_location = sort(entries, 's:cmp_listitem_loc')
+    return self._sorted_entries_by_location
+endfunction
+
+" a:1: start index of entries in the location/quickfix list.
+function! s:base_list.add_entries(entries, ...) dict abort
+    let idx = a:0 ? a:1 : len(self.entries)+1
+    for entry in a:entries
+        call add(self.entries, extend(copy(entry), {'nmqfidx': idx}))
+        let idx += 1
+    endfor
+    if self.debug
+        let indexes = map(copy(self.entries), 'v:val.nmqfidx')
+        if len(neomake#compat#uniq(sort(copy(indexes)))) != len(indexes)
+            call neomake#log#error(printf('Duplicate qf indexes in list entries: %s.',
+                        \ string(indexes)))
+        endif
+    endif
+    " Sort if it was sorted before.
+    if has_key(self, '_sorted_entries_by_location')
+        call extend(self._sorted_entries_by_location, a:entries)
+        call self.sort_by_location()
+    endif
+endfunction
+
+" Add entries for a job (non-efm method).
+function! s:base_list.add_entries_for_job(entries, jobinfo) dict abort
+    return self._appendlist(a:entries, a:jobinfo)
+endfunction
+
+" Append entries to location/quickfix list.
+function! s:base_list._appendlist(entries, jobinfo) abort
+    call neomake#log#debug(printf('Adding %d list entries.', len(a:entries)))
+
+    let loclist_win = 0
+    if self.type ==# 'loclist'
+        " NOTE: prefers using 0 for when winid is not supported with
+        " setloclist() yet (vim74-xenial).
+        if index(get(w:, 'neomake_make_ids', []), a:jobinfo.make_id) == -1
+            if has_key(self, 'winid')
+                let loclist_win = self.winid
+            else
+                let [t, w] = neomake#core#get_tabwin_for_makeid(a:jobinfo.make_id)
+                if [t, w] == [-1, -1]
+                    throw printf('Neomake: could not find location list for make_id %d.', a:jobinfo.make_id)
+                endif
+                if t != tabpagenr()
+                    throw printf('Neomake: trying to use location list from another tab (current=%d != target=%d).', tabpagenr(), t)
+                endif
+                let loclist_win = w
+            endif
+        endif
+    endif
+
+    let set_entries = a:entries
+    if self.need_init
+        let action = ' '
+        let self.need_init = 0
+
+        if self.type ==# 'loclist'
+            call neomake#log#debug('Creating location list.', self.make_info)
+            if s:needs_to_init_qf_for_lwindow
+                call setloclist(0, [])
+                let action = 'a'
+            endif
+        else
+            call neomake#log#debug('Creating quickfix list.', self.make_info)
+            if s:needs_to_init_qf_for_lwindow
+                call setqflist([])
+                let action = 'a'
+            endif
+        endif
+    else
+        if s:needs_to_replace_qf_for_lwindow
+            let action = 'r'
+            if self.type ==# 'loclist'
+                let set_entries = getloclist(loclist_win) + set_entries
+            else
+                let set_entries = getqflist() + set_entries
+            endif
+        else
+            let action = 'a'
+        endif
+    endif
+
+    " Add marker for custom quickfix to the first (new) entry.
+    let needs_custom_qf_marker = neomake#quickfix#is_enabled()
+    if needs_custom_qf_marker
+        if action ==# 'a'
+            let prev_idx = 0
+        else
+            let prev_idx = len(self.entries)
+        endif
+        let maker_name = a:jobinfo.maker.name
+        let config = {
+                    \ 'name': maker_name,
+                    \ 'short': get(a:jobinfo.maker, 'short_name', maker_name[:3]),
+                    \ }
+        let set_entries = copy(set_entries)
+        let marker_entry = copy(set_entries[prev_idx])
+        let marker_entry.text .= printf(' nmcfg:%s', string(config))
+        let set_entries[prev_idx] = marker_entry
+    endif
+
+    " NOTE: need to fetch (or pre-parse with new patch) to get updated bufnr etc.
+    if self.type ==# 'loclist'
+        call setloclist(loclist_win, set_entries, action)
+        let added = getloclist(loclist_win)[len(self.entries) :]
+    else
+        call setqflist(set_entries, action)
+        let added = getqflist()[len(self.entries) :]
+    endif
+
+    if needs_custom_qf_marker
+        " Remove marker that should only be in the quickfix list.
+        let added[0].text = substitute(added[0].text, ' nmcfg:{.\{-}}$', '', '')
+    endif
+
+    if self.debug
+    if added != a:entries
+        let diff = neomake#list#_diff_new_entries(a:entries, added)
+        if !empty(diff)
+            for [k, v] in items(diff)
+                " TODO: if debug
+                " TODO: handle valid=1 being added?
+                call neomake#log#debug(printf(
+                  \ 'Entry %d differs after adding: %s.',
+                  \ k+1,
+                  \ string(v)),
+                  \ a:jobinfo)
+            endfor
+        endif
+    endif
+    endif
+
+    let parsed_entries = copy(a:entries)
+    let idx = 0
+    for e in added
+        if parsed_entries[idx].bufnr != e.bufnr
+            call neomake#log#debug(printf(
+                        \ 'Updating entry bufnr: %s => %s.',
+                        \ a:entries[idx].bufnr, e.bufnr))
+            let parsed_entries[idx].bufnr = e.bufnr
+        endif
+        let idx += 1
+    endfor
+
+    call self.add_entries(parsed_entries)
+    return parsed_entries
+endfunction
+
+function! neomake#list#_diff_new_entries(orig, new) abort
+    if a:orig == a:new
+        return {}
+    endif
+    let i = 0
+    let r = {}
+    for new in a:new
+        let orig = copy(get(a:orig, i, {}))
+        for [k, v] in items({'pattern': '', 'module': '', 'valid': 1})
+            if has_key(new, k)
+                let orig[k] = v
+            endif
+        endfor
+        if new != orig
+            " 'removed': {'length': 4, 'filename': 'from.rs',
+            " 'maker_name': 'cargo'}}
+            let new = copy(new)
+            for k in ['length', 'maker_name']
+                if has_key(orig, k)
+                    let new[k] = orig[k]
+                endif
+            endfor
+            let diff = neomake#utils#diff_dict(orig, new)
+            if !empty(diff)
+                let r[i] = diff
+            endif
+        endif
+        let i += 1
+    endfor
+    return r
+endfunction
+
+" Add raw lines using errorformat.
+" This either pre-parses them with newer versions, or uses
+" :laddexpr/:caddexpr.
+function! s:base_list.add_lines_with_efm(lines, jobinfo) dict abort
+    let maker = a:jobinfo.maker
+    let file_mode = self.type ==# 'loclist'
+    if s:use_efm_parsing
+        let efm = a:jobinfo.maker.errorformat
+        let parsed_entries = getqflist({'lines': a:lines, 'efm': efm}).items
+    else
+        if self.need_init
+            let self.need_init = 0
+            if self.type ==# 'loclist'
+                call neomake#log#debug('Creating location list.', self.make_info)
+                call setloclist(0, [])
+            else
+                call neomake#log#debug('Creating quickfix list.', self.make_info)
+                call setqflist([])
+            endif
+        endif
+
+        let olderrformat = &errorformat
+        let &errorformat = maker.errorformat
+        try
+            if file_mode
+                let cmd = 'laddexpr'
+            else
+                let cmd = 'caddexpr'
+            endif
+            exe 'noautocmd '.cmd.' a:lines'
+            let a:jobinfo._delayed_qf_autocmd = 'QuickfixCmdPost '.cmd
+        finally
+            let &errorformat = olderrformat
+            call a:jobinfo.cd_back()
+        endtry
+
+        let new_list = file_mode ? getloclist(0) : getqflist()
+        let parsed_entries = new_list[len(self.entries) :]
+    endif
+    if empty(parsed_entries)
+        return []
+    endif
+
+    let Postprocess = neomake#utils#GetSetting('postprocess', maker, [], a:jobinfo.ft, a:jobinfo.bufnr)
+    if type(Postprocess) != type([])
+        let postprocessors = [Postprocess]
+    else
+        let postprocessors = Postprocess
+    endif
+
+    let maker_name = maker.name
+    let default_type = 'unset'
+
+    let entries = []
+    let changed_entries = {}
+    let removed_entries = []
+    let different_bufnrs = {}
+    let bufnr_from_temp = {}
+    let bufnr_from_stdin = {}
+    let tempfile_bufnrs = has_key(self.make_info, 'tempfiles') ? map(copy(self.make_info.tempfiles), 'bufnr(v:val)') : []
+    let uses_stdin = get(a:jobinfo, 'uses_stdin', 0)
+
+    let entry_idx = -1
+    for entry in parsed_entries
+        let entry_idx += 1
+        let before = copy(entry)
+        " Handle unlisted buffers via tempfiles and uses_stdin.
+        if file_mode && entry.bufnr && entry.bufnr != a:jobinfo.bufnr
+                    \ && (!empty(tempfile_bufnrs) || uses_stdin)
+            let map_bufnr = index(tempfile_bufnrs, entry.bufnr)
+            if map_bufnr != -1
+                let entry.bufnr = a:jobinfo.bufnr
+                let map_bufnr = tempfile_bufnrs[map_bufnr]
+                if !has_key(bufnr_from_temp, map_bufnr)
+                    let bufnr_from_temp[map_bufnr] = []
+                endif
+                let bufnr_from_temp[map_bufnr] += [entry_idx+1]
+            elseif uses_stdin
+                if !buflisted(entry.bufnr) && bufexists(entry.bufnr)
+                    if !has_key(bufnr_from_stdin, entry.bufnr)
+                        let bufnr_from_stdin[entry.bufnr] = []
+                    endif
+                    let bufnr_from_stdin[entry.bufnr] += [entry_idx+1]
+                    let entry.bufnr = a:jobinfo.bufnr
+                endif
+            endif
+        endif
+        if self.debug && entry.bufnr && entry.bufnr != a:jobinfo.bufnr
+            if !has_key(different_bufnrs, entry.bufnr)
+                let different_bufnrs[entry.bufnr] = 1
+            else
+                let different_bufnrs[entry.bufnr] += 1
+            endif
+        endif
+        if !empty(postprocessors)
+            let g:neomake_postprocess_context = {'jobinfo': a:jobinfo}
+            try
+                for F in postprocessors
+                    if type(F) == type({})
+                        call call(F.fn, [entry], F)
+                    else
+                        call call(F, [entry], maker)
+                    endif
+                    unlet! F  " vim73
+                endfor
+            finally
+                unlet! g:neomake_postprocess_context  " Might be unset already with sleep in postprocess.
+            endtry
+        endif
+        if entry != before
+            let changed_entries[entry_idx] = entry
+            if self.debug
+                call neomake#log#debug(printf(
+                  \ 'Modified list entry %d (postprocess): %s.',
+                  \ entry_idx + 1,
+                  \ substitute(string(neomake#utils#diff_dict(before, entry)), '\n', '\\n', 'g')),
+                  \ a:jobinfo)
+            endif
+        endif
+
+        if entry.valid <= 0
+            if entry.valid < 0 || maker.remove_invalid_entries
+                call insert(removed_entries, entry_idx)
+                let entry_copy = copy(entry)
+                call neomake#log#debug(printf(
+                            \ 'Removing invalid entry: %s (%s).',
+                            \ remove(entry_copy, 'text'),
+                            \ string(entry_copy)), a:jobinfo)
+                continue
+            endif
+        endif
+
+        if empty(entry.type) && entry.valid
+            if default_type ==# 'unset'
+                let default_type = neomake#utils#GetSetting('default_entry_type', maker, 'W', a:jobinfo.ft, a:jobinfo.bufnr)
+            endif
+            if !empty(default_type)
+                let entry.type = default_type
+                let changed_entries[entry_idx] = entry
+            endif
+        endif
+        call add(entries, entry)
+    endfor
+
+    if !s:use_efm_parsing
+        let prev_index = len(self.entries)
+        " Add marker for custom quickfix to the first (new) entry.
+        if neomake#quickfix#is_enabled()
+            let config = {
+                        \ 'name': maker_name,
+                        \ 'short': get(a:jobinfo.maker, 'short_name', maker_name[:3]),
+                        \ }
+            let marker_entry = copy(entries[0])
+            let marker_entry.text .= printf(' nmcfg:%s', string(config))
+            let changed_entries[prev_index] = marker_entry
+        endif
+
+        if !empty(changed_entries) || !empty(removed_entries)
+            " Need to update/replace current list.
+            let list = file_mode ? getloclist(0) : getqflist()
+            if !empty(changed_entries)
+                for k in keys(changed_entries)
+                    let list[prev_index + k] = changed_entries[k]
+                endfor
+            endif
+            if !empty(removed_entries)
+                for k in removed_entries
+                    call remove(list, prev_index + k)
+                endfor
+            endif
+            if file_mode
+                call setloclist(0, list, 'r')
+            else
+                call setqflist(list, 'r')
+            endif
+        endif
+    endif
+
+    if !empty(bufnr_from_temp) || !empty(bufnr_from_stdin)
+        if !has_key(self.make_info, '_wipe_unlisted_buffers')
+            let self.make_info._wipe_unlisted_buffers = []
+        endif
+        let self.make_info._wipe_unlisted_buffers += keys(bufnr_from_stdin) + keys(bufnr_from_stdin)
+        if !empty(bufnr_from_temp)
+            for [tempbuf, entries_idx] in items(bufnr_from_temp)
+                call neomake#log#debug(printf(
+                            \ 'Used bufnr from temporary buffer %d (%s) for %d entries: %s.',
+                            \ tempbuf,
+                            \ bufname(+tempbuf),
+                            \ len(entries_idx),
+                            \ join(entries_idx, ', ')), a:jobinfo)
+            endfor
+        endif
+        if !empty(bufnr_from_stdin)
+            for [tempbuf, entries_idx] in items(bufnr_from_stdin)
+                call neomake#log#debug(printf(
+                            \ 'Used bufnr from stdin buffer %d (%s) for %d entries: %s.',
+                            \ tempbuf,
+                            \ bufname(+tempbuf),
+                            \ len(entries_idx),
+                            \ join(entries_idx, ', ')), a:jobinfo)
+            endfor
+        endif
+    endif
+    if !empty(different_bufnrs)
+        call neomake#log#debug(printf('WARN: seen entries with bufnr different from jobinfo.bufnr (%d): %s, current bufnr: %d.', a:jobinfo.bufnr, string(different_bufnrs), bufnr('%')))
+    endif
+
+    if empty(entries)
+        return []
+    endif
+
+    if s:use_efm_parsing
+        call self._appendlist(entries, a:jobinfo)
+    else
+        call self.add_entries(entries)
+    endif
+    return entries
+endfunction
+
+" Get the current location or quickfix list.
+function! neomake#list#get() abort
+    let winnr = winnr()
+    let win_info = getwinvar(winnr, '_neomake_info', {})
+    if has_key(win_info, 'loclist')
+        return win_info['loclist']
+    endif
+    let info = get(g:, '_neomake_info', {})
+    if has_key(info, 'qflist')
+        return info['qflist']
+    endif
+    return {}
+endfunction
+
+function! neomake#list#get_loclist(...) abort
+    let winnr = a:0 ? a:1 : winnr()
+    let info = neomake#compat#getwinvar(winnr, '_neomake_info', {})
+    if !has_key(info, 'loclist')
+        " Create a new list, not bound to a job.
+        call neomake#log#debug('Creating new List object.')
+        let list = neomake#list#List('loclist')
+        call list.add_entries(getloclist(winnr))
+        let info['loclist'] = list
+        call setwinvar(winnr, '_neomake_info', info)
+    endif
+    return info['loclist']
+endfunction
+
+" TODO: save project-maker quickfix list.
+function! neomake#list#get_qflist() abort
+    let info = get(g:, '_neomake_info', {})
+    if !has_key(info, 'qflist')
+        " Create a new list, not bound to a job.
+        call neomake#log#debug('Creating new List object.')
+        let list = neomake#list#List('quickfix')
+        call list.add_entries(getqflist())
+        let info['qflist'] = list
+        let g:_neomake_info = info
+    endif
+    return info['qflist']
+endfunction
+
+function! s:get_list(file_mode) abort
+    if a:file_mode
+        let list = neomake#list#get_loclist()
+        let g:unimpaired_prevnext = ['NeomakePrevLoclist', 'NeomakeNextLoclist']
+    else
+        let list = neomake#list#get_qflist()
+        let g:unimpaired_prevnext = ['NeomakePrevQuickfix', 'NeomakeNextQuickfix']
+    endif
+    return list
+endfunction
+
+function! neomake#list#next(c, ...) abort
+    let file_mode = a:0 ? a:1 : 1
+    let list = s:get_list(file_mode)
+    call s:goto_nearest(list, a:c == 0 ? 1 : a:c)
+endfunction
+
+function! neomake#list#prev(c, ...) abort
+    let file_mode = a:0 ? a:1 : 1
+    let list = s:get_list(file_mode)
+    call s:goto_nearest(list, a:c == 0 ? -1 : -a:c)
+endfunction
+
+" TODO: global / already used somewhere else? / config
+let g:neomake#list#type_prio = {
+            \ 'E': 0,
+            \ 'W': 1,
+            \ 'I': 2,
+            \ }
+
+" TODO: allow to customize via own callback(s)?
+function! s:cmp_listitem_loc(a, b) abort
+    let buf_diff = a:a.bufnr - a:b.bufnr
+    if buf_diff
+        return buf_diff
+    endif
+
+    if exists(':Assert')
+        Assert a:a.bufnr != -1
+        Assert a:b.bufnr != -1
+    endif
+
+    let lnum_diff = a:a.lnum - a:b.lnum
+    if lnum_diff
+        return lnum_diff
+    endif
+
+    let col_diff = a:a.col - a:b.col
+    if col_diff
+        return col_diff
+    endif
+
+    let prio = g:neomake#list#type_prio
+    return get(prio, a:a.type, 99) - get(prio, a:b.type, 99)
+endfunction
+
+function! s:goto_nearest(list, offset) abort
+    let [lnum, col] = getpos('.')[1:2]
+    if a:offset == 0
+        throw 'a:offset must not be 0'
+    endif
+
+    if !has_key(a:list, '_sorted_entries_by_location')
+        call a:list.sort_by_location()
+    endif
+    let entries = a:list._sorted_entries_by_location
+    if a:offset < 0
+        call reverse(entries)
+    endif
+
+    let c = a:offset
+    let step = a:offset > 0 ? 1 : -1
+    let found = 0
+    for item in entries
+        if (a:offset > 0 && (item.lnum > lnum || (item.lnum == lnum && item.col > col)))
+                    \ || (a:offset < 0 && (item.lnum < lnum || (item.lnum == lnum && item.col < col)))
+            let c -= step
+            let found = item.nmqfidx
+            if c == 0
+                break
+            endif
+        endif
+    endfor
+
+    if found
+        if a:list.type ==# 'loclist'
+            if exists(':AssertEqual')
+                " @vimlint(EVL102, 1, l:ll_item)
+                let ll_item = getloclist(0)[found-1]
+                AssertEqual [ll_item.bufnr, ll_item.lnum], [item.bufnr, item.lnum]
+            endif
+            execute 'll '.found
+        else
+            if exists(':AssertEqual')
+                " @vimlint(EVL102, 1, l:cc_item)
+                let cc_item = getqflist()[found-1]
+                AssertEqual [cc_item.bufnr, cc_item.lnum], [item.bufnr, item.lnum]
+            endif
+            execute 'cc '.found
+        endif
+    elseif c > 0
+        call neomake#log#error('No more next items.')
+    elseif c < 0
+        call neomake#log#error('No more previous items.')
+    endif
+endfunction
+
+" vim: ts=4 sw=4 et

--- a/plugin/neomake.vim
+++ b/plugin/neomake.vim
@@ -125,6 +125,14 @@ command! -bar NeomakeEnableTab call s:enable(t:)
 command! NeomakeStatus call s:display_status()
 " }}}
 
+" NOTE: experimental, no default mappings.
+" NOTE: uses -addr=lines (default), and therefore negative counts do not work
+"       (see https://github.com/vim/vim/issues/3654).
+command! -bar -count=1 NeomakeNextLoclist call neomake#list#next(<count>, 1)
+command! -bar -count=1 NeomakePrevLoclist call neomake#list#prev(<count>, 1)
+command! -bar -count=1 NeomakeNextQuickfix call neomake#list#next(<count>, 0)
+command! -bar -count=1 NeomakePrevQuickfix call neomake#list#prev(<count>, 0)
+
 function! s:define_highlights() abort
     if g:neomake_place_signs
         call neomake#signs#DefineHighlights()

--- a/tests/customqf.vader
+++ b/tests/customqf.vader
@@ -220,12 +220,29 @@ Execute (Handles empty entries):
   endfunction
   CallNeomake {'enabled_makers': [maker]}
 
-Execute (Does not change current error via regular command maker):
+Execute (Does not change current error text (command maker)):
   call neomake#quickfix#enable(1)
   try
     new
-    CallNeomake {'enabled_makers': [g:error_maker]}
+    CallNeomake 1, [g:error_maker]
     AssertEqual neomake#GetCurrentErrorMsg(), 'error-maker: error (E)'
+    lopen
+    AssertEqual getline(1), 'erro 1:- error'
+    lclose
+    bwipe
+  finally
+    call neomake#quickfix#disable()
+  endtry
+
+Execute (Does not change current error text (entries maker)):
+  call neomake#quickfix#enable(1)
+  try
+    new
+    CallNeomake 1, [g:entry_maker]
+    AssertEqual neomake#GetCurrentErrorMsg(), 'entry_maker: error (E)'
+    lopen
+    AssertEqual getline(1), 'entr 1:- error'
+    lclose
     bwipe
   finally
     call neomake#quickfix#disable()

--- a/tests/cwd.vader
+++ b/tests/cwd.vader
@@ -266,8 +266,7 @@ Execute (get_list_entries: filename with cwd):
   AssertEqual expand('%:p'), tempdir.'/project/sub/file_in_subdir_2'
   Assert filereadable('project/sub/file_in_subdir_2'), 'file is readable'
 
-  call neomake#Make(1, [maker])
-  NeomakeTestsWaitForFinishedJobs
+  CallNeomake 1, [maker]
   AssertNeomakeMessage 'Updating entry bufnr: 0 => '.bufnr.'.'
 
   AssertEqualQf getloclist(0), [{

--- a/tests/ft_javascript.vader
+++ b/tests/ft_javascript.vader
@@ -96,4 +96,6 @@ Execute (javascript: flow: no trailing newline):
   \  'type': 'E', 'pattern': '',
   \  'text': 'Error: Cannot call `list` because a callable signature is missing in exports [1].'},
   \ ]
+  " Replaced newline in log message.
+  AssertNeomakeMessage "\\VModified list entry 1 (postprocess): {'added': {'length': 2}, 'changed': {'text': ['11\\\\nError: Cannot call `list` because a callable signature is missing in exports [1].', 'Error: Cannot call `list` because a callable signature is missing in exports [1].']}}."
   bwipe

--- a/tests/integration.vader
+++ b/tests/integration.vader
@@ -210,6 +210,7 @@ Execute (Neomake: handle output for removed window):
     let bufnr = bufnr('%')
     call neomake#Make(1, [g:sleep_efm_maker])
     let jobinfo = neomake#GetJobs()[0]
+    let make_info = values(neomake#GetStatus().make_info)[0]
     quit
     NeomakeTestsWaitForFinishedJobs
     AssertEqual len(g:neomake_test_countschanged), 0,
@@ -226,7 +227,7 @@ Execute (Neomake: handle output for removed window):
     exe 'b' bufnr
     doautocmd BufEnter
     AssertNeomakeMessage "Processing pending output for job's buffer in new window."
-    AssertNeomakeMessage 'Creating location list.', 3, jobinfo
+    AssertNeomakeMessage 'Creating location list.', 3, make_info
     AssertEqual len(g:neomake_test_finished), 1
     AssertEqual len(g:neomake_test_countschanged), 1
     AssertEqual map(getloclist(0), 'v:val.text'), ['error message', 'warning', 'error2']
@@ -854,10 +855,10 @@ Execute (Location list should be cleared only after first output):
   call g:NeomakeSetupAutocmdWrappers()
   lgetexpr 'init'
 
-  let s:au_called = 0
+  let s:au_called = []
   function! OnNeomakeJobFinished() abort
-    if s:au_called == 0
-      let s:au_called = 1
+    if empty(s:au_called)
+      call add(s:au_called, 1)
       call vader#assert#equal([map(getloclist(0), 'v:val.text'),
           \   len(g:neomake_test_finished),
           \   len(g:neomake_test_countschanged)],
@@ -880,7 +881,7 @@ Execute (Location list should be cleared only after first output):
     AssertEqual getloclist(0)[0].text, 'slept'
   endif
   NeomakeTestsWaitForFinishedJobs
-  AssertEqual s:au_called, 1
+  AssertEqual s:au_called, [1]
   AssertEqual getloclist(0)[0].text, 'slept'
   AssertEqual len(g:neomake_test_countschanged), 1
   delfunction OnNeomakeJobFinished

--- a/tests/isolated/highlights.vader
+++ b/tests/isolated/highlights.vader
@@ -125,6 +125,10 @@ Execute (get_list_entries: based on example from doc):
   " Check that existing buffer was used for filename.
   AssertEqual llist[4].bufnr, buf1, 'get_list_entries_buf1 was picked up'
 
+  AssertNeomakeMessage "Entry 2 differs after adding: {'changed': {'valid': [1, 0]}}.", 3
+  AssertNeomakeMessage "Entry 4 differs after adding: {'changed': {'bufnr': [0, ".unlisted_bufnr."]}, 'removed': {'filename': '/path/to/file'}}.", 3
+  AssertNeomakeMessage "Entry 5 differs after adding: {'changed': {'bufnr': [0, ".buf1."]}, 'removed': {'filename': 'get_list_entries_buf1'}}.", 3
+
   AssertEqualQf llist, [
   \ {'lnum': 1, 'bufnr': buf1, 'col': 0, 'valid': 1, 'vcol': 0, 'nr': -1,
   \  'type': 'E', 'pattern': '', 'text': 'Some error'},

--- a/tests/list.vader
+++ b/tests/list.vader
@@ -1,0 +1,189 @@
+Include: include/setup.vader
+
+Execute (List: basic: loclist):
+  new
+  normal! oline2
+  normal! gg0
+  let maker = {}
+  function! maker.get_list_entries(...)
+    let b = bufnr('%')
+    return [
+    \ {'text': '1', 'lnum': 1, 'bufnr': b},
+    \ {'text': '2', 'lnum': 2, 'col': 3, 'bufnr': b},
+    \ ]
+  endfunction
+  CallNeomake 1, [maker]
+  AssertNeomakeMessage 'Adding 2 list entries.', 3
+
+  AssertEqual getpos('.'), [0, 1, 1, 0]
+  NeomakeNextLoclist
+  AssertEqual getpos('.'), [0, 2, 3, 0]
+  NeomakePrevLoclist
+  AssertEqual getpos('.'), [0, 1, 1, 0]
+  AssertNeomakeMessageAbsent 'Creating new List object.'
+  bwipe!
+
+Execute (List: basic: quickfix):
+  new
+  normal! oline2
+  normal! gg0
+  let maker = {}
+  function! maker.get_list_entries(...)
+    let b = bufnr('%')
+    return [
+    \ {'text': '1', 'lnum': 1, 'bufnr': b},
+    \ {'text': '2', 'lnum': 2, 'col': 3, 'bufnr': b},
+    \ ]
+  endfunction
+  CallNeomake 0, [maker]
+
+  AssertEqual getpos('.'), [0, 1, 1, 0]
+  NeomakeNextQuickfix
+  AssertEqual getpos('.'), [0, 2, 3, 0]
+  NeomakePrevQuickfix
+  AssertEqual getpos('.'), [0, 1, 1, 0]
+  AssertNeomakeMessageAbsent 'Creating new List object.'
+  bwipe!
+
+Execute (Sorting by location):
+  let list = neomake#list#List('loclist')
+  AssertEqual list.sort_by_location(), []
+
+  let input = [
+  \ {'lnum': 1, 'col': 2, 'bufnr': 1, 'type': ''},
+  \ {'lnum': 1, 'col': 5, 'bufnr': 2, 'type': ''},
+  \ {'lnum': 2, 'col': 1, 'bufnr': 1, 'type': ''},
+  \ {'lnum': 3, 'col': 5, 'bufnr': 1, 'type': ''},
+  \ {'lnum': 1, 'col': 2, 'bufnr': 1, 'type': 'E'},
+  \ ]
+  call list.add_entries(input)
+
+  AssertEqual list.sort_by_location(), [
+  \ {'lnum': 1, 'col': 2, 'bufnr': 1, 'type': 'E'},
+  \ {'lnum': 1, 'col': 2, 'bufnr': 1, 'type': ''},
+  \ {'lnum': 2, 'col': 1, 'bufnr': 1, 'type': ''},
+  \ {'lnum': 3, 'col': 5, 'bufnr': 1, 'type': ''},
+  \ {'lnum': 1, 'col': 5, 'bufnr': 2, 'type': ''},
+  \ ]
+  AssertEqual input[-1].lnum, 1, 'does not sort list in-place'
+
+  " Sorts newly added entries.
+  call list.add_entries([
+  \ {'lnum': 1, 'col': 1, 'bufnr': 1, 'type': 'W'},
+  \ ])
+  AssertEqual list._sorted_entries_by_location, [
+  \ {'lnum': 1, 'col': 1, 'bufnr': 1, 'type': 'W'},
+  \ {'lnum': 1, 'col': 2, 'bufnr': 1, 'type': 'E'},
+  \ {'lnum': 1, 'col': 2, 'bufnr': 1, 'type': ''},
+  \ {'lnum': 2, 'col': 1, 'bufnr': 1, 'type': ''},
+  \ {'lnum': 3, 'col': 5, 'bufnr': 1, 'type': ''},
+  \ {'lnum': 1, 'col': 5, 'bufnr': 2, 'type': ''},
+  \ ]
+
+Execute (list: error with duplicate nmqfidx (debug=1)):
+  let list = neomake#list#List('loclist')
+  AssertEqual list.debug, 1
+  call list.add_entries([
+  \ {'lnum': 1, 'col': 1, 'bufnr': 1, 'type': 'W'},
+  \ ])
+  call list.add_entries([
+  \ {'lnum': 1, 'col': 1, 'bufnr': 1, 'type': 'W'},
+  \ ], 1)
+  AssertNeomakeMessage 'Duplicate qf indexes in list entries: [1, 1].', 0
+
+Execute (list: no error with duplicate nmqfidx (debug=0)):
+  let list = neomake#list#List('loclist')
+  let list.debug = 0
+  call list.add_entries([
+  \ {'lnum': 1, 'col': 1, 'bufnr': 1, 'type': 'W'},
+  \ ])
+  call list.add_entries([
+  \ {'lnum': 1, 'col': 1, 'bufnr': 1, 'type': 'W'},
+  \ ], 1)
+
+Execute (quickfix list: gets local and sorts):
+  Save g:_neomake_info
+  unlet g:_neomake_info
+
+  let list = neomake#list#List('quickfix')
+  AssertEqual list.sort_by_location(), []
+
+  call setqflist([
+  \ {'lnum': 1, 'col': 2, 'bufnr': 1},
+  \ {'lnum': 1, 'col': 5, 'bufnr': 1},
+  \ {'lnum': 2, 'col': 1, 'bufnr': 1},
+  \ {'lnum': 3, 'col': 5, 'bufnr': 1},
+  \ {'lnum': 1, 'col': 1, 'bufnr': 1},
+  \ ])
+
+  let list = neomake#list#get_qflist()
+  AssertEqual map(list.sort_by_location(), '[v:val.lnum, v:val.col, v:val.bufnr]'), [
+  \ [1, 1, 1],
+  \ [1, 2, 1],
+  \ [1, 5, 1],
+  \ [2, 1, 1],
+  \ [3, 5, 1],
+  \ ]
+
+Execute (neomake#list#next):
+  new
+  let bufnr = bufnr('%')
+  normal! iline1
+  normal! oline2
+  normal! oline3
+  normal! gg^
+
+  call setloclist(0, [
+  \ {'lnum': 1, 'col': 1, 'bufnr': bufnr, 'text': 'idx1'},
+  \ {'lnum': 1, 'col': 5, 'bufnr': bufnr, 'text': 'idx2'},
+  \ {'lnum': 2, 'col': 1, 'bufnr': bufnr, 'text': 'idx3'},
+  \ {'lnum': 3, 'col': 5, 'bufnr': bufnr, 'text': 'idx4'},
+  \ {'lnum': 1, 'col': 2, 'bufnr': bufnr, 'text': 'idx5'},
+  \ ])
+  AssertEqual map(getloclist(0), '[v:val.lnum, v:val.text]'),
+  \ [[1, 'idx1'], [1, 'idx2'], [2, 'idx3'], [3, 'idx4'], [1, 'idx5']],
+  \ 'Sane lnums'
+
+  Assert !exists('w:_neomake_info.loclist')
+
+  AssertEqual getpos('.'), [0, 1, 1, 0]
+  NeomakeNextLoclist
+  AssertEqual getpos('.'), [0, 1, 2, 0]
+
+  NeomakePrevLoclist
+  AssertEqual getpos('.'), [0, 1, 1, 0]
+  NeomakePrevLoclist
+  AssertNeomakeMessage 'No more previous items.'
+
+  3NeomakeNextLoclist
+  AssertEqual getpos('.'), [0, 2, 1, 0]
+
+  " Goes to last entry, without error message (like with :lnext).
+  99NeomakeNextLoclist
+  AssertEqual getpos('.'), [0, 3, 5, 0]
+
+  " Error message when at last entry already (like with :lnext).
+  99NeomakeNextLoclist
+  AssertEqual getpos('.'), [0, 3, 5, 0]
+  AssertNeomakeMessage 'No more next items.'
+
+  " count=0 gets handles as 1.
+  0NeomakePrevLoclist
+  AssertEqual getpos('.'), [0, 2, 1, 0]
+  0NeomakeNextLoclist
+  AssertEqual getpos('.'), [0, 3, 5, 0]
+  bwipe!
+
+Execute (neomake#list#_diff_new_entries):
+  AssertEqual neomake#list#_diff_new_entries([], []), {}
+  AssertEqual neomake#list#_diff_new_entries([{}], [{'valid': 0}]), {'0': {'changed': {'valid': [1, 0]}}}
+  AssertEqual neomake#list#_diff_new_entries([{}, {}], [{}, {'valid': 0}]), {'1': {'changed': {'valid': [1, 0]}}}
+
+  " Handles different lengths.
+  AssertEqual neomake#list#_diff_new_entries([{}], []), {}
+  AssertEqual neomake#list#_diff_new_entries([], [{}]), {}
+
+  AssertEqual neomake#list#_diff_new_entries([{'length': 1}], [{}]), {}
+
+  AssertEqual neomake#list#_diff_new_entries([{'text': 'error'}], [{'text': 'error', 'valid': 1, 'pattern': ''}]),
+  \ {}

--- a/tests/lists.vader
+++ b/tests/lists.vader
@@ -74,7 +74,7 @@ Execute (Goes back to original window after opening list):
   new
   let winnr = winnr()
   let wincount = winnr('$')
-  call neomake#Make(1, [g:error_maker])
+  CallNeomake 1, [g:error_maker]
   NeomakeTestsWaitForFinishedJobs
 
   AssertEqual winnr, winnr()
@@ -107,6 +107,7 @@ Execute (open_list=2 handling with get_list_entries maker and invalid entries):
   \ ['error2', 'E', 0]]
 
   AssertEqual winnr, winnr()
+
   if has('patch-7.4.379')
     AssertEqual wincount, winnr('$'), 'Location list did not appear for invalid entries'
   else
@@ -138,6 +139,7 @@ Execute (open_list=2 handling with get_list_entries maker and invalid entries (q
   \ ['error2', 'E', 0]]
 
   AssertEqual winnr, winnr()
+
   if has('patch-7.4.379')
     AssertEqual wincount, winnr('$'), 'Quickfix list did not appear for invalid entries'
   else
@@ -188,8 +190,13 @@ Execute (Stays in location window with :lwindow in QuickFixCmdPost (like vim-qf)
   AssertEqual map(getloclist(0), '[v:val.text, v:val.type]'), [['error', 'E']]
 
   AssertEqual wincount + 1, winnr('$'), 'Location list appeared'
-  " Not what you expect when being unaware of the autocmd, but it is like that.
-  AssertNotEqual winnr, winnr()
+
+  if has('patch-8.0.1040')  " 'efm' in setqflist/getqflist
+    AssertEqual winnr, winnr()
+  else
+    " Not what you expect when being unaware of the autocmd, but it is like that.
+    AssertNotEqual winnr, winnr()
+  endif
   exe winnr.'wincmd w'
   lclose
   bwipe
@@ -245,7 +252,11 @@ Execute (Goes back to original window after opening list (wincmd in postprocess)
     AssertNeomakeMessage 'action queue: processed 2 items.'
 
     Assert !exists('#neomake_event_queue#WinEnter'), 'autocmd was deleted'
-    AssertEqual s:called, 1
+    if has('patch-8.0.1040')  " 'efm' in setqflist/getqflist
+      AssertEqual s:called, 0
+    else
+      AssertEqual s:called, 1
+    endif
 
     wincmd p
     AssertEqual 1, winnr()
@@ -380,7 +391,11 @@ Execute (Goes back to original window after opening list (mapexpr)):
     AssertNeomakeMessage 'action queue: processed 2 items.'
 
     Assert !exists('#neomake_event_queue#WinEnter'), 'autocmd was deleted'
-    AssertEqual s:called, 1
+    if has('patch-8.0.1040')  " 'efm' in setqflist/getqflist
+      AssertEqual s:called, 0
+    else
+      AssertEqual s:called, 1
+    endif
 
     wincmd p
     AssertEqual 1, winnr()
@@ -654,7 +669,11 @@ Execute (Quiet with no QuickfixCmdPost autocommands):
   CallNeomake 1, [g:error_maker]
   Assert len(getloclist(0))
   AssertEqual NeomakeTestsGetVimMessages(), []
-  AssertEqual s:called, 1
+  if has('patch-8.0.1040')
+    AssertEqual s:called, 0
+  else
+    AssertEqual s:called, 1
+  endif
   bwipe
 
 Execute (open_list and list_height can be buffer settings):
@@ -682,4 +701,18 @@ Execute (open_list and list_height can be buffer settings):
 
   AssertEqual winheight(wincount + 1), 2
   lclose
+  bwipe
+
+Execute (postprocess: removing all entries):
+  new
+  AssertEqual getloclist(0), []
+  let maker = copy(g:error_maker)
+  function! maker.postprocess(entry) abort
+    let a:entry.valid = -1
+  endfunction
+
+  CallNeomake 1, [maker]
+  AssertNeomakeMessage 'processing 1 lines of output.'
+  AssertNeomakeMessage '\v^Removing invalid entry: error .*'
+  AssertEqual getloclist(0), []
   bwipe

--- a/tests/main.vader
+++ b/tests/main.vader
@@ -26,6 +26,7 @@ Include (Hooks get queued): hooks-queue.vader
 Include (Integration tests): integration.vader
 Include (Jobinfo): jobinfo.vader
 Include (JSON): json.vader
+Include (List): list.vader
 Include (Lists): lists.vader
 Include (List entries): list-entries.vader
 Include (Logging): log.vader

--- a/tests/makers.vader
+++ b/tests/makers.vader
@@ -819,14 +819,14 @@ Execute (neomake#Make uses current filetype by default):
   new
   set ft=neomake_tests
   let b:neomake_neomake_tests_true_append_file = 0
-  let s:au_called = 0
+  let s:au_called = []
   augroup neomake_tests
     autocmd User NeomakeJobFinished AssertEqual g:neomake_hook_context.jobinfo.ft, 'neomake_tests'
-    autocmd User NeomakeJobFinished let s:au_called = 1
+    autocmd User NeomakeJobFinished call add(s:au_called, 1)
   augroup END
   call neomake#Make({'enabled_makers': ['true']})
   NeomakeTestsWaitForFinishedJobs
-  Assert s:au_called, 'autocommand was called'
+  AssertEqual s:au_called, [1]
   bwipe
 
 Execute (Neomake/Neomake! run ft maker in project mode):

--- a/tests/processing.vader
+++ b/tests/processing.vader
@@ -1,5 +1,25 @@
 Include: include/setup.vader
 
+" TODO: not really necessary (likely), but provides better/easier test results.
+Execute (get_list_entries: basic end-to-end test):
+  let s:counter = 0
+  let maker = {}
+  function! maker.get_list_entries(...) abort dict
+    let s:counter += 1
+    return [{
+      \ 'lnum': 23,
+      \ 'col': 42,
+      \ 'text': printf('error_msg_%d', s:counter),
+      \ 'type': 'E',
+      \ }]
+  endfunction
+
+  CallNeomake 1, [maker]
+  CallNeomake 1, [maker]
+  AssertEqual map(getloclist(0), 'v:val.text'), ['error_msg_2']
+  lolder
+  AssertEqual map(getloclist(0), 'v:val.text'), ['error_msg_1']
+
 Execute (Output is only processed in normal/insert mode (loclist)):
   if NeomakeAsyncTestsSetup()
     new

--- a/tests/signs.vader
+++ b/tests/signs.vader
@@ -458,7 +458,11 @@ Execute (Signs should be placed with QuickfixCmdPost already (loclist)):
   let signs = neomake#signs#by_lnum(bufnr('%'))
   AssertEqual signs, {'1': [5000, 'neomake_file_err']}
 
-  AssertEqual s:calls, [signs]
+  if has('patch-8.0.1040')  " 'efm' in setqflist/getqflist
+    AssertEqual s:calls, []
+  else
+    AssertEqual s:calls, [signs]
+  endif
   bwipe
   delfunction OnQuickfixCmdPost
 
@@ -479,6 +483,10 @@ Execute (Signs should be placed with QuickfixCmdPost already (qflist)):
   let signs = neomake#signs#by_lnum(bufnr('%'))
   AssertEqual signs, {'1': [5000, 'neomake_project_err']}
 
-  AssertEqual s:calls, [signs]
+  if has('patch-8.0.1040')  " 'efm' in setqflist/getqflist
+    AssertEqual s:calls, []
+  else
+    AssertEqual s:calls, [signs]
+  endif
   bwipe
   delfunction OnQuickfixCmdPost

--- a/tests/tempfiles.vader
+++ b/tests/tempfiles.vader
@@ -540,7 +540,7 @@ Execute (unlisted buffers created for tempfiles get wiped):
     \ maker1.tempfile_name)
     let buf1 = g:neomake_test_matchlist[1]
     AssertNeomakeMessage printf(
-    \ '\vUsed bufnr from temporary buffer (\d+) \(%s\) for 1 entries: 2.',
+    \ '\vUsed bufnr from temporary buffer (\d+) \(%s\) for 1 entries: 1.',
     \ maker2.tempfile_name)
     let buf2 = g:neomake_test_matchlist[1]
 


### PR DESCRIPTION
This adds new commands to go to the next/prev entry (relative to the cursor by default):
NeomakeNextLoclist/NeomakePrevLoclist and NeomakeNextQuickfix/NeomakePrevQuickfix

Integrates with vim-unimpaired via https://github.com/tpope/vim-unimpaired/pull/146.