### PR TITLE
Add "use_list" make option

### DIFF
--- a/tests/lists.vader
+++ b/tests/lists.vader
@@ -829,3 +829,19 @@ Execute (creates single list for clean maker):
   silent lolder
   AssertEqual map(getloclist(0), 'v:val.text'), ['init']
   bwipe
+
+Execute (use_list: make option):
+  new
+  lgetexpr 'init'
+  CallNeomake {'file_mode': 1, 'use_list': 0, 'enabled_makers': [g:error_maker]}
+  AssertEqual map(getloclist(0), 'v:val.text'), ['init']
+  bwipe
+
+Execute (use_list: enabled via all makers having use_list=0):
+  new
+  let maker = copy(g:error_maker)
+  let maker.use_list = 0
+  lgetexpr 'init'
+  CallNeomake 1, [maker]
+  AssertEqual map(getloclist(0), 'v:val.text'), ['init']
+  bwipe


### PR DESCRIPTION
This also get enabled when all jobs/makers use it.

It currently does not use settings, and therefore has to be used
explicitly, e.g. via `call neomake#Make({'use_list': 0, …})`, or by
setting it in a custom maker object directly (and only using makers with
`use_list=0`).