### PR TITLE
automake: remove BufWritePost/changedtick workaround

### DIFF
--- a/autoload/neomake/configure.vim
+++ b/autoload/neomake/configure.vim
@@ -54,16 +54,6 @@ function! s:tick_changed(context) abort
             call s:debug_log('tick is unchanged')
             return 0
         endif
-
-        " NOTE: every write (BufWritePost) increments b:changedtick.
-        if a:context.event ==# 'BufWritePost'
-            let adjusted_prev_tick = [prev_tick[0]+1, prev_tick[1]]
-            if adjusted_prev_tick == cur_tick
-                let r = 0
-                call setbufvar(bufnr, '_neomake_automake_tick', adjusted_prev_tick)
-                call s:debug_log('tick is unchanged with BufWritePost adjustment')
-            endif
-        endif
     endif
     return r
 endfunction

--- a/tests/automake.vader
+++ b/tests/automake.vader
@@ -562,23 +562,14 @@ Execute (BufWritePost does not run for unchanged buffer):
   AssertEqual len(g:neomake_test_jobfinished), 2
   Assert exists('b:_neomake_automake_tick')
 
+  " Every write triggers a run (due to b:changedtick being incremented,
+  " https://github.com/vim/vim/issues/2764).
   w
-  AssertEqual len(g:neomake_test_jobfinished), 2
-  AssertNeomakeMessage 'automake: buffer was not changed.'
+  AssertEqual len(g:neomake_test_jobfinished), 3
 
   normal! ifoo
   w
-  AssertEqual len(g:neomake_test_jobfinished), 3
-
-  w
-  AssertEqual len(g:neomake_test_jobfinished), 3
-  AssertNeomakeMessage 'automake: buffer was not changed.'
-
-  normal! oline2
-  call neomake#Make(1, [])
   AssertEqual len(g:neomake_test_jobfinished), 4
-  w
-  AssertNeomakeMessage 'automake: buffer was not changed.'
 
   NeomakeTestsWaitForFinishedJobs
   AssertEqual len(g:neomake_test_jobfinished), 4
@@ -599,23 +590,17 @@ Execute (BufWritePost does not run for unchanged buffer (delayed)):
     NeomakeTestsWaitForNextFinishedJob
     AssertEqual len(g:neomake_test_jobfinished), 1
 
-    w
-    NeomakeTestsWaitForFinishedJobs
-    AssertEqual len(g:neomake_test_jobfinished), 1
-    AssertNeomakeMessage 'automake: buffer was not changed.'
-
-    normal! ifoo
+    " Every write triggers a run (due to b:changedtick being incremented,
+    " https://github.com/vim/vim/issues/2764).
     w
     NeomakeTestsWaitForNextFinishedJob
     AssertEqual len(g:neomake_test_jobfinished), 2
 
+    normal! ifoo
     w
-    AssertNeomakeMessage 'automake: buffer was not changed.'
-    w
-    AssertNeomakeMessage 'automake: buffer was not changed.'
+    NeomakeTestsWaitForNextFinishedJob
+    AssertEqual len(g:neomake_test_jobfinished), 3
 
-    NeomakeTestsWaitForFinishedJobs
-    AssertEqual len(g:neomake_test_jobfinished), 2
     bwipe
   endif
 

--- a/tests/automake.vader
+++ b/tests/automake.vader
@@ -1518,3 +1518,31 @@ Execute (automake: creates/handles single cleanup autocmd per buffer):
   call neomake#configure#reset_automake()
   Assert !exists('#neomake_automake_clean#BufWipeout')
   bwipe
+
+Execute (BufWritePost via doautocmd is handled (e.g. vim-fugitive)):
+  call g:NeomakeSetupAutocmdWrappers()
+  call neomake#configure#automake('w')
+
+  function! s:BufWriteCmd() abort
+    exe 'doautocmd BufWritePost '.expand('<amatch>')
+  endfunction
+  augroup neomake_tests
+    au BufWriteCmd * call s:BufWriteCmd()
+  augroup END
+
+  new
+  let b:neomake_test_enabledmakers = ['success_entry_maker']
+  set filetype=neomake_tests
+
+  exe 'w' tempname()
+  NeomakeTestsWaitForFinishedJobs
+  AssertEqual len(g:neomake_test_jobfinished), 1
+  Assert exists('b:_neomake_automake_tick')
+
+  " Setup tick for when :diffget was used (only changing it by one), in
+  " contrast to e.g. ":normal o".
+  let b:_neomake_automake_tick[0] = b:_neomake_automake_tick[0] - 1
+  setlocal modified
+  update
+  AssertEqual len(g:neomake_test_jobfinished), 2
+  bwipe!

--- a/tests/main.vader
+++ b/tests/main.vader
@@ -47,6 +47,7 @@ Include (Toggling): toggle.vader
 Include (Utils: project root): utils_projectroot.vader
 Include (Utils): utils.vader
 Include (Verbosity): verbosity.vader
+Include (Vim/Neovim behavior): vim_and_neovim_behavior.vader
 
 ~ Filetype specific
 Include (Asciidoc): ft_asciidoc.vader

--- a/tests/vim_and_neovim_behavior.vader
+++ b/tests/vim_and_neovim_behavior.vader
@@ -2,6 +2,7 @@
 Include: include/setup.vader
 
 Execute (Test Vim's b:changedtick behavior):
+  " https://github.com/vim/vim/issues/2764
   new
   let before = b:changedtick
   exe 'w' tempname()

--- a/tests/vim_and_neovim_behavior.vader
+++ b/tests/vim_and_neovim_behavior.vader
@@ -1,0 +1,64 @@
+" Tests for generic behavior in Vim/Neovim.
+Include: include/setup.vader
+
+Execute (Test Vim's b:changedtick behavior):
+  new
+  let before = b:changedtick
+  exe 'w' tempname()
+  AssertEqual before + 1, b:changedtick
+
+  let before = b:changedtick
+  w
+  AssertEqual before + 1, b:changedtick
+
+  let before = b:changedtick
+  update
+  AssertEqual before, b:changedtick
+
+  setlocal modified
+  let before = b:changedtick
+  update
+  AssertEqual before + 1, b:changedtick
+
+  let before = b:changedtick
+  normal! ochanged
+  AssertEqual before + 2, b:changedtick
+  update
+  AssertEqual before + 3, b:changedtick
+  bwipe
+
+
+  " Via BufWriteCmd / autocommands.
+  augroup neomake_tests
+    autocmd BufWritePost <buffer>
+  augroup END
+  function! s:BufWriteCmd() abort
+    exe "doautocmd BufWritePre expand('<amatch>')"
+    setlocal nomodified
+    exe "doautocmd BufWritePost expand('<amatch>')"
+  endfunction
+  new
+  augroup neomake_tests
+    au BufWriteCmd * call s:BufWriteCmd()
+  augroup END
+  let before = b:changedtick
+  exe 'w' tempname()
+  AssertEqual before, b:changedtick
+
+  w
+  AssertEqual before, b:changedtick
+
+  update
+  AssertEqual before, b:changedtick
+
+  setlocal modified
+  let before = b:changedtick
+  update
+  AssertEqual before, b:changedtick
+
+  let before = b:changedtick
+  normal! ochanged
+  AssertEqual before + 2, b:changedtick
+  update
+  AssertEqual before + 2, b:changedtick
+  bwipe


### PR DESCRIPTION
Due to https://github.com/vim/vim/issues/2764.