### PR TITLE
Add underscore to private automake buffer vars

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -1497,10 +1497,10 @@ function! s:do_clean_make_info(make_info) abort
         exe 'silent bwipeout '.join(wipe_unlisted_buffers)
     endif
 
-    let buf_prev_makes = getbufvar(a:make_info.options.bufnr, 'neomake_automake_make_ids')
+    let buf_prev_makes = getbufvar(a:make_info.options.bufnr, '_neomake_automake_make_ids')
     if !empty(buf_prev_makes)
         call filter(buf_prev_makes, 'v:val != make_id')
-        call setbufvar(a:make_info.options.bufnr, 'neomake_automake_make_ids', buf_prev_makes)
+        call setbufvar(a:make_info.options.bufnr, '_neomake_automake_make_ids', buf_prev_makes)
     endif
 
     unlet s:make_info[make_id]

--- a/tests/automake.vader
+++ b/tests/automake.vader
@@ -556,12 +556,12 @@ Execute (BufWritePost does not run for unchanged buffer):
 
   CallNeomake 1, []
   AssertEqual len(g:neomake_test_jobfinished), 1
-  Assert !exists('b:neomake_automake_tick')
+  Assert !exists('b:_neomake_automake_tick')
 
   exe 'w' tempname()
   NeomakeTestsWaitForFinishedJobs
   AssertEqual len(g:neomake_test_jobfinished), 2
-  Assert exists('b:neomake_automake_tick')
+  Assert exists('b:_neomake_automake_tick')
 
   w
   NeomakeTestsWaitForFinishedJobs
@@ -637,7 +637,7 @@ Execute (Automake stops previous jobs):
     call NeomakeTestsHandleSecondTextChanged()
     NeomakeTestsWaitForMessage '\vautomake: callback for timer \d+'
     let first_make_id = neomake#GetStatus().last_make_id
-    AssertEqual [first_make_id], b:neomake_automake_make_ids
+    AssertEqual [first_make_id], b:_neomake_automake_make_ids
 
     normal! ifoo
     doautocmd TextChanged
@@ -647,7 +647,7 @@ Execute (Automake stops previous jobs):
     AssertNeomakeMessage '\Vautomake: started timer (15ms):'
     NeomakeTestsWaitForMessage '\vautomake: callback for timer \d+'
     let second_make_id = neomake#GetStatus().last_make_id
-    Assert index(b:neomake_automake_make_ids, second_make_id) > -1, 'Second make is registered'
+    Assert index(b:_neomake_automake_make_ids, second_make_id) > -1, 'Second make is registered'
     NeomakeTestsWaitForFinishedJobs
     bwipe!
   endif


### PR DESCRIPTION
- b:_neomake_automake_make_ids
- b:_neomake_automake_tick

This way they will not show up with `b:neomake_<tab>`.