### PR TITLE
supports_stdin can be a setting

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -516,11 +516,12 @@ endif
 let s:command_maker_base = copy(g:neomake#core#command_maker_base)
 " Check if a temporary file is used, and set it in s:make_info in case it is.
 function! s:command_maker_base._get_tempfilename(jobinfo) abort dict
-    if has_key(self, 'supports_stdin')
-        if type(self.supports_stdin) == type(function('tr'))
-            let supports_stdin = self.supports_stdin(a:jobinfo)
+    let Supports_stdin = neomake#utils#GetSetting('supports_stdin', self, s:unset_dict, a:jobinfo.ft, a:jobinfo.bufnr)
+    if Supports_stdin isnot s:unset_dict
+        if type(Supports_stdin) == type(function('tr'))
+            let supports_stdin = call(Supports_stdin, [a:jobinfo], self)
         else
-            let supports_stdin = self.supports_stdin
+            let supports_stdin = Supports_stdin
         endif
         if supports_stdin
             let a:jobinfo.uses_stdin = 1

--- a/doc/neomake.txt
+++ b/doc/neomake.txt
@@ -471,8 +471,10 @@ Define a new filetype or project-level maker. See |neomake-makers|.
 *b:neomake_<name>_<property>*
 *b:neomake_<ft>_<name>_<property>*
 Configure properties for a maker where <property> is one of `exe`, `args`,
-`errorformat`, `buffer_output`, `remove_invalid_entries` or `append_file`.
-This can be set per buffer, too. Example: >
+`errorformat`, `buffer_output`, `remove_invalid_entries`, `append_file`,
+or `supports_stdin`.
+
+This can also be set per buffer, e.g.: >
     let g:neomake_javascript_jshint_exe = './myjshint'
     let b:neomake_javascript_jshint_exe = './myotherjshint'
 <

--- a/tests/stdin.vader
+++ b/tests/stdin.vader
@@ -312,3 +312,12 @@ Execute (stdin maker: can always use stdin):
   endif
   AssertEqual map(getloclist(0), 'v:val.text'), ['line1', 'line2']
   bwipe!
+
+Execute (supports_stdin can be a setting):
+  new
+  let b:neomake_mymaker_supports_stdin = 1
+  let maker = neomake#create_maker_object({'name': 'mymaker'}, 'vim')
+  let jobinfo = NeomakeTestsFakeJobinfo()
+  AssertEqual maker._get_fname_for_buffer(jobinfo), '-'
+  AssertNeomakeMessage 'Using stdin for unnamed buffer (-).', 3
+  bwipe


### PR DESCRIPTION
This is useful for e.g. vint to skip the version check.