### PR TITLE
neomake#utils#GetHighlight: use mode with reverse

### DIFF
--- a/autoload/neomake/utils.vim
+++ b/autoload/neomake/utils.vim
@@ -313,15 +313,16 @@ endfunction
 " Get property from highlighting group.
 function! neomake#utils#GetHighlight(group, what, ...) abort
     let fallback = a:0 ? a:1 : ''
-    let reverse = synIDattr(synIDtrans(hlID(a:group)), 'reverse')
+    let mode = a:what[-1:] ==# '#' ? 'gui' : 'cterm'
+    let reverse = synIDattr(synIDtrans(hlID(a:group)), 'reverse', mode)
     let what = a:what
     if reverse
         let what = neomake#utils#ReverseSynIDattr(what)
     endif
     if what[-1:] ==# '#'
-        let val = synIDattr(synIDtrans(hlID(a:group)), what, 'gui')
+        let val = synIDattr(synIDtrans(hlID(a:group)), what, mode)
     else
-        let val = synIDattr(synIDtrans(hlID(a:group)), what, 'cterm')
+        let val = synIDattr(synIDtrans(hlID(a:group)), what, mode)
     endif
     if empty(val) || val == -1
         if !empty(fallback)

--- a/tests/isolated/sign-highlights.vader
+++ b/tests/isolated/sign-highlights.vader
@@ -99,3 +99,15 @@ Execute (neomake#signs#DefineHighlights: all NONE):
   AssertEqual highlights, [
   \ 'NeomakeErrorSignDefault xxx cleared',
   \ ]
+
+Execute (neomake#utils#GetHighlight: correct mode with reverse):
+  highlight clear NeomakeTest
+  highlight NeomakeTest ctermfg=black guifg=black ctermbg=white guibg=white
+  AssertEqual neomake#utils#GetHighlight('NeomakeTest', 'fg'), '0'
+  AssertEqual neomake#utils#GetHighlight('NeomakeTest', 'fg#'), 'black'
+  highlight NeomakeTest cterm=reverse
+  AssertEqual neomake#utils#GetHighlight('NeomakeTest', 'fg'), '15'
+  AssertEqual neomake#utils#GetHighlight('NeomakeTest', 'fg#'), 'black'
+  highlight NeomakeTest cterm=NONE gui=reverse
+  AssertEqual neomake#utils#GetHighlight('NeomakeTest', 'fg'), '0'
+  AssertEqual neomake#utils#GetHighlight('NeomakeTest', 'fg#'), 'white'

--- a/tests/isolated/sign-highlights.vader
+++ b/tests/isolated/sign-highlights.vader
@@ -102,12 +102,14 @@ Execute (neomake#signs#DefineHighlights: all NONE):
 
 Execute (neomake#utils#GetHighlight: correct mode with reverse):
   highlight clear NeomakeTest
-  highlight NeomakeTest ctermfg=black guifg=black ctermbg=white guibg=white
+  highlight NeomakeTest ctermfg=0 guifg=black ctermbg=7 guibg=white
   AssertEqual neomake#utils#GetHighlight('NeomakeTest', 'fg'), '0'
   AssertEqual neomake#utils#GetHighlight('NeomakeTest', 'fg#'), 'black'
+
   highlight NeomakeTest cterm=reverse
-  AssertEqual neomake#utils#GetHighlight('NeomakeTest', 'fg'), '15'
+  AssertEqual neomake#utils#GetHighlight('NeomakeTest', 'fg'), '7'
   AssertEqual neomake#utils#GetHighlight('NeomakeTest', 'fg#'), 'black'
+
   highlight NeomakeTest cterm=NONE gui=reverse
   AssertEqual neomake#utils#GetHighlight('NeomakeTest', 'fg'), '0'
   AssertEqual neomake#utils#GetHighlight('NeomakeTest', 'fg#'), 'white'


### PR DESCRIPTION
Use the correct/explicit mode when testing for "reverse".