### PR TITLE
Improve behavior of virtualtext after disabling

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -1427,8 +1427,10 @@ function! s:clean_make_info(make_info, ...) abort
         endif
         call s:clean_for_new_make(a:make_info)
 
-        call neomake#EchoCurrentError(1)
-        call neomake#virtualtext#handle_current_error()
+        if exists('#neomake')
+            call neomake#EchoCurrentError(1)
+            call neomake#virtualtext#handle_current_error()
+        endif
 
         if get(a:make_info, 'canceled', 0)
             call neomake#log#debug('Skipping final processing for canceled make.', a:make_info)

--- a/autoload/neomake/cmd.vim
+++ b/autoload/neomake/cmd.vim
@@ -109,6 +109,7 @@ function! s:handle_disabled_status(scope, disabled) abort
                 augroup! neomake
             endif
             call neomake#configure#disable_automake()
+            call neomake#virtualtext#handle_current_error()
         else
             call neomake#setup#setup_autocmds()
         endif

--- a/autoload/neomake/virtualtext.vim
+++ b/autoload/neomake/virtualtext.vim
@@ -76,14 +76,14 @@ if exists('*nvim_create_namespace')  " Includes nvim_buf_set_virtual_text.
     let s:cur_virtualtext = []
 
     function! neomake#virtualtext#handle_current_error() abort
-        if !get(g:, 'neomake_virtualtext_current_error', 1)
-            return
-        endif
-
+        " Clean always.
         if !empty(s:cur_virtualtext)
             if bufexists(s:cur_virtualtext[0])
                 call nvim_buf_clear_highlight(s:cur_virtualtext[0], s:cur_virtualtext[1], 0, -1)
             endif
+        endif
+        if !get(g:, 'neomake_virtualtext_current_error', 1)
+            return
         endif
         let entry = neomake#get_nearest_error()
         if empty(entry)


### PR DESCRIPTION
Previously it would still display the error, but not clear it with
`:NeomakeDisable`.

Needs to be improved, but appears to be a good quick fix.

Ref: https://github.com/neomake/neomake/issues/2390