### PR TITLE
Add eslint to typescript markers

### DIFF
--- a/autoload/neomake/makers/ft/typescript.vim
+++ b/autoload/neomake/makers/ft/typescript.vim
@@ -39,3 +39,7 @@ function! neomake#makers#ft#typescript#tslint() abort
     endif
     return maker
 endfunction
+
+function! neomake#makers#ft#typescript#eslint() abort
+    return neomake#makers#ft#javascript#eslint()
+endfunction


### PR DESCRIPTION
eslint can now be used for typescript aswell, see: https://github.com/typescript-eslint/typescript-eslint