### PR TITLE
automake: restart: compare tick

### DIFF
--- a/autoload/neomake/configure.vim
+++ b/autoload/neomake/configure.vim
@@ -96,7 +96,7 @@ endfunction
 function! s:handle_changed_buffer(make_id, event) abort
     " Cleanup always.
     if exists('b:_neomake_automake_changed_context')
-        let [make_id, prev_tick, changedtick, context] = b:_neomake_automake_changed_context
+        let [make_id, changedtick, context] = b:_neomake_automake_changed_context
 
         if changedtick == b:changedtick
             call s:debug_log(printf('handle_changed_buffer: %s: tick was not changed', a:event))
@@ -129,7 +129,7 @@ function! s:handle_changed_buffer(make_id, event) abort
         return
     endif
 
-    call setbufvar(context.bufnr, 'neomake_automake_tick', prev_tick)
+    call setbufvar(context.bufnr, 'neomake_automake_tick', changedtick)
     call filter(b:neomake_automake_make_ids, 'v:val != '.a:make_id)
     call s:update_cancel_rate(context.bufnr, 0)
 
@@ -215,7 +215,6 @@ function! s:neomake_do_automake(context) abort
     let event = a:context.event
 
     call s:debug_log('neomake_do_automake: '.event, {'bufnr': bufnr})
-    let prev_tick = getbufvar(bufnr, 'neomake_automake_tick')
     if !s:tick_changed({'event': event, 'bufnr': bufnr, 'ft': ft})
         call s:debug_log('buffer was not changed', {'bufnr': bufnr})
         return
@@ -243,7 +242,7 @@ function! s:neomake_do_automake(context) abort
                 call add(events, event)
             endif
         endfor
-        call setbufvar(bufnr, '_neomake_automake_changed_context', [make_id, prev_tick, a:context])
+        call setbufvar(bufnr, '_neomake_automake_changed_context', [make_id, getbufvar(bufnr, 'changedtick'), a:context])
         augroup neomake_automake_abort
             exe printf('au! * <buffer=%d>', bufnr)
             for event in events

--- a/autoload/neomake/configure.vim
+++ b/autoload/neomake/configure.vim
@@ -96,7 +96,7 @@ endfunction
 function! s:handle_changed_buffer(make_id, event) abort
     " Cleanup always.
     if exists('b:_neomake_automake_changed_context')
-        let [make_id, changedtick, context] = b:_neomake_automake_changed_context
+        let [make_id, prev_tick, changedtick, context] = b:_neomake_automake_changed_context
 
         if changedtick == b:changedtick
             call s:debug_log(printf('handle_changed_buffer: %s: tick was not changed', a:event))
@@ -129,7 +129,7 @@ function! s:handle_changed_buffer(make_id, event) abort
         return
     endif
 
-    call setbufvar(context.bufnr, 'neomake_automake_tick', changedtick)
+    call setbufvar(context.bufnr, 'neomake_automake_tick', prev_tick)
     call filter(b:neomake_automake_make_ids, 'v:val != '.a:make_id)
     call s:update_cancel_rate(context.bufnr, 0)
 
@@ -219,6 +219,7 @@ function! s:neomake_do_automake(context) abort
         call s:debug_log('buffer was not changed', {'bufnr': bufnr})
         return
     endif
+    let prev_tick = getbufvar(bufnr, 'neomake_automake_tick')
 
     call s:debug_log(printf('enabled makers: %s', join(map(copy(a:context.maker_jobs), 'v:val.maker.name'), ', ')))
     let make_options = {
@@ -242,7 +243,7 @@ function! s:neomake_do_automake(context) abort
                 call add(events, event)
             endif
         endfor
-        call setbufvar(bufnr, '_neomake_automake_changed_context', [make_id, getbufvar(bufnr, 'changedtick'), a:context])
+        call setbufvar(bufnr, '_neomake_automake_changed_context', [make_id, prev_tick, getbufvar(bufnr, 'changedtick'), a:context])
         augroup neomake_automake_abort
             exe printf('au! * <buffer=%d>', bufnr)
             for event in events

--- a/autoload/neomake/configure.vim
+++ b/autoload/neomake/configure.vim
@@ -96,7 +96,12 @@ endfunction
 function! s:handle_changed_buffer(make_id, event) abort
     " Cleanup always.
     if exists('b:_neomake_automake_changed_context')
-        let [make_id, prev_tick, context] = b:_neomake_automake_changed_context
+        let [make_id, prev_tick, changedtick, context] = b:_neomake_automake_changed_context
+
+        if changedtick == b:changedtick
+            call s:debug_log(printf('handle_changed_buffer: %s: tick was not changed', a:event))
+            return
+        endif
 
         if s:need_to_skip_first_textchanged && a:event ==# 'TextChanged'
             if !get(b:, '_neomake_seen_TextChanged', 0)

--- a/tests/automake.vader
+++ b/tests/automake.vader
@@ -1175,6 +1175,7 @@ Execute (automake: display of error with O during maker run (TextChanged)):
     " augroup still exists.
     Assert exists('#neomake_automake_abort')
     " Gets cleaned up on triggered autocmd without neomake_make_ids.
+    normal! o
     doautocmd TextChangedI
     Assert exists('#neomake_automake_abort')
     Assert !exists('#neomake_automake_abort#TextChanged')
@@ -1196,6 +1197,7 @@ Execute (automake: restarts (BufWritePost)):
     function! maker1.process_output(...)
       let s:error_count += 1
       if s:error_count == 1
+        normal! o
         doautocmd TextChangedI
         doautocmd TextChanged
       endif
@@ -1233,6 +1235,7 @@ Execute (automake: handles unexpected make_id):
 
     let maker1 = copy(g:error_maker)
     function! maker1.process_output(...)
+      normal! o
       doautocmd TextChangedI
       return [{'lnum': 1, 'text': 'error1'}]
     endfunction
@@ -1449,6 +1452,7 @@ Execute (automake: restart via non-TextChangedI with delay):
     AssertNeomakeMessage 'automake: increasing delay (1/0 canceled timers/makes, rate=1.20): 10 => 12/3000.'
 
     NeomakeTestsWaitForMessage '\Vautomake: started jobs:'
+    normal! o
     doautocmd TextChanged
     call NeomakeTestsHandleSecondTextChanged()
     AssertNeomakeMessage 'automake: buffer was changed (TextChanged), canceling make.'
@@ -1479,6 +1483,7 @@ Execute (automake: restart via non-TextChangedI without delay):
     NeomakeTestsWaitForMessage 'Running makers: sleep-maker (auto).'
 
     call NeomakeTestsSetVimMessagesMarker()
+    normal! o
     doautocmd TextChanged
     call NeomakeTestsHandleSecondTextChanged()
     AssertNeomakeMessage 'automake: restarting for original event (BufWritePost) without delay.', 3
@@ -1486,5 +1491,5 @@ Execute (automake: restart via non-TextChangedI without delay):
     AssertNeomakeMessage 'automake: neomake_do_automake: BufWritePost.', 3
 
     NeomakeTestsWaitForFinishedJobs
-    bwipe
+    bwipe!
   endif


### PR DESCRIPTION
This is needed to work around some Vim bug, where TextChanged is
triggered still when defined after/during BufWritePost handling.