### PR TITLE
tests/log.vader: losen delay

### DIFF
--- a/tests/log.vader
+++ b/tests/log.vader
@@ -17,7 +17,7 @@ Execute (neomake#log#debug writes to logfile always):
   sleep 10m
   call neomake#log#debug('msg4.', {})
   let logfile_msg = readfile(g:neomake_logfile)[-1]
-  Assert logfile_msg =~# '\v\d\d:\d\d:\d\d \d+ \[D \+0.0\d\] \[-.-:-:\d+\] msg4.$', 'Message does not match: '.logfile_msg
+  Assert logfile_msg =~# '\v\d\d:\d\d:\d\d \d+ \[D \+0.\d\d\] \[-.-:-:\d+\] msg4.$', 'Message does not match: '.logfile_msg
 
 Execute (neomake#log#debug unsets logfile in case of errors):
   Save g:neomake_logfile


### PR DESCRIPTION
Might take longer than 10ms (on CI):

    > [D +0.19]: [-.-:-:1] msg4.
      (319/654) [EXECUTE] (X) Message does not match: 18:31:44 85 [D +0.19] [-.-:-:1] msg4.