### PR TITLE
tslint formatter output changed in 5.12.1?!

### DIFF
--- a/autoload/neomake/makers/ft/typescript.vim
+++ b/autoload/neomake/makers/ft/typescript.vim
@@ -24,7 +24,7 @@ endfunction
 
 function! neomake#makers#ft#typescript#tslint() abort
     let maker = {
-        \ 'errorformat': '%-G,%EERROR: %f[%l\, %c]: %m,%E%f[%l\, %c]: %m',
+        \ 'errorformat': '%EERROR: %f:%l:%c - %m,%WWARNING: %f:%l:%c - %m',
         \ }
     let config = neomake#utils#FindGlobFile('tsconfig.json')
     if !empty(config)


### PR DESCRIPTION
Hello
Thanks for your excellent work. I love neomake.
I normally use it to program in typescript
And I got that the tslint flashlight didn't show anything even though by console there were errors and warnings.
I took my time to review the problem and noticed that the output format of the error had changed.
I use one of the latest stable versions of tslint

Tslint 5.12.1

Output format in tslint
```
➜  test-tslint tslint --project tsconfig.json  

WARNING: /home/ender/workspace/test-tslint/test.ts:3:13 - Missing semicolon
WARNING: /home/ender/workspace/test-tslint/test.ts:5:1 - Calls to 'console.log' are not allowed.
```
Espero que sirva de algo y gracias

Translated with www.DeepL.com/Translator