### PR TITLE
ci: codecov: do not use flags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,9 +20,11 @@ common: &common
 
           # Upload to codecov, which handles this per job itself.
           coverage xml
+          # Env for codecov.
+          VIM=${CIRCLE_JOB%%-*}
           # -Z: exit with 1 in case of failures.
           codecov -Z -X search -X gcov -X pycov -f coverage.xml \
-            -n "$CIRCLE_JOB" -F ${CIRCLE_JOB%%-*},${CIRCLE_JOB//[-.]/}
+            -n "$CIRCLE_JOB" -e VIM,CIRCLE_JOB
           set +x
     - persist_to_workspace:
         root: .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ common: &common
           coverage xml
           # -Z: exit with 1 in case of failures.
           codecov -Z -X search -X gcov -X pycov -f coverage.xml \
-            -n "$CIRCLE_JOB" -F "$VIM" -e CIRCLE_JOB
+            -n "$CIRCLE_JOB" -F "${CIRCLE_JOB%%-*}" -e CIRCLE_JOB
           set +x
     - persist_to_workspace:
         root: .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ common: &common
           VIM=${CIRCLE_JOB%%-*}
           # -Z: exit with 1 in case of failures.
           codecov -Z -X search -X gcov -X pycov -f coverage.xml \
-            -n "$CIRCLE_JOB" -e VIM,CIRCLE_JOB
+            -n "$CIRCLE_JOB" -F "$VIM" -e VIM,CIRCLE_JOB
           set +x
     - persist_to_workspace:
         root: .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,12 +20,9 @@ common: &common
 
           # Upload to codecov, which handles this per job itself.
           coverage xml
-          # Env for codecov.
-          VIM=${CIRCLE_JOB%%-*}
-          export VIM
           # -Z: exit with 1 in case of failures.
           codecov -Z -X search -X gcov -X pycov -f coverage.xml \
-            -n "$CIRCLE_JOB" -F "$VIM" -e VIM,CIRCLE_JOB
+            -n "$CIRCLE_JOB" -F "$VIM" -e CIRCLE_JOB
           set +x
     - persist_to_workspace:
         root: .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,7 @@ common: &common
           coverage xml
           # Env for codecov.
           VIM=${CIRCLE_JOB%%-*}
+          export VIM
           # -Z: exit with 1 in case of failures.
           codecov -Z -X search -X gcov -X pycov -f coverage.xml \
             -n "$CIRCLE_JOB" -F "$VIM" -e VIM,CIRCLE_JOB


### PR DESCRIPTION
Those appear to trigger timeouts with Codecov's backend.  Use env vars
instead.