### PR TITLE
Avoid using same color as Normal bg for signs

### DIFF
--- a/autoload/neomake/signs.vim
+++ b/autoload/neomake/signs.vim
@@ -256,7 +256,13 @@ endfunction
 
 function! neomake#signs#DefineHighlights() abort
     let ctermbg = neomake#utils#GetHighlight('SignColumn', 'bg')
+    if ctermbg ==# 'NONE'
+        let ctermbg =  neomake#utils#GetHighlight('Normal', 'bg')
+    endif
     let guibg = neomake#utils#GetHighlight('SignColumn', 'bg#')
+    if guibg ==# 'NONE'
+        let guibg = neomake#utils#GetHighlight('Normal', 'bg#')
+    endif
     let bg = 'ctermbg='.ctermbg.' guibg='.guibg
 
     for [group, fg_from] in items({


### PR DESCRIPTION
Hello, I'm using this [vim-one](https://github.com/rakr/vim-one) colorscheme and the error sign is using the same background as color, so maybe we can do the same as for gotham colorscheme:

Before:

<img width="1061" alt="before" src="https://user-images.githubusercontent.com/1817522/53211619-1fc11600-3642-11e9-9b4a-defe7c5edb95.png">

After:

<img width="1056" alt="after" src="https://user-images.githubusercontent.com/1817522/53211621-23549d00-3642-11e9-810a-158e2db2324c.png">

I guess this same problem can happen with other colorschemes so this should be a "generic solution", but I'm not sure if maybe I'm missing something since I'm not familiarized with vim script.

Thanks!