### PR TITLE
signs: change default for warning sign to "‼"

### DIFF
--- a/autoload/neomake/signs.vim
+++ b/autoload/neomake/signs.vim
@@ -216,7 +216,7 @@ function! neomake#signs#RedefineErrorSign(...) abort
 endfunction
 
 function! neomake#signs#RedefineWarningSign(...) abort
-    let default_opts = {'text': '⚠', 'texthl': 'NeomakeWarningSign'}
+    let default_opts = {'text': '‼', 'texthl': 'NeomakeWarningSign'}
     let opts = {}
     if a:0
         call extend(opts, a:1)


### PR DESCRIPTION
'DOUBLE EXCLAMATION MARK' (U+203C) is typically more visible than
'WARNING SIGN' (U+26A0), which would require the emoji variation
selector (U+fe0f) to render it in width 2, but that makes it wider than
the other defaults, and is not handled well in Neovim/Vim.

Ref: https://github.com/kovidgoyal/kitty/issues/1612
Ref: https://github.com/neovim/neovim/issues/7151