### PR TITLE
Use neomake#jobinfo#new() for jobinfo objects

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -293,7 +293,7 @@ function! s:MakeJob(make_id, options) abort
     "                        1 for non-async)
     "  - serialize_abort_on_error (default: 0)
     "  - exit_callback (string/function, default: 0)
-    let jobinfo = extend(deepcopy(g:neomake#jobinfo#base), extend({
+    let jobinfo = extend(neomake#jobinfo#new(), extend({
         \ 'id': job_id,
         \ 'make_id': a:make_id,
         \ 'name': empty(get(a:options.maker, 'name', '')) ? 'neomake_'.job_id : a:options.maker.name,

--- a/autoload/neomake/debug.vim
+++ b/autoload/neomake/debug.vim
@@ -60,8 +60,9 @@ function! neomake#debug#validate_maker(maker) abort
         endif
     endfor
 
+    let jobinfo = neomake#jobinfo#new()
     try
-        let maker = neomake#core#instantiate_maker(a:maker, {}, 0)
+        let maker = neomake#core#instantiate_maker(a:maker, jobinfo, 0)
         if !executable(maker.exe)
             let t = get(maker, 'auto_enabled', 0) ? 'warnings' : 'errors'
             let issues[t] += [printf("maker's exe (%s) is not executable.", maker.exe)]

--- a/autoload/neomake/jobinfo.vim
+++ b/autoload/neomake/jobinfo.vim
@@ -1,6 +1,7 @@
 let s:jobinfo_base = {
             \ 'cd_back_cmd': '',
             \ 'pending_output': [],
+            \ 'file_mode': 1,
             \ }
 function! s:jobinfo_base.get_pid() abort
     if has_key(self, 'vim_job')
@@ -83,5 +84,10 @@ function! s:jobinfo_base.cd(...) abort
     return ''
 endfunction
 
-let g:neomake#jobinfo#base = s:jobinfo_base
+function! neomake#jobinfo#new() abort
+    let jobinfo = deepcopy(s:jobinfo_base)
+    let jobinfo.bufnr = bufnr('%')
+    return jobinfo
+endfunction
+
 " vim: ts=4 sw=4 et

--- a/tests/include/init.vim
+++ b/tests/include/init.vim
@@ -329,7 +329,7 @@ let s:jobinfo_count = 0
 function! NeomakeTestsFakeJobinfo() abort
   let s:jobinfo_count += 1
   let make_id = -42
-  let jobinfo = copy(g:neomake#jobinfo#base)
+  let jobinfo = neomake#jobinfo#new()
   let maker = copy(g:neomake#config#_defaults.maker_defaults)
   let maker.name = 'fake_jobinfo_name'
 

--- a/tests/jobinfo.vader
+++ b/tests/jobinfo.vader
@@ -17,7 +17,7 @@ Execute (jobinfo.get_pid):
 
 Execute (jobinfo.cd: handles/keeps trailing slash with root dir):
   new
-  let jobinfo = copy(g:neomake#jobinfo#base)
+  let jobinfo = neomake#jobinfo#new()
   let tmpdir = fnamemodify(tempname(), ':h')
   exe 'lcd '.tmpdir
   Assert haslocaldir()
@@ -48,7 +48,7 @@ Execute (jobinfo.cd: empty dir defaults to $HOME):
   let root = fnamemodify('/', ':p')
   exe 'lcd '.root
 
-  let jobinfo = copy(g:neomake#jobinfo#base)
+  let jobinfo = neomake#jobinfo#new()
   Assert !has_key(jobinfo, 'cwd')
 
   Save $HOME


### PR DESCRIPTION
This adds `file_mode` and `bufnr` there by default now.