### PR TITLE
s:HandleLoclistQflistDisplay: handle a:1 as default

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -973,11 +973,8 @@ endfunction
 let s:ignore_automake_events = 0
 " a:1: override "open_list" setting.
 function! s:HandleLoclistQflistDisplay(jobinfo, loc_or_qflist, ...) abort
-    if a:0
-        let open_val = a:1
-    else
-        let open_val = neomake#utils#GetSetting('open_list', a:jobinfo.maker, 0, a:jobinfo.ft, a:jobinfo.bufnr)
-    endif
+    let open_list_default = a:0 ? a:1 : 0
+    let open_val = neomake#utils#GetSetting('open_list', a:jobinfo.maker, open_list_default, a:jobinfo.ft, a:jobinfo.bufnr)
     if !open_val
         return
     endif


### PR DESCRIPTION
This is used with the experimental neomake#_handle_list_display wrapper,
which I am using myself, and it should not ignore
`b:neomake_open_list = 0`.