### PR TITLE
Use g:neomake_debug_list to control list debugging

### DIFF
--- a/autoload/neomake/list.vim
+++ b/autoload/neomake/list.vim
@@ -37,9 +37,10 @@ function! neomake#list#List(type) abort
     let list = deepcopy(s:base_list)
     let list.type = a:type
     " Display debug messages about changed entries.
-    let list.debug = exists('g:neomake_test_messages')
+    let list.debug = get(g:, 'neomake_debug_list',
+                \ exists('g:neomake_test_messages')
                 \ || !empty(get(g:, 'neomake_logfile'))
-                \ || neomake#utils#get_verbosity() >= 3
+                \ || neomake#utils#get_verbosity() >= 3)
     return list
 endfunction
 
@@ -205,12 +206,12 @@ function! s:base_list._call_qf_fn(action, ...) abort
         if s:has_support_for_qfid
             let args[-1].items = 1
             if self.debug
-                call neomake#log#debug(printf('list: calling for "get", returning items: %s.', string(fns_args)))
+                call neomake#log#debug(printf('list: call: "get", returning items: %s.', string(fns_args)))
             endif
             return call(fn, args).items
         endif
         if self.debug
-            call neomake#log#debug(printf('list: calling for "get": %s.', string(fns_args)))
+            call neomake#log#debug(printf('list: call: "get": %s.', string(fns_args)))
         endif
         return call(fn, args)
     endif
@@ -218,7 +219,7 @@ function! s:base_list._call_qf_fn(action, ...) abort
     for fns in fns_args
         let [fn, args] = fns
         if self.debug
-            call neomake#log#debug(printf('list: calling for "%s": %s.', a:action, string(fns_args)))
+            call neomake#log#debug(printf('list: call: "%s": %s.', a:action, string(fns_args)))
         endif
         call call(fn, args, self)
     endfor

--- a/autoload/neomake/list.vim
+++ b/autoload/neomake/list.vim
@@ -608,7 +608,11 @@ function! s:base_list.add_lines_with_efm(lines, jobinfo) dict abort
             else
                 let cmd = 'caddexpr'
             endif
-            exe 'noautocmd '.cmd.' a:lines'
+            let cmd = 'noautocmd '.cmd.' a:lines'
+            if self.debug
+                call neomake#log#debug(printf('list: exe: %s (with %d lines).', cmd, len(a:lines)), a:jobinfo)
+            endif
+            exe cmd
             let a:jobinfo._delayed_qf_autocmd = 'QuickfixCmdPost '.cmd
         finally
             let &errorformat = olderrformat

--- a/autoload/neomake/list.vim
+++ b/autoload/neomake/list.vim
@@ -608,12 +608,12 @@ function! s:base_list.add_lines_with_efm(lines, jobinfo) dict abort
             else
                 let cmd = 'caddexpr'
             endif
+            let a:jobinfo._delayed_qf_autocmd = 'QuickfixCmdPost '.cmd
             let cmd = 'noautocmd '.cmd.' a:lines'
             if self.debug
                 call neomake#log#debug(printf('list: exe: %s (with %d lines).', cmd, len(a:lines)), a:jobinfo)
             endif
             exe cmd
-            let a:jobinfo._delayed_qf_autocmd = 'QuickfixCmdPost '.cmd
         finally
             let &errorformat = olderrformat
             call a:jobinfo.cd_back()

--- a/tests/list.vader
+++ b/tests/list.vader
@@ -1,5 +1,29 @@
 Include: include/setup.vader
 
+Execute (list: default for debug):
+  Save g:neomake_test_messages, g:neomake_debug_list, g:neomake_verbose
+
+  unlet! g:neomake_test_messages
+  unlet! g:neomake_debug_list
+  unlet! g:neomake_verbose
+
+  AssertEqual neomake#list#List('loclist').debug, 0
+  let g:neomake_debug_list = 1
+  AssertEqual neomake#list#List('loclist').debug, 1
+
+  let g:neomake_test_messages = []
+  let g:neomake_debug_list = 0
+  AssertEqual neomake#list#List('loclist').debug, 0
+
+  unlet g:neomake_debug_list
+  AssertEqual neomake#list#List('loclist').debug, 1
+
+  unlet g:neomake_test_messages
+  let g:neomake_verbose = 3
+  AssertEqual neomake#list#List('loclist').debug, 1
+
+  Restore
+
 Execute (List: basic: loclist):
   new
   normal! oline2


### PR DESCRIPTION
Still enabled by default with a logfile, but might be too verbose.