### PR TITLE
s:CleanJobinfo: log when not cleaning make info

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -1297,6 +1297,11 @@ function! s:CleanJobinfo(jobinfo, ...) abort
     " Trigger cleanup (and autocommands) if all jobs have finished.
     if empty(make_info.active_jobs) && empty(make_info.jobs_queue)
         call s:clean_make_info(make_info)
+    else
+        call neomake#log#debug(printf(
+                    \ 'Not cleaning make info yet (%d active jobs, %d pending jobs)',
+                    \ len(make_info.active_jobs), len(make_info.jobs_queue)),
+                    \ make_info.options)
     endif
     return g:neomake#action_queue#processed
 endfunction

--- a/tests/automake.vader
+++ b/tests/automake.vader
@@ -1089,9 +1089,11 @@ Execute (automake: display of error with O during maker run):
     AssertEqual neomake#GetCurrentErrorMsg(), ''
 
     NeomakeTestsWaitForMessage '\Vautomake: callback for timer \d\+ (via TextChanged).', 3
-    let make_id = neomake#GetStatus().last_make_id
+    let make_info = values(neomake#GetStatus().make_info)[0]
+    let make_id = make_info.make_id
     Assert exists('#neomake_automake_abort')
     NeomakeTestsWaitForFinishedJobs
+    AssertNeomakeMessage 'Not cleaning make info yet (1 active jobs, 0 pending jobs)', 3, make_info
 
     AssertNeomakeMessage 'Processing 1 entries.', 3
     AssertNeomakeMessage 'mymaker1: completed with exit code 1.', 3

--- a/tests/automake.vader
+++ b/tests/automake.vader
@@ -1090,13 +1090,13 @@ Execute (automake: display of error with O during maker run):
 
     NeomakeTestsWaitForMessage '\Vautomake: callback for timer \d\+ (via TextChanged).', 3
     let make_info = values(neomake#GetStatus().make_info)[0]
-    let make_id = make_info.make_id
+    let make_id = make_info.options.make_id
     Assert exists('#neomake_automake_abort')
     NeomakeTestsWaitForFinishedJobs
-    AssertNeomakeMessage 'Not cleaning make info yet (1 active jobs, 0 pending jobs)', 3, make_info
 
     AssertNeomakeMessage 'Processing 1 entries.', 3
     AssertNeomakeMessage 'mymaker1: completed with exit code 1.', 3
+    AssertNeomakeMessage 'Not cleaning make info yet (1 active jobs, 0 pending jobs)', 3, make_info
     AssertNeomakeMessage '\V\^Skipping cleaning of make info: 1 active jobs: [''Job \d\+: mymaker2''].', 3
 
     AssertNeomakeMessage 'exit: mymaker2: 0.', 3


### PR DESCRIPTION
Ref: https://github.com/neomake/neomake/issues/2201.