### PR TITLE
Use l: prefix with uppercase variable names (for possible function assignment)

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -523,7 +523,7 @@ endif
 let s:command_maker_base = copy(g:neomake#core#command_maker_base)
 " Check if a temporary file is used, and set it in s:make_info in case it is.
 function! s:command_maker_base._get_tempfilename(jobinfo) abort dict
-    let Supports_stdin = neomake#utils#GetSetting('supports_stdin', self, s:unset_dict, a:jobinfo.ft, a:jobinfo.bufnr)
+    let l:Supports_stdin = neomake#utils#GetSetting('supports_stdin', self, s:unset_dict, a:jobinfo.ft, a:jobinfo.bufnr)
     if Supports_stdin isnot s:unset_dict
         if type(Supports_stdin) == type(function('tr'))
             let supports_stdin = call(Supports_stdin, [a:jobinfo], self)
@@ -809,7 +809,7 @@ function! neomake#create_maker_object(maker, ft) abort
     let [maker, ft, bufnr] = [a:maker, a:ft, bufnr('%')]
 
     " Create the maker object.
-    let GetEntries = neomake#utils#GetSetting('get_list_entries', maker, -1, ft, bufnr)
+    let l:GetEntries = neomake#utils#GetSetting('get_list_entries', maker, -1, ft, bufnr)
     if GetEntries isnot# -1
         let maker = copy(maker)
         let maker.get_list_entries = GetEntries
@@ -2209,7 +2209,7 @@ function! s:exit_handler(jobinfo, data) abort
         endfor
 
         if !get(jobinfo, 'failed_to_start')
-            let ExitCallback = neomake#utils#GetSetting('exit_callback',
+            let l:ExitCallback = neomake#utils#GetSetting('exit_callback',
                         \ extend(copy(jobinfo), maker), 0, jobinfo.ft, jobinfo.bufnr)
             if ExitCallback isnot# 0
                 let callback_dict = { 'status': jobinfo.exit_code,
@@ -2217,7 +2217,7 @@ function! s:exit_handler(jobinfo, data) abort
                                     \ 'has_next': !empty(s:make_info[jobinfo.make_id].jobs_queue) }
                 try
                     if type(ExitCallback) == type('')
-                        let ExitCallback = function(ExitCallback)
+                        let l:ExitCallback = function(ExitCallback)
                     endif
                     call call(ExitCallback, [callback_dict], jobinfo)
                 catch

--- a/autoload/neomake/config.vim
+++ b/autoload/neomake/config.vim
@@ -111,9 +111,9 @@ function! neomake#config#get_with_source(name, ...) abort
             if source ==# 'maker'
                 let maker_prefixes = map(copy(prefixes), '!empty(v:val) && v:val[-1] ==# maker_name ? v:val[:-2] : v:val')
                 let maker_setting_parts = parts[0] == maker_name ? parts[1:] : parts
-                let [prefix, R] = s:get(lookup, maker_setting_parts, maker_prefixes)
+                let [prefix, l:R] = s:get(lookup, maker_setting_parts, maker_prefixes)
             else
-                let [prefix, R] = s:get(lookup, parts, prefixes)
+                let [prefix, l:R] = s:get(lookup, parts, prefixes)
             endif
             if R isnot# g:neomake#config#undefined
                 let log_name = join(map(copy(parts), "substitute(v:val, '\\.', '|', '')"), '.')

--- a/autoload/neomake/core.vim
+++ b/autoload/neomake/core.vim
@@ -38,12 +38,12 @@ function! neomake#core#instantiate_maker(maker, options, check_exe) abort
     let bufnr = get(options, 'bufnr', '')
 
     " Call InitForJob function in maker object, if any.
-    let Init = neomake#utils#GetSetting('InitForJob', maker, g:neomake#config#undefined, ft, bufnr)
+    let l:Init = neomake#utils#GetSetting('InitForJob', maker, g:neomake#config#undefined, ft, bufnr)
     if empty(Init)
         " Deprecated: should use InitForJob instead.
         if has_key(maker, 'fn')
             unlet Init  " vim73
-            let Init = maker.fn
+            let l:Init = maker.fn
             call neomake#log#warn_once(printf("Please use 'InitForJob' instead of 'fn' for maker %s.", maker.name),
                         \ printf('deprecated-fn-%s', maker.name))
         endif

--- a/autoload/neomake/debug.vim
+++ b/autoload/neomake/debug.vim
@@ -11,7 +11,7 @@ function! s:pprint(v, ...) abort
             return '{}'
         endif
         let r = "{\n"
-        for [k, V] in items(a:v)
+        for [k, l:V] in items(a:v)
             let r .= printf("%s  %s: %s,\n",
                         \ indent,
                         \ string(k),
@@ -102,7 +102,7 @@ function! s:get_maker_info(maker, ...) abort
     let maker_defaults = a:0 ? a:1 : {}
     let maker = a:maker
     let r = []
-    for [k, V] in sort(copy(items(maker)))
+    for [k, l:V] in sort(copy(items(maker)))
         if k !=# 'name' && k !=# 'ft' && k !~# '^_'
             if !has_key(maker_defaults, k)
                         \ || type(V) != type(maker_defaults[k])

--- a/autoload/neomake/list.vim
+++ b/autoload/neomake/list.vim
@@ -686,7 +686,7 @@ function! s:base_list.add_lines_with_efm(lines, jobinfo) dict abort
         endif
     endif
 
-    let Postprocess = neomake#utils#GetSetting('postprocess', maker, [], a:jobinfo.ft, a:jobinfo.bufnr)
+    let l:Postprocess = neomake#utils#GetSetting('postprocess', maker, [], a:jobinfo.ft, a:jobinfo.bufnr)
     if type(Postprocess) != type([])
         let postprocessors = [Postprocess]
     else
@@ -739,7 +739,7 @@ function! s:base_list.add_lines_with_efm(lines, jobinfo) dict abort
         if !empty(postprocessors)
             let g:neomake_postprocess_context = {'jobinfo': a:jobinfo}
             try
-                for F in postprocessors
+                for l:F in postprocessors
                     if type(F) == type({})
                         call call(F.fn, [entry], F)
                     else

--- a/autoload/neomake/utils.vim
+++ b/autoload/neomake/utils.vim
@@ -15,7 +15,7 @@ function! neomake#utils#Stringify(obj) abort
         return '['.join(ls, ', ').']'
     elseif type(a:obj) == type({})
         let ls = []
-        for [k, V] in items(neomake#utils#fix_self_ref(a:obj))
+        for [k, l:V] in items(neomake#utils#fix_self_ref(a:obj))
             if type(V) == type(function('tr'))
                 let fname = substitute(string(V), ', {\zs.*\ze})', '…', '')
                 call add(ls, k.': '.fname)
@@ -126,7 +126,7 @@ let s:super_ft_cache = {}
 function! neomake#utils#GetSupersetOf(ft) abort
     if !has_key(s:super_ft_cache, a:ft)
         call neomake#utils#load_ft_makers(a:ft)
-        let SupersetOf = 'neomake#makers#ft#'.a:ft.'#SupersetOf'
+        let l:SupersetOf = 'neomake#makers#ft#'.a:ft.'#SupersetOf'
         if exists('*'.SupersetOf)
             let s:super_ft_cache[a:ft] = call(SupersetOf, [])
         else
@@ -200,14 +200,14 @@ function! neomake#utils#GetSetting(key, maker, default, ft, bufnr, ...) abort
     " Check new-style config.
     if exists('g:neomake') || !empty(getbufvar(a:bufnr, 'neomake'))
         let context = {'ft': a:ft, 'maker': a:maker, 'bufnr': a:bufnr, 'maker_only': maker_only}
-        let [Ret, source] = neomake#config#get_with_source(a:key, g:neomake#config#undefined, context)
+        let [l:Ret, source] = neomake#config#get_with_source(a:key, g:neomake#config#undefined, context)
         " Check old-style setting when source is the maker.
         if source ==# 'maker' && !maker_only
             let tmpmaker = {}
             if has_key(a:maker, 'name')
                 let tmpmaker.name = a:maker.name
             endif
-            let RetOld = s:get_oldstyle_setting(a:key, tmpmaker, s:unset, a:ft, a:bufnr, 1)
+            let l:RetOld = s:get_oldstyle_setting(a:key, tmpmaker, s:unset, a:ft, a:bufnr, 1)
             if RetOld isnot# s:unset
                 return RetOld
             endif
@@ -241,7 +241,7 @@ function! s:get_oldstyle_setting(key, maker, default, ft, bufnr, maker_only) abo
         endif
         let config_var = 'neomake_'.part.'_'.a:key
         if a:bufnr isnot# ''
-            let Bufcfgvar = neomake#compat#getbufvar(a:bufnr, config_var, s:unset)
+            let l:Bufcfgvar = neomake#compat#getbufvar(a:bufnr, config_var, s:unset)
             if Bufcfgvar isnot s:unset
                 return copy(Bufcfgvar)
             endif

--- a/contrib/vim-checks
+++ b/contrib/vim-checks
@@ -111,7 +111,7 @@ check_errors ' \+$' 'Trailing whitespace'
 check_errors '^ * end\?i\? *$' 'Write endif, not en, end, or endi'
 check_errors '^((    )*([^ ]|$)|\s+\\)' 'Use four spaces for indentation' -v -E
 check_errors $'\t' 'Do not use tabs for indentation'
-check_errors '^\s*[^" ].*[^&]l:\w' 'Do not use l: prefix for local variables'
+check_errors '^\s*[^" ].*[^&]l:[a-z]' 'Do not use l: prefix for local variables'
 for arg in "${args[@]}"; do
     expand_arg "$arg"
     grep --files-without-match '^"[ ]vim: ts=4 sw=4 et' "${expanded_arg[@]}" \

--- a/tests/utils.vader
+++ b/tests/utils.vader
@@ -234,11 +234,11 @@ Execute (neomake#utils#GetSetting does not create a partial for dict funcs):
   function maker.func()
   endfunction
 
-  let Func = neomake#utils#GetSetting('func', maker, '', '', '', 1)
+  let l:Func = neomake#utils#GetSetting('func', maker, '', '', '', 1)
   AssertEqual type(Func), type(function('tr'))
   AssertEqual Func, get(maker, 'func')
 
-  let Func = neomake#utils#GetSetting('func', maker, '', '', '', 0)
+  let l:Func = neomake#utils#GetSetting('func', maker, '', '', '', 0)
   AssertEqual type(Func), type(function('tr'))
   AssertEqual Func, get(maker, 'func')
 


### PR DESCRIPTION
Would cause the following error with an existing function `F`:

> E705: Variable name conflicts with existing function: F.