### PR TITLE
tests: do not use --embed with nvim in RPC based test

### DIFF
--- a/tests/compat.vader
+++ b/tests/compat.vader
@@ -78,7 +78,15 @@ Execute (neomake#compat#get_mode):
 
   if has('nvim')
     let nvim_exe = '/proc/'.getpid().'/exe'
-    let nvim = jobstart([nvim_exe, '-u', 'tests/vim/vimrc', '--headless', '--embed'], {'rpc': v:true})
+    let nvim_cmd = [nvim_exe, '-u', 'tests/vim/vimrc', '--headless']
+    if has('nvim-0.3.0')
+      " Do not use --embed, which might cause it to hang with hit-enter prompt
+      " due to `echom` (while debugging).  Requires Neovim 0.3.0+.
+      let nvim_cmd += ['--cmd', "call stdioopen({'rpc': v:true})"]
+    else
+      let nvim_cmd += ['--embed']
+    endif
+    let nvim = jobstart(nvim_cmd, {'rpc': v:true})
     call rpcrequest(nvim, 'nvim_call_function', 'feedkeys', ['d', '!'])
     call rpcrequest(nvim, 'nvim_eval', 'assert_equal(neomake#compat#get_mode(), "no")')
     let rpc_errors = rpcrequest(nvim, 'nvim_eval', 'v:errors')

--- a/tests/stdin.vader
+++ b/tests/stdin.vader
@@ -219,7 +219,7 @@ Execute (stdin maker: does not use buffer's cwd by default):
   bwipe
 
 Execute (stdin maker: can use buffer's cwd):
-  let maker = {'exe': 'true', 'name': 'flake8'}
+  let maker = {'exe': 'cat', 'name': 'flake8'}
   function maker.supports_stdin(jobinfo) abort
     call a:jobinfo.cd('%:h')
     return 1


### PR DESCRIPTION
Ref: https://github.com/neovim/neovim/issues/10031#issuecomment-493755631

With `--embed` it would hang with output during autoload, likely waiting
for an hit-enter prompt (e.g. with `for i in range(0, 10) | echom i | endfor`
in `autoload/neomake/highlights.vim`).

TODO:

- [x] does not work with nvim-0.1.7 - should be done conditionally then, based on the Neovim version where this started working.