### PR TITLE
typescript: tslint: handle new errorformat with 5.12.0

### DIFF
--- a/autoload/neomake/makers/ft/typescript.vim
+++ b/autoload/neomake/makers/ft/typescript.vim
@@ -29,10 +29,8 @@ function! neomake#makers#ft#typescript#tslint() abort
                 \ 'errorformat': '%-G,'
                     \ .'%EERROR: %f:%l:%c - %m,'
                     \ .'%WWARNING: %f:%l:%c - %m,'
-                    \ .'%E%f:%l:%c - %m,'
                     \ .'%EERROR: %f[%l\, %c]: %m,'
-                    \ .'%WWARNING: %f[%l\, %c]: %m,'
-                    \ .'%E%f[%l\, %c]: %m',
+                    \ .'%WWARNING: %f[%l\, %c]: %m',
                 \ }
     let config = neomake#utils#FindGlobFile('tsconfig.json')
     if !empty(config)

--- a/autoload/neomake/makers/ft/typescript.vim
+++ b/autoload/neomake/makers/ft/typescript.vim
@@ -23,12 +23,16 @@ function! neomake#makers#ft#typescript#tsc() abort
 endfunction
 
 function! neomake#makers#ft#typescript#tslint() abort
+    " NOTE: output format changed in tslint 5.12.0.
     let maker = {
                 \ 'args': ['-t', 'prose'],
                 \ 'errorformat': '%-G,'
-                \ .'%EERROR: %f[%l\, %c]: %m,'
-                \ .'%WWARNING: %f[%l\, %c]: %m,'
-                \ .'%E%f[%l\, %c]: %m',
+                    \ .'%EERROR: %f:%l:%c - %m,'
+                    \ .'%WWARNING: %f:%l:%c - %m,'
+                    \ .'%E%f:%l:%c - %m,'
+                    \ .'%EERROR: %f[%l\, %c]: %m,'
+                    \ .'%WWARNING: %f[%l\, %c]: %m,'
+                    \ .'%E%f[%l\, %c]: %m',
                 \ }
     let config = neomake#utils#FindGlobFile('tsconfig.json')
     if !empty(config)

--- a/tests/ft_typescript.vader
+++ b/tests/ft_typescript.vader
@@ -10,7 +10,9 @@ Execute (typescript: tslint):
   let output = [
     \ '',
     \ "WARNING: t.ts[1, 1]: Calls to 'console.log' are not allowed.",
-    \ "ERROR: t.ts[7, 15]: Missing semicolon",
+    \ "ERROR: t.ts[1, 15]: Missing semicolon",
+    \ "WARNING: t.ts:2:1 - Calls to 'console.log' are not allowed.",
+    \ "ERROR: t.ts:2:15 - Missing semicolon",
     \ '',
     \ ]
   lgetexpr join(output, "\n")
@@ -26,7 +28,7 @@ Execute (typescript: tslint):
   \ 'pattern': '',
   \ 'text': 'Calls to ''console.log'' are not allowed.'
   \ }, {
-  \ 'lnum': 7,
+  \ 'lnum': 1,
   \ 'bufnr': bufnr('%'),
   \ 'col': 15,
   \ 'valid': 1,
@@ -34,7 +36,28 @@ Execute (typescript: tslint):
   \ 'nr': -1,
   \ 'type': 'E',
   \ 'pattern': '',
-  \ 'text': 'Missing semicolon'}]
+  \ 'text': 'Missing semicolon',
+  \ }, {
+  \ 'lnum': 2,
+  \ 'bufnr': bufnr('%'),
+  \ 'col': 1,
+  \ 'valid': 1,
+  \ 'vcol': 0,
+  \ 'nr': -1,
+  \ 'type': 'W',
+  \ 'pattern': '',
+  \ 'text': 'Calls to ''console.log'' are not allowed.'
+  \ }, {
+  \ 'lnum': 2,
+  \ 'bufnr': bufnr('%'),
+  \ 'col': 15,
+  \ 'valid': 1,
+  \ 'vcol': 0,
+  \ 'nr': -1,
+  \ 'type': 'E',
+  \ 'pattern': '',
+  \ 'text': 'Missing semicolon',
+  \ }]
   bwipe
 
 Execute (typescript: tsc):


### PR DESCRIPTION
Fixes https://github.com/neomake/neomake/pull/2307.