### PR TITLE
Add stdin support for RuboCop

### DIFF
--- a/autoload/neomake/makers/ft/ruby.vim
+++ b/autoload/neomake/makers/ft/ruby.vim
@@ -5,12 +5,20 @@ function! neomake#makers#ft#ruby#EnabledMakers() abort
 endfunction
 
 function! neomake#makers#ft#ruby#rubocop() abort
-    return {
+    let maker = {
         \ 'args': ['--format', 'emacs', '--force-exclusion', '--display-cop-names'],
         \ 'errorformat': '%f:%l:%c: %t: %m,%E%f:%l: %m',
         \ 'postprocess': function('neomake#makers#ft#ruby#RubocopEntryProcess'),
         \ 'output_stream': 'stdout',
         \ }
+
+    function! maker.supports_stdin(_jobinfo) abort
+        let self.args += ['--stdin', '%']
+        let self.tempfile_name = ''
+        return 1
+    endfunction
+
+    return maker
 endfunction
 
 function! neomake#makers#ft#ruby#RubocopEntryProcess(entry) abort


### PR DESCRIPTION
I was annoyed by RuboCop complaining about the temporary filename chosen by Neomake. (RuboCop includes a linter for the filenames as well.)

Adding support for stdin fixes this.