### PR TITLE
fix echo messages too long when there are double width characters

### DIFF
--- a/autoload/neomake/utils.vim
+++ b/autoload/neomake/utils.vim
@@ -35,7 +35,7 @@ endfunction
 function! neomake#utils#truncate_width(string, width) abort
     let pos = a:width
     while 1
-        let s = matchstr(a:string, '.\{,' . (pos-1) . '}', 0, 1)
+        let s = matchstr(a:string, '.\{,'.string(pos-1).'}', 0, 1)
         let w = strwidth(s)
         if w <= a:width
             return s

--- a/autoload/neomake/utils.vim
+++ b/autoload/neomake/utils.vim
@@ -33,7 +33,7 @@ function! neomake#utils#Stringify(obj) abort
 endfunction
 
 function! neomake#utils#truncate_width(string, width) abort
-    let pos = a:width - 1
+    let pos = a:width
     while 1
         let s = matchstr(a:string, '.\{,'.pos.'}', 0, 1)
         let w = strwidth(s)

--- a/autoload/neomake/utils.vim
+++ b/autoload/neomake/utils.vim
@@ -34,7 +34,7 @@ endfunction
 
 function! neomake#utils#truncate_width(string, width) abort
     let pos = a:width
-    while 1
+    while pos >= 0
         let s = matchstr(a:string, '.\{,'.pos.'}', 0, 1)
         let w = strwidth(s)
         if w <= a:width
@@ -42,6 +42,7 @@ function! neomake#utils#truncate_width(string, width) abort
         endif
         let pos -= max([(w-a:width)/2, 1])
     endwhile
+    return ''
 endfunction
 
 " This comes straight out of syntastic.

--- a/autoload/neomake/utils.vim
+++ b/autoload/neomake/utils.vim
@@ -35,7 +35,7 @@ endfunction
 function! neomake#utils#truncate_width(string, width) abort
     let pos = a:width
     while 1
-        let s = matchstr(a:string, '.\{,'.(pos-1).'}', 0, 1)
+        let s = matchstr(a:string, '.\{,' . (pos-1) . '}', 0, 1)
         let w = strwidth(s)
         if w <= a:width
             return s

--- a/autoload/neomake/utils.vim
+++ b/autoload/neomake/utils.vim
@@ -32,8 +32,16 @@ function! neomake#utils#Stringify(obj) abort
     endif
 endfunction
 
-function! neomake#utils#wstrpart(mb_string, start, len) abort
-    return matchstr(a:mb_string, '.\{,'.a:len.'}', 0, a:start+1)
+function! neomake#utils#truncate_width(string, width) abort
+    let pos = a:width
+    while 1
+        let s = matchstr(a:string, '.\{,'.(pos-1).'}', 0, 1)
+        let w = strwidth(s)
+        if w <= a:width
+            return s
+        endif
+        let pos -= w - a:width
+    endwhile
 endfunction
 
 " This comes straight out of syntastic.
@@ -50,7 +58,7 @@ function! neomake#utils#WideMessage(msg) abort " {{{2
     "width as the proper amount of characters
     let chunks = split(msg, "\t", 1)
     let msg = join(map(chunks[:-2], "v:val . repeat(' ', &tabstop - strwidth(v:val) % &tabstop)"), '') . chunks[-1]
-    let msg = neomake#utils#wstrpart(msg, 0, &columns - 1)
+    let msg = neomake#utils#truncate_width(msg, &columns-1)
 
     set noruler noshowcmd
     redraw

--- a/autoload/neomake/utils.vim
+++ b/autoload/neomake/utils.vim
@@ -40,7 +40,7 @@ function! neomake#utils#truncate_width(string, width) abort
         if w <= a:width
             return s
         endif
-        let pos -= w - a:width
+        let pos -= max([(w-a:width)/2, 1])
     endwhile
 endfunction
 

--- a/autoload/neomake/utils.vim
+++ b/autoload/neomake/utils.vim
@@ -33,9 +33,9 @@ function! neomake#utils#Stringify(obj) abort
 endfunction
 
 function! neomake#utils#truncate_width(string, width) abort
-    let pos = a:width
+    let pos = a:width - 1
     while 1
-        let s = matchstr(a:string, '.\{,'.string(pos-1).'}', 0, 1)
+        let s = matchstr(a:string, '.\{,'.pos.'}', 0, 1)
         let w = strwidth(s)
         if w <= a:width
             return s

--- a/tests/utils.vader
+++ b/tests/utils.vader
@@ -438,6 +438,9 @@ Execute (neomake#utils#diff_dict):
     \ {'changed': {'a': [[], {}]}}
 
 Execute (neomake#utils#truncate_width):
+  AssertEqual neomake#utils#truncate_width('', 0), ''
+  AssertEqual neomake#utils#truncate_width('', -1), ''
+
   AssertEqual neomake#utils#truncate_width('123', 0), ''
   AssertEqual neomake#utils#truncate_width('123', 1), '1'
   AssertEqual neomake#utils#truncate_width('123', 2), '12'
@@ -450,9 +453,9 @@ Execute (neomake#utils#truncate_width):
   AssertEqual neomake#utils#truncate_width('长长的。', 4), '长长'
   AssertEqual neomake#utils#truncate_width('长长的。', 10), '长长的。'
 
-  AssertEqual neomake#utils#truncate_width('abc。', 4), 'abc'
-  AssertEqual neomake#utils#truncate_width('abc。', 5), 'abc。'
-  AssertEqual neomake#utils#truncate_width('abc。xyz', 6), 'abc。x'
+  AssertEqual neomake#utils#truncate_width('abc😄', 4), 'abc'
+  AssertEqual neomake#utils#truncate_width('abc😄', 5), 'abc😄'
+  AssertEqual neomake#utils#truncate_width('abc😄xyz', 6), 'abc😄x'
 
 Execute (neomake#utils#sort_by_col):
   function! s:sort(l)

--- a/tests/utils.vader
+++ b/tests/utils.vader
@@ -444,15 +444,15 @@ Execute (neomake#utils#truncate_width):
   AssertEqual neomake#utils#truncate_width('123', 3), '123'
   AssertEqual neomake#utils#truncate_width('123', 4), '123'
 
-  AssertEqual neomake#utils#truncate_width('长长的…', 1), ''
-  AssertEqual neomake#utils#truncate_width('长长的…', 2), '长'
-  AssertEqual neomake#utils#truncate_width('长长的…', 3), '长'
-  AssertEqual neomake#utils#truncate_width('长长的…', 4), '长长'
-  AssertEqual neomake#utils#truncate_width('长长的…', 10), '长长的…'
+  AssertEqual neomake#utils#truncate_width('长长的。', 1), ''
+  AssertEqual neomake#utils#truncate_width('长长的。', 2), '长'
+  AssertEqual neomake#utils#truncate_width('长长的。', 3), '长'
+  AssertEqual neomake#utils#truncate_width('长长的。', 4), '长长'
+  AssertEqual neomake#utils#truncate_width('长长的。', 10), '长长的。'
 
-  AssertEqual neomake#utils#truncate_width('abc…', 4), 'abc'
-  AssertEqual neomake#utils#truncate_width('abc…', 5), 'abc…'
-  AssertEqual neomake#utils#truncate_width('abc…xyz', 6), 'abc…x'
+  AssertEqual neomake#utils#truncate_width('abc。', 4), 'abc'
+  AssertEqual neomake#utils#truncate_width('abc。', 5), 'abc。'
+  AssertEqual neomake#utils#truncate_width('abc。xyz', 6), 'abc。x'
 
 Execute (neomake#utils#sort_by_col):
   function! s:sort(l)

--- a/tests/utils.vader
+++ b/tests/utils.vader
@@ -453,9 +453,9 @@ Execute (neomake#utils#truncate_width):
   AssertEqual neomake#utils#truncate_width('长长的。', 4), '长长'
   AssertEqual neomake#utils#truncate_width('长长的。', 10), '长长的。'
 
-  AssertEqual neomake#utils#truncate_width('abc😄', 4), 'abc'
-  AssertEqual neomake#utils#truncate_width('abc😄', 5), 'abc😄'
-  AssertEqual neomake#utils#truncate_width('abc😄xyz', 6), 'abc😄x'
+  AssertEqual neomake#utils#truncate_width('abc。', 4), 'abc'
+  AssertEqual neomake#utils#truncate_width('abc。', 5), 'abc。'
+  AssertEqual neomake#utils#truncate_width('abc。xyz', 6), 'abc。x'
 
 Execute (neomake#utils#sort_by_col):
   function! s:sort(l)

--- a/tests/utils.vader
+++ b/tests/utils.vader
@@ -437,17 +437,22 @@ Execute (neomake#utils#diff_dict):
   AssertEqual neomake#utils#diff_dict({'a': []}, {'a': {}}),
     \ {'changed': {'a': [[], {}]}}
 
-Execute (neomake#utils#wstrpart):
-  AssertEqual neomake#utils#wstrpart('123', 0, 0), ''
-  AssertEqual neomake#utils#wstrpart('123', 0, 1), '1'
-  AssertEqual neomake#utils#wstrpart('123', 0, 2), '12'
-  AssertEqual neomake#utils#wstrpart('123', 1, 2), '23'
-  AssertEqual neomake#utils#wstrpart('123', 1, 1), '2'
-  AssertEqual neomake#utils#wstrpart('123', 1, 0), ''
+Execute (neomake#utils#truncate_width):
+  AssertEqual neomake#utils#truncate_width('123', 0), ''
+  AssertEqual neomake#utils#truncate_width('123', 1), '1'
+  AssertEqual neomake#utils#truncate_width('123', 2), '12'
+  AssertEqual neomake#utils#truncate_width('123', 3), '123'
+  AssertEqual neomake#utils#truncate_width('123', 4), '123'
 
-  AssertEqual neomake#utils#wstrpart('…', 0, 1), '…'
-  AssertEqual neomake#utils#wstrpart('12…45', 1, 3), '2…4'
-  AssertEqual neomake#utils#wstrpart('…after', 1, 10), 'after'
+  AssertEqual neomake#utils#truncate_width('长长的…', 1), ''
+  AssertEqual neomake#utils#truncate_width('长长的…', 2), '长'
+  AssertEqual neomake#utils#truncate_width('长长的…', 3), '长'
+  AssertEqual neomake#utils#truncate_width('长长的…', 4), '长长'
+  AssertEqual neomake#utils#truncate_width('长长的…', 10), '长长的…'
+
+  AssertEqual neomake#utils#truncate_width('abc…', 4), 'abc'
+  AssertEqual neomake#utils#truncate_width('abc…', 5), 'abc…'
+  AssertEqual neomake#utils#truncate_width('abc…xyz', 6), 'abc…x'
 
 Execute (neomake#utils#sort_by_col):
   function! s:sort(l)


### PR DESCRIPTION
#895 fixed that a character was cut in the middle, but it may still be too long.