### PR TITLE
Set permissions on temporary files

### DIFF
--- a/autoload/neomake/utils.vim
+++ b/autoload/neomake/utils.vim
@@ -508,6 +508,9 @@ endfunction
 
 function! neomake#utils#write_tempfile(bufnr, temp_file) abort
     call writefile(neomake#utils#get_buffer_lines(a:bufnr), a:temp_file, 'b')
+    if exists('*setfperm')
+        call setfperm(a:temp_file, 'rw-r--r--')
+    endif
 endfunction
 
 " Wrapper around fnamemodify that handles special buffers (e.g. fugitive).

--- a/autoload/neomake/utils.vim
+++ b/autoload/neomake/utils.vim
@@ -509,7 +509,11 @@ endfunction
 function! neomake#utils#write_tempfile(bufnr, temp_file) abort
     call writefile(neomake#utils#get_buffer_lines(a:bufnr), a:temp_file, 'b')
     if exists('*setfperm')
-        call setfperm(a:temp_file, 'rw-r--r--')
+        let perms = getfperm(bufname(+a:bufnr))
+        if empty(perms)
+            let perms = 'rw-------'
+        endif
+        call setfperm(a:temp_file, perms)
     endif
 endfunction
 

--- a/tests/tempfiles.vader
+++ b/tests/tempfiles.vader
@@ -20,7 +20,7 @@ Execute (Neomake uses temporary file for unsaved buffer):
     let make_info = values(neomake#GetStatus().make_info)[0]
     let temp_file = make_info.tempfiles[0]
     AssertEqual fnamemodify(temp_file, ':h:h'), fnamemodify(tempname(), ':h')
-    AssertEqual getfperm(temp_file), 'rw-r--r--'
+    AssertEqual getfperm(temp_file), 'rw-------'
     NeomakeTestsWaitForFinishedJobs
   endif
 
@@ -62,15 +62,67 @@ Execute (Uses temporary file for unreadable buffer):
   let b:neomake_neomake_tests_enabled_makers = ['true']
   let b:neomake_neomake_tests_true_tempfile_enabled = 1
 
+  if exists('*setfperm')
+    let s:validated = 0
+    function! s:validate_tempfile()
+      let s:validated = 1
+      let tempfile = g:neomake_hook_context.jobinfo.tempfile
+      AssertEqual getfperm(tempfile), 'rw-------'
+    endfunction
+    augroup neomake_tests
+      au User NeomakeJobFinished call s:validate_tempfile()
+    augroup END
+  endif
+
   RunNeomake
 
-  let bufnr = bufnr('%')
   AssertNeomakeMessage '\v^Using tempfile for unreadable buffer: "(.*)"', 3
   let tempfile_name = g:neomake_test_matchlist[1]
   AssertEqual fnamemodify(tempfile_name, ':t'), printf(
   \ '.doesnotexist@neomake_%d_%d', getpid(), neomake#GetStatus().last_make_id)
   AssertEqual fnamemodify(tempfile_name, ':h'), getcwd()
+  if exists('*setfperm')
+    AssertEqual s:validated, 1
+  endif
   bwipe
+
+Execute (Uses permissions of original file):
+  if !exists('*setfperm')
+    NeomakeTestsSkip 'no setfperm support.'
+  else
+    new
+    let fname = tempname()
+    call writefile([], fname)
+    call setfperm(fname, '---rw----')
+    exe 'edit '.fname
+
+    silent normal! O
+
+    set ft=neomake_tests
+    let b:neomake_neomake_tests_enabled_makers = ['true']
+    let b:neomake_neomake_tests_true_tempfile_enabled = 1
+
+    let s:validated = 0
+    function! s:validate_tempfile()
+      let tempfile = g:neomake_hook_context.jobinfo.tempfile
+      AssertEqual getfperm(tempfile), '---rw----'
+      let s:validated = 1
+    endfunction
+    augroup neomake_tests
+      au User NeomakeJobFinished call s:validate_tempfile()
+    augroup END
+
+    RunNeomake
+
+    AssertNeomakeMessage '\v^Using tempfile for modified buffer: "(.*)"', 3
+    let tempfile_name = g:neomake_test_matchlist[1]
+    AssertEqual glob(tempfile_name), ''
+    AssertEqual s:validated, 1
+
+    AssertEqual v:warningmsg, 'W10: Warning: Changing a readonly file'
+    let v:warningmsg = ''
+    bwipe!
+  endif
 
 Execute (Only 2nd maker uses temporary file):
   call g:NeomakeSetupAutocmdWrappers()


### PR DESCRIPTION
This patch sets the file permissions on temporary files to 0644, which I presume was the intention because there was a test testing this. I'm not sure if it is necessary to check if setfperm exists. It seems like it was added to vim quite recently, in 2016: https://github.com/vim/vim/commit/8049253b96838b3584600e5ad229abad37a95b10

fixes #2293