### PR TITLE
Revert "CI: do not compact test output"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ common: &common
   working_directory: ~/repo
   steps:
     - checkout
-    - run: make --keep-going testcoverage TEST_VIM=$TEST_VIM _SED_HIGHLIGHT_ERRORS='| contrib/highlight-log vader'
+    - run: make --keep-going testcoverage TEST_VIM=$TEST_VIM
     - run:
         name: Upload coverage results
         command: |


### PR DESCRIPTION
This reverts commit 9121134965190e873a9671ea33c3061e161e778d.