### PR TITLE
vim: do not enable neomake_checks by default

### DIFF
--- a/autoload/neomake/makers/ft/vim.vim
+++ b/autoload/neomake/makers/ft/vim.vim
@@ -1,13 +1,5 @@
 function! neomake#makers#ft#vim#EnabledMakers(options) abort
-    let makers = ['vint']
-
-    " Add neomake_checks for Neomake's own files.
-    let bufpath = fnamemodify(bufname(a:options.bufnr), ':p')
-    if bufpath[:len(s:neomake_root)-1] == s:neomake_root
-        call add(makers, 'neomake_checks')
-    endif
-
-    return makers
+    return ['vint']
 endfunction
 
 let s:slash = neomake#utils#Slash()

--- a/autoload/neomake/makers/ft/vim.vim
+++ b/autoload/neomake/makers/ft/vim.vim
@@ -1,4 +1,4 @@
-function! neomake#makers#ft#vim#EnabledMakers(options) abort
+function! neomake#makers#ft#vim#EnabledMakers() abort
     return ['vint']
 endfunction
 


### PR DESCRIPTION
It should only look at (versioned) files in (autoload|plugin)/, but is
not really worth it in general.