### PR TITLE
ada: use gnatc to check both syntax and semantics

### DIFF
--- a/autoload/neomake/makers/ft/ada.vim
+++ b/autoload/neomake/makers/ft/ada.vim
@@ -4,7 +4,7 @@ endfunction
 
 function! neomake#makers#ft#ada#gcc() abort
     return {
-        \ 'args': ['-c', '-x', 'ada', '-gnats'],
+        \ 'args': ['-c', '-x', 'ada', '-gnatc'],
         \ 'errorformat':
             \ '%-G%f:%s:,' .
             \ '%f:%l:%c: %m,' .


### PR DESCRIPTION
The -gnats flag only checks syntax which misses quite a few cases that
will result in a build failure.