### PR TITLE
[WIP] automake: cancel make if buffer was changed

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -1758,15 +1758,9 @@ function! s:ProcessEntries(jobinfo, entries, ...) abort
     if empty(a:entries)
         return
     endif
-    let s = s:make_info[a:jobinfo.make_id]
     if get(s:make_info[a:jobinfo.make_id].options, 'is_automake', 0)
-        let tick = getbufvar(a:jobinfo.bufnr, 'neomake_automake_tick', [])
-        if !empty(tick)
-            if tick != [getbufvar(a:jobinfo.bufnr, 'changedtick'), a:jobinfo.ft]
-                call neomake#log#debug('Buffer was changed, canceling automake.', a:jobinfo)
-                  call neomake#CancelMake(a:jobinfo.make_id)
-                  return g:neomake#action_queue#processed
-            endif
+        if neomake#configure#_cancel_automake(a:jobinfo)
+            return g:neomake#action_queue#processed
         endif
     endif
     if s:need_to_postpone_loclist(a:jobinfo)

--- a/autoload/neomake/configure.vim
+++ b/autoload/neomake/configure.vim
@@ -117,7 +117,7 @@ function! s:neomake_do_automake(context) abort
                 \ 'file_mode': 1,
                 \ 'jobs': deepcopy(a:context.maker_jobs),
                 \ 'ft': ft,
-                \ 'automake': 1})
+                \ 'is_automake': 1})
     let started_jobs = filter(copy(jobinfos), "!get(v:val, 'finished', 0)")
     call s:debug_log(printf('started jobs: %s', string(map(copy(started_jobs), 'v:val.id'))))
     if !empty(started_jobs)

--- a/tests/automake.vader
+++ b/tests/automake.vader
@@ -36,6 +36,55 @@ Execute (augroup neomake_automake does not exist by default):
   call neomake#configure#automake()
   Assert !exists('#neomake_automake')
 
+Execute (automake: display of error with O during maker run):
+  if NeomakeAsyncTestsSetup()
+    Save g:neomake g:neomake_test_enabledmakers
+
+    new
+    normal! o
+
+    set filetype=neomake_tests
+    let maker1 = copy(g:error_maker)
+    let maker1.name = 'mymaker1'
+    function! maker1.process_output(...)
+      return [{'lnum': 1, 'text': 'error1'}]
+    endfunction
+    let maker2 = copy(g:sleep_maker)
+    let maker2.name = 'mymaker2'
+    function! maker2.process_output(...)
+      normal! O
+      return [{'text': 'error2'}]
+    endfunction
+    let g:neomake_test_enabledmakers = [maker1, maker2]
+    call neomake#configure#automake({
+    \ 'TextChanged': {'delay': 10}})
+    doautocmd TextChanged
+    call NeomakeTestsHandleSecondTextChanged()
+
+    AssertNeomakeMessage '\vautomake: started timer \(10ms\): (\d+)'
+    AssertEqual neomake#GetCurrentErrorMsg(), ''
+
+    NeomakeTestsWaitForMessage 'automake: callback for timer 1 (via TextChanged).', 3
+    NeomakeTestsWaitForFinishedJobs
+    AssertEqual neomake#GetCurrentErrorMsg(), ''
+
+    AssertNeomakeMessage 'Processing 1 entries.', 3
+    AssertNeomakeMessage 'mymaker1: completed with exit code 1.', 3
+    AssertNeomakeMessage '\V\^Skipping cleaning of make info: 1 active jobs: [''Job \d\+: mymaker2''].', 3
+
+    AssertNeomakeMessage 'exit: mymaker2: 0.', 3
+    AssertNeomakeMessage 'Buffer was changed, canceling automake.', 3
+    AssertNeomakeMessage 'Cancelling make.', 3
+    AssertNeomakeMessage 'Cancelling job.', 3
+    AssertNeomakeMessage 'Job exited already.', 3
+    AssertNeomakeMessage '\V\^Skipping cleaning of make info: 1 active jobs: [''Job \d\+: mymaker2 [canceled]''].', 3
+    AssertNeomakeMessage 'mymaker2: completed with exit code 0.', 3
+    AssertNeomakeMessage 'Cleaning jobinfo.', 3
+    AssertNeomakeMessage 'Cleaning make info.', 3
+    AssertEqual map(getloclist(0), 'v:val.text'), ['error1']
+    bwipe!
+  endif
+
 Execute (short setup: 'n'):
   Save g:neomake
   call neomake#configure#automake('n')


### PR DESCRIPTION
This avoids having wrong information (outdated, or wrong offset with
e.g. `O`).

TODO:

- [ ] re-run immediately on `InsertLeave` (if canceled while in insert mode?)
- [ ] test with `feedkeys-x!`