### PR TITLE
Fix s:ProcessPendingOutput with pending JSON output

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -1936,7 +1936,9 @@ function! s:ProcessPendingOutput(jobinfo, lines, source) abort
         call neomake#action_queue#remove(a:jobinfo, s:function('s:process_pending_output'))
     endif
 
-    call s:ProcessJobOutput(a:jobinfo, a:lines, a:source)
+    if !empty(a:lines)
+        call s:ProcessJobOutput(a:jobinfo, a:lines, a:source)
+    endif
 
     " Clean job if it had exited already.
     if !empty(a:jobinfo.pending_output)

--- a/tests/processing.vader
+++ b/tests/processing.vader
@@ -1094,3 +1094,24 @@ Execute (handles terminal mode, requeues for BufEnter/WinEnter):
     AssertEqual map(getloclist(0), 'v:val.text'), ['error']
     bwipe
   endif
+
+Execute (process_json with action queue / pending outputs):
+  let s:called = 0
+
+  let maker = NeomakeTestsCommandMaker('json-maker', 'echo ''{}''')
+  function! maker.process_json(context) abort dict
+    let s:called += 1
+    AssertEqual a:context.json, {}
+    return []
+  endfunction
+
+  call neomake#Make({'enabled_makers': [maker]})
+  norm! V
+  NeomakeTestsWaitForFinishedJobs
+  AssertNeomakeMessage "output on stdout: ['{}', ''].", 3
+  AssertNeomakeMessage 'Not processing output for mode "V".', 3
+  exe "norm! \<Esc>"
+  doautocmd CursorHold
+  AssertNeomakeMessage "Calling maker's process_json method with 0 JSON entries.", 3
+  AssertNeomakeMessage 'Processed 1 pending outputs.', 3
+  AssertEqual s:called, 1


### PR DESCRIPTION
Do not call `s:ProcessJobOutput` without new lines, but only pending
output.