### PR TITLE
tests/logging: add winnr to context

### DIFF
--- a/autoload/neomake/log.vim
+++ b/autoload/neomake/log.vim
@@ -61,7 +61,7 @@ function! s:log(level, msg, ...) abort
         call vader#log(test_msg)
         " Only keep context entries that are relevant for / used in the message.
         let context = a:0
-                    \ ? filter(copy(context), "index(['id', 'make_id', 'bufnr'], v:key) != -1")
+                    \ ? extend(filter(copy(context), "index(['id', 'make_id', 'bufnr', 'winnr'], v:key) != -1"), {'winnr': winnr()}, 'keep')
                     \ : {}
         call add(g:neomake_test_messages, [a:level, a:msg, context])
         if index(['.', '!', ')', ']'], a:msg[-1:-1]) == -1

--- a/tests/automake.vader
+++ b/tests/automake.vader
@@ -309,8 +309,8 @@ Execute (Automake):
   exe 'doautocmd' event
   let m = len(g:neomake_test_messages)
   AssertEqual g:neomake_test_messages[n : m], [
-  \ [3, 'automake: handling event '.event.'.', {'bufnr': bufnr('%')}],
-  \ [3, 'automake: no enabled makers.', {'bufnr': bufnr('%')}],
+  \ [3, 'automake: handling event '.event.'.', {'bufnr': bufnr('%'), 'winnr': winnr()}],
+  \ [3, 'automake: no enabled makers.', {'bufnr': bufnr('%'), 'winnr': winnr()}],
   \ ]
 
   call neomake#configure#automake('nw')

--- a/tests/include/init.vim
+++ b/tests/include/init.vim
@@ -192,11 +192,10 @@ function! s:AssertNeomakeMessage(msg, ...)
       call filter(context, "index(['id', 'make_id', 'bufnr', 'winnr'], v:key) != -1")
       let l:UNDEF = {}
       for [k, v] in items(info)
-        let expected = get(context, k, l:UNDEF)
-        if expected is l:UNDEF
-          unlet v  " for Vim without patch-7.4.1546
+        if !has_key(context, k)
           continue
         endif
+        let expected = context[k]
         try
           let same = v ==# expected
         catch

--- a/tests/include/init.vim
+++ b/tests/include/init.vim
@@ -189,13 +189,11 @@ function! s:AssertNeomakeMessage(msg, ...)
     if type(context) == type({})
       let context_diff = []
       " Only compare entries relevant for messages.
-      call filter(context, "index(['id', 'make_id', 'bufnr'], v:key) != -1")
+      call filter(context, "index(['id', 'make_id', 'bufnr', 'winnr'], v:key) != -1")
       let l:UNDEF = {}
       for [k, v] in items(info)
         let expected = get(context, k, l:UNDEF)
         if expected is l:UNDEF
-          call add(context_diff, printf('Missing value for context.%s: '
-              \  ."expected nothing, but got '%s'.", k, string(v)))
           continue
         endif
         try

--- a/tests/include/init.vim
+++ b/tests/include/init.vim
@@ -190,7 +190,6 @@ function! s:AssertNeomakeMessage(msg, ...)
       let context_diff = []
       " Only compare entries relevant for messages.
       call filter(context, "index(['id', 'make_id', 'bufnr', 'winnr'], v:key) != -1")
-      let l:UNDEF = {}
       for [k, v] in items(info)
         if !has_key(context, k)
           continue

--- a/tests/include/init.vim
+++ b/tests/include/init.vim
@@ -194,6 +194,7 @@ function! s:AssertNeomakeMessage(msg, ...)
       for [k, v] in items(info)
         let expected = get(context, k, l:UNDEF)
         if expected is l:UNDEF
+          unlet v  " for Vim without patch-7.4.1546
           continue
         endif
         try
@@ -202,6 +203,7 @@ function! s:AssertNeomakeMessage(msg, ...)
           call add(context_diff, printf(
             \ 'Could not compare context entries (expected: %s, actual: %s): %s',
             \ string(expected), string(v), v:exception))
+          unlet v  " for Vim without patch-7.4.1546
           continue
         endtry
         if !same

--- a/tests/integration.vader
+++ b/tests/integration.vader
@@ -8,10 +8,10 @@ Execute (Neomake with unknown maker):
   let make_id = neomake#GetStatus().last_make_id
   let bufnr = bufnr('%')
   AssertEqual g:neomake_test_messages, [
-  \ [3, "Calling Make with options {'ft': '', 'file_mode': 1, 'enabled_makers': ['doesnotexist']}.", {'make_id': make_id, 'bufnr': bufnr}],
-  \ [0, 'Maker not found (for empty filetype): doesnotexist.', {'make_id': make_id, 'bufnr': bufnr}],
-  \ [3, 'Nothing to make: no valid makers.', {'make_id': make_id, 'bufnr': bufnr}],
-  \ [3, 'Cleaning make info.', {'make_id': make_id, 'bufnr': bufnr}]]
+  \ [3, "Calling Make with options {'ft': '', 'file_mode': 1, 'enabled_makers': ['doesnotexist']}.", {'make_id': make_id, 'bufnr': bufnr, 'winnr': winnr()}],
+  \ [0, 'Maker not found (for empty filetype): doesnotexist.', {'make_id': make_id, 'bufnr': bufnr, 'winnr': winnr()}],
+  \ [3, 'Nothing to make: no valid makers.', {'make_id': make_id, 'bufnr': bufnr, 'winnr': winnr()}],
+  \ [3, 'Cleaning make info.', {'make_id': make_id, 'bufnr': bufnr, 'winnr': winnr()}]]
   " ACK the error.
   AssertNeomakeMessage 'Maker not found (for empty filetype): doesnotexist.', 0
 
@@ -25,10 +25,10 @@ Execute (Neomake with unknown maker for multiple fts):
   let make_id = neomake#GetStatus().last_make_id
   let bufnr = bufnr('%')
   AssertEqual g:neomake_test_messages, [
-  \ [3, "Calling Make with options {'ft': 'ft1.ft2', 'file_mode': 1, 'enabled_makers': ['doesnotexist']}.", {'make_id': make_id, 'bufnr': bufnr}],
-  \ [0, 'Maker not found (for filetype ft1.ft2): doesnotexist.', {'make_id': make_id, 'bufnr': bufnr}],
-  \ [3, 'Nothing to make: no valid makers.', {'make_id': make_id, 'bufnr': bufnr}],
-  \ [3, 'Cleaning make info.', {'make_id': make_id, 'bufnr': bufnr}]]
+  \ [3, "Calling Make with options {'ft': 'ft1.ft2', 'file_mode': 1, 'enabled_makers': ['doesnotexist']}.", {'make_id': make_id, 'bufnr': bufnr, 'winnr': winnr()}],
+  \ [0, 'Maker not found (for filetype ft1.ft2): doesnotexist.', {'make_id': make_id, 'bufnr': bufnr, 'winnr': winnr()}],
+  \ [3, 'Nothing to make: no valid makers.', {'make_id': make_id, 'bufnr': bufnr, 'winnr': winnr()}],
+  \ [3, 'Cleaning make info.', {'make_id': make_id, 'bufnr': bufnr, 'winnr': winnr()}]]
   bwipe
   " ACK the error.
   AssertNeomakeMessage 'Maker not found (for filetype ft1.ft2): doesnotexist.', 0


### PR DESCRIPTION
Do not require to pass whole context with asserting messages.