### PR TITLE
signs: fix/improve neomake#signs#DefineHighlights

### DIFF
--- a/autoload/neomake/signs.vim
+++ b/autoload/neomake/signs.vim
@@ -255,8 +255,9 @@ function! neomake#signs#RedefineInfoSign(...) abort
 endfunction
 
 function! neomake#signs#DefineHighlights() abort
-    let ctermbg = neomake#utils#GetHighlight('SignColumn', 'bg')
-    let guibg = neomake#utils#GetHighlight('SignColumn', 'bg#')
+    " Use background from SignColumn.
+    let ctermbg = neomake#utils#GetHighlight('SignColumn', 'bg', 'Normal')
+    let guibg = neomake#utils#GetHighlight('SignColumn', 'bg#', 'Normal')
     let bg = 'ctermbg='.ctermbg.' guibg='.guibg
 
     for [group, fg_from] in items({
@@ -266,14 +267,17 @@ function! neomake#signs#DefineHighlights() abort
                 \ 'NeomakeMessageSign': ['ModeMsg', 'fg']
                 \ })
         let [fg_group, fg_attr] = fg_from
-        let ctermfg = neomake#utils#GetHighlight(fg_group, fg_attr)
-        let guifg = neomake#utils#GetHighlight(fg_group, fg_attr.'#')
+        " NOTE: fg falls back to "Normal" always, not "SignColumn" inbetween.
+        let ctermfg = neomake#utils#GetHighlight(fg_group, fg_attr, 'Normal')
+        let guifg = neomake#utils#GetHighlight(fg_group, fg_attr.'#', 'Normal')
+
         " Ensure that we're not using SignColumn bg as fg (as with gotham
         " colorscheme, issue https://github.com/neomake/neomake/pull/659).
-        if ctermfg == ctermbg && guifg == guibg
-            let fg_attr = neomake#utils#ReverseSynIDattr(fg_attr)
-            let ctermfg = neomake#utils#GetHighlight(fg_group, fg_attr)
-            let guifg = neomake#utils#GetHighlight(fg_group, fg_attr.'#')
+        if ctermfg !=# 'NONE' && ctermfg ==# ctermbg
+            let ctermfg = neomake#utils#GetHighlight(fg_group, neomake#utils#ReverseSynIDattr(fg_attr))
+        endif
+        if guifg !=# 'NONE' && guifg ==# guibg
+            let guifg = neomake#utils#GetHighlight(fg_group, neomake#utils#ReverseSynIDattr(fg_attr).'#')
         endif
         exe 'hi '.group.'Default ctermfg='.ctermfg.' guifg='.guifg.' '.bg
         if !neomake#utils#highlight_is_defined(group)

--- a/autoload/neomake/utils.vim
+++ b/autoload/neomake/utils.vim
@@ -264,7 +264,8 @@ function! s:get_oldstyle_setting(key, maker, default, ft, bufnr, maker_only) abo
 endfunction
 
 " Get property from highlighting group.
-function! neomake#utils#GetHighlight(group, what) abort
+function! neomake#utils#GetHighlight(group, what, ...) abort
+    let fallback = a:0 ? a:1 : ''
     let reverse = synIDattr(synIDtrans(hlID(a:group)), 'reverse')
     let what = a:what
     if reverse
@@ -276,7 +277,12 @@ function! neomake#utils#GetHighlight(group, what) abort
         let val = synIDattr(synIDtrans(hlID(a:group)), what, 'cterm')
     endif
     if empty(val) || val == -1
-        let val = 'NONE'
+        if !empty(fallback)
+            " NOTE: this might still be NONE also for "Normal", with
+            " e.g. `vim -u NONE`.
+            return neomake#utils#GetHighlight(fallback, a:what)
+        endif
+        return 'NONE'
     endif
     return val
 endfunction

--- a/tests/include/init.vim
+++ b/tests/include/init.vim
@@ -305,7 +305,7 @@ function! g:NeomakeSetupAutocmdWrappers()
   augroup END
 endfunction
 
-command! -nargs=1 NeomakeTestsSkip call vader#log('SKIP: ' . <args>)
+command! -nargs=1 -bar NeomakeTestsSkip call vader#log('SKIP: ' . <args>)
 
 function! NeomakeAsyncTestsSetup()
   if neomake#has_async_support()

--- a/tests/isolated.vader
+++ b/tests/isolated.vader
@@ -10,3 +10,4 @@ Include: isolated/tempfiles-cleanup.vader
 Include: isolated/resets-ignore_automake_events.vader
 Include: isolated/completion-handles-throw.vader
 Include: isolated/statusline-highlights.vader
+Include: isolated/sign-highlights.vader

--- a/tests/isolated/sign-highlights.vader
+++ b/tests/isolated/sign-highlights.vader
@@ -1,0 +1,101 @@
+Include: ../include/setup.vader
+
+Execute (neomake#signs#DefineHighlights: SignColumn bg=NONE):
+  hi clear Error
+  hi clear Normal
+  hi clear LineNr
+  highlight LineNr ctermfg=250 guifg=#c2c2c3
+  highlight! link SignColumn LineNr
+  AssertEqual neomake#utils#GetHighlight('SignColumn', 'bg'), 'NONE'
+  AssertEqual neomake#utils#GetHighlight('SignColumn', 'bg', 'Normal'), 'NONE'
+
+  " Normal and Error are not defined.
+  call neomake#signs#DefineHighlights()
+  let highlights = sort(filter(split(neomake#utils#redir('hi'), '\n'),
+  \ 'v:val =~# ''^NeomakeErrorSignDefault'''))
+  AssertEqual highlights, [
+  \ 'NeomakeErrorSignDefault xxx cleared',
+  \ ]
+
+  " Normal is not defined, only fg for Error.
+  highlight Error ctermfg=166 guifg=#e45649
+
+  call neomake#signs#DefineHighlights()
+  let highlights = sort(filter(split(neomake#utils#redir('hi'), '\n'),
+  \ 'v:val =~# ''^NeomakeErrorSignDefault'''))
+  AssertEqual highlights, [
+  \ 'NeomakeErrorSignDefault xxx cleared',
+  \ ]
+
+  highlight Normal ctermfg=23 ctermbg=255 guifg=#494b53 guibg=#fafafa
+  AssertEqual neomake#utils#GetHighlight('SignColumn', 'bg', 'Normal'), '255'
+
+  call neomake#signs#DefineHighlights()
+  let highlights = sort(filter(split(neomake#utils#redir('hi'), '\n'),
+  \ 'v:val =~# ''^NeomakeError'''))
+
+  AssertEqual highlights, [
+  \ 'NeomakeError   xxx links to SpellBad',
+  \ 'NeomakeErrorSign xxx links to NeomakeErrorSignDefault',
+  \ 'NeomakeErrorSignDefault xxx ctermfg=166 ctermbg=255 guifg=#e45649 guibg=#fafafa',
+  \ ]
+
+Execute (neomake#signs#DefineHighlights with "NONE" SignColumn, no Normal):
+  hi clear Normal
+  hi clear SignColumn
+  highlight SignColumn ctermfg=250 guifg=#c2c2c3
+  highlight Error cterm=bold ctermfg=166 ctermbg=255 gui=bold guifg=#e45649 guibg=#fafafa
+
+  call neomake#signs#DefineHighlights()
+  let highlights = sort(filter(split(neomake#utils#redir('hi'), '\n'),
+  \ 'v:val =~# ''^NeomakeErrorSignDefault'''))
+
+  AssertEqual highlights, [
+  \ 'NeomakeErrorSignDefault xxx ctermfg=255 guifg=#fafafa',
+  \ ]
+
+Execute (neomake#signs#DefineHighlights: checks same gui bg/fg separately):
+  hi clear Normal
+  highlight Normal ctermbg=1 guibg=#aaaaaa
+  if substitute(neomake#utils#redir('hi Normal'), '^\s+', '', '') !=# 'Normal         xxx ctermbg=1 guibg=#aaaaaa'
+    NeomakeTestsSkip 'Setting ctermbg on Normal is buggy'  " nvim 0.1.7
+  else
+    hi clear Error
+    hi clear SignColumn
+
+    call neomake#signs#DefineHighlights()
+    let highlights = sort(filter(split(neomake#utils#redir('hi'), '\n'),
+    \ 'v:val =~# ''^NeomakeErrorSignDefault'''))
+    AssertEqual highlights, [
+    \ 'NeomakeErrorSignDefault xxx ctermbg=1 guibg=#aaaaaa',
+    \ ]
+
+    highlight Error      ctermbg=1 guibg=#bbbbbb
+    call neomake#signs#DefineHighlights()
+    let highlights = sort(filter(split(neomake#utils#redir('hi'), '\n'),
+    \ 'v:val =~# ''^NeomakeErrorSignDefault'''))
+    AssertEqual highlights, [
+    \ 'NeomakeErrorSignDefault xxx ctermbg=1 guifg=#bbbbbb guibg=#aaaaaa',
+    \ ]
+
+    highlight SignColumn ctermbg=166 guifg=#bbbbbb
+    call neomake#signs#DefineHighlights()
+    let highlights = sort(filter(split(neomake#utils#redir('hi'), '\n'),
+    \ 'v:val =~# ''^NeomakeErrorSignDefault'''))
+    AssertEqual highlights, [
+    \ 'NeomakeErrorSignDefault xxx ctermfg=1 ctermbg=166 guifg=#bbbbbb guibg=#aaaaaa',
+    \ ]
+  endif
+
+Execute (neomake#signs#DefineHighlights: all NONE):
+  hi clear Error
+  hi clear Normal
+  hi clear SignColumn
+
+  call neomake#signs#DefineHighlights()
+  let highlights = sort(filter(split(neomake#utils#redir('hi'), '\n'),
+  \ 'v:val =~# ''^NeomakeErrorSignDefault'''))
+
+  AssertEqual highlights, [
+  \ 'NeomakeErrorSignDefault xxx cleared',
+  \ ]


### PR DESCRIPTION
Fallback to "Normal" highlight if there is no background for
"SignColumn".

Fixes https://github.com/neomake/neomake/pull/2316.

TODO:

- [ ] revisit tests