### PR TITLE
rust: cargo: fix type for entries with code

### DIFF
--- a/autoload/neomake/makers/ft/rust.vim
+++ b/autoload/neomake/makers/ft/rust.vim
@@ -130,7 +130,8 @@ function! neomake#makers#ft#rust#CargoProcessOutput(context) abort
 
         let decoded = neomake#compat#json_decode(line)
         let data = get(decoded, 'message', -1)
-        if type(data) != type({}) || empty(data['spans'])
+        if type(data) != type({}) || empty(get(data, 'spans', []))
+            " call neomake#log#debug(printf('cargo: ignoring input: %s.', line))
             continue
         endif
 

--- a/autoload/neomake/makers/ft/rust.vim
+++ b/autoload/neomake/makers/ft/rust.vim
@@ -135,16 +135,18 @@ function! neomake#makers#ft#rust#CargoProcessOutput(context) abort
         endif
 
         let error = {'maker_name': 'cargo'}
+
         let code_dict = get(data, 'code', -1)
-        if code_dict is g:neomake#compat#json_null
-            if get(data, 'level', '') ==# 'warning'
-                let error.type = 'W'
-            else
-                let error.type = 'E'
-            endif
-        else
+        if index(['E', 'W'], code_dict['code'][:0]) != -1
             let error.type = code_dict['code'][0]
-            let error.nr = code_dict['code'][1:]
+            let error.nr = str2nr(code_dict['code'][1:])
+        else
+            let level = get(data, 'level', -1)
+            if level != -1
+                let error.type = toupper(level[0])
+            else
+                let error.type = 'W'
+            endif
         endif
 
         let span = data.spans[0]

--- a/autoload/neomake/makers/ft/rust.vim
+++ b/autoload/neomake/makers/ft/rust.vim
@@ -137,7 +137,8 @@ function! neomake#makers#ft#rust#CargoProcessOutput(context) abort
         let error = {'maker_name': 'cargo'}
 
         let code_dict = get(data, 'code', -1)
-        if index(['E', 'W'], code_dict['code'][:0]) != -1
+        if code_dict isnot g:neomake#compat#json_null
+                    \ && index(['E', 'W'], code_dict['code'][0]) != -1
             let error.type = code_dict['code'][0]
             let error.nr = str2nr(code_dict['code'][1:])
         else

--- a/autoload/neomake/makers/ft/rust.vim
+++ b/autoload/neomake/makers/ft/rust.vim
@@ -138,17 +138,17 @@ function! neomake#makers#ft#rust#CargoProcessOutput(context) abort
         let error = {'maker_name': 'cargo'}
 
         let code_dict = get(data, 'code', -1)
-        if code_dict isnot g:neomake#compat#json_null
-                    \ && index(['E', 'W'], code_dict['code'][0]) != -1
-            let error.type = code_dict['code'][0]
-            let error.nr = str2nr(code_dict['code'][1:])
-        else
+        if code_dict is g:neomake#compat#json_null
+                    \ || index(['E', 'W'], code_dict['code'][0]) == -1
             let level = get(data, 'level', -1)
             if level != -1
                 let error.type = toupper(level[0])
             else
                 let error.type = 'W'
             endif
+        else
+            let error.type = code_dict['code'][0]
+            let error.nr = str2nr(code_dict['code'][1:])
         endif
 
         let span = data.spans[0]

--- a/tests/ft_rust.vader
+++ b/tests/ft_rust.vader
@@ -1,5 +1,33 @@
 Include: include/setup.vader
 
+Execute (rust: cargo: handles code correctly):
+  let null = g:neomake#compat#json_null
+  let true = g:neomake#compat#json_true
+
+  let json = join([
+  \ '{"reason":"compiler-message"',
+  \ '"package_id":"inko 0.3.0 (path+file:///home/yorickpeterse/Projects/inko/inko/vm)"',
+  \ '"target":{"kind":["lib"]',
+  \   '"crate_types":["lib"]',
+  \   '"name":"libinko"',
+  \   '"src_path":"/home/yorickpeterse/Projects/inko/inko/vm/src/lib.rs"',
+  \   '"edition":"2015"}',
+  \ '"message":{"message":"field is never used: `stealer`"',
+  \   '"code":{"code":"dead_code","explanation":null}',
+  \   '"level":"warning"',
+  \   '"spans":[{"file_name":"src/scheduling/scheduler.rs","byte_start":83,"byte_end":102,"line_start":4,"line_end":4,"column_start":5,"column_end":24,"is_primary":true,"text":[{"text":"    stealer: Stealer<T>,","highlight_start":5,"highlight_end":24}],"label":null,"suggested_replacement":null,"suggestion_applicability":null,"expansion":null}]',
+  \   '"children":[{"message":"#[warn(dead_code)] on by default","code":null,"level":"note","spans":[],"children":[],"rendered":null}]',
+  \   '"rendered":"warning: field is never used: `stealer`\\n --> src/scheduling/scheduler.rs:4:5\\n  |\\n4 |     stealer: Stealer<T>,\\n  |     ^^^^^^^^^^^^^^^^^^^\\n  |\\n  = note: #[warn(dead_code)] on by default\\n\\n"}}',
+  \ ], ',')
+
+  let context = {'output': [json]}
+  let errors = neomake#makers#ft#rust#CargoProcessOutput(context)
+  AssertEqual errors, [
+  \ {'lnum': 4, 'col': 5, 'filename': 'src/scheduling/scheduler.rs',
+  \  'type': 'W',
+  \  'maker_name': 'cargo', 'length': 19,
+  \  'text': 'field is never used: `stealer`. #[warn(dead_code)] on by default'}]
+
 Execute (cargo skip non json line):
   new
   file build/lib.rs
@@ -41,7 +69,7 @@ Execute (cargo: uses primary span):
   CallNeomake 1, [cargo]
 
   AssertEqualQf getloclist(0), [{
-  \ 'lnum': 6, 'bufnr': bufnr('%'), 'col': 5, 'valid': 1, 'vcol': 0, 'nr': 49,
+  \ 'lnum': 6, 'bufnr': bufnr('%'), 'col': 5, 'valid': 1, 'vcol': 0, 'nr': 61,
   \ 'type': 'E', 'pattern': '',
   \ 'text': 'this function takes 1 parameter but 2 parameters were supplied: expected 1 parameter',
   \ }]


### PR DESCRIPTION
Also use str2nr to have "nr" 61 for "0061", and not 49.

Fixes https://github.com/neomake/neomake/issues/1919.