### PR TITLE
hide [no test files] line for go maker

### DIFF
--- a/autoload/neomake/makers/ft/go.vim
+++ b/autoload/neomake/makers/ft/go.vim
@@ -16,6 +16,8 @@ function! neomake#makers#ft#go#go() abort
             \ 'test', '-c',
             \ '-o', g:neomake#compat#dev_null,
         \ ],
+        \ 'output_stream': 'stdout',
+        \ 'filter_output': function('neomake#makers#ft#go#FilterNoTestFiles'),
         \ 'append_file': 0,
         \ 'cwd': '%:h',
         \ 'serialize': 1,
@@ -29,6 +31,12 @@ function! neomake#makers#ft#go#go() abort
         \ 'postprocess': function('neomake#postprocess#compress_whitespace'),
         \ 'version_arg': 'version',
         \ }
+endfunction
+
+function! neomake#makers#ft#go#FilterNoTestFiles(lines, context) abort
+    if a:context.source ==# 'stdout'
+        call filter(a:lines, "v:val !~# '\\[no test files\\]'")
+    endif
 endfunction
 
 function! neomake#makers#ft#go#golint() abort

--- a/tests/ft_go.vader
+++ b/tests/ft_go.vader
@@ -32,3 +32,15 @@ Execute (go: gometalinter):
   \ {'lnum': 17, 'bufnr': bufnr('%'), 'col': 0, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': 'w', 'pattern': '', 'text': 'Subprocess launching with variable.,HIGH,HIGH (gas)'},
   \ ]
   bwipe
+
+Execute (go: golangci_lint):
+  new
+  file rain.go
+
+  let maker = NeomakeTestsGetMakerWithOutput(neomake#makers#ft#go#go(), [
+  \ '?   	github.com/cenkalti/rain/rainrpc	[no test files]',
+  \ ])
+  CallNeomake 1, [maker]
+
+  AssertEqual getloclist(0), []
+  bwipe

--- a/tests/ft_go.vader
+++ b/tests/ft_go.vader
@@ -22,7 +22,7 @@ Execute (go: go):
   \  .'/home/user/go/src/bytes (from $GOPATH)'}]
   bwipe
 
-Execute (go: gometalinter):
+Execute (go: go: filters "[no test files]"):
   new
   file git.go
 


### PR DESCRIPTION
When there are no test files, go command prints an output line similar to:
```
?   	github.com/cenkalti/rain/rainrpc	[no test files]
```

This line does not need to be visible on location list. This PR makes a change to hide that line.