### PR TITLE
logging: use debug level for hook messages

### DIFF
--- a/autoload/neomake/utils.vim
+++ b/autoload/neomake/utils.vim
@@ -438,7 +438,7 @@ function! s:handle_hook(jobinfo, event, context) abort
     if !empty(a:jobinfo)
         let log_args += [a:jobinfo]
     endif
-    call call('neomake#log#info', log_args)
+    call call('neomake#log#debug', log_args)
 
     unlockvar g:neomake_hook_context
     let g:neomake_hook_context = a:context

--- a/tests/automake.vader
+++ b/tests/automake.vader
@@ -245,7 +245,7 @@ Execute (Automake):
   AssertEqual len(g:neomake_test_jobfinished), 1
 
   " 'jobs' in logged context.
-  AssertNeomakeMessage '\VCalling User autocmd NeomakeFinished with context: \.\*''jobs'': [''true'']\.\*}.', 2
+  AssertNeomakeMessage '\VCalling User autocmd NeomakeFinished with context: \.\*''jobs'': [''true'']\.\*}.', 3
 
   " Tick was not reset on FileType-reconfig (no changes).
   doautocmd FileType

--- a/tests/hooks-queue.vader
+++ b/tests/hooks-queue.vader
@@ -89,20 +89,20 @@ Execute (Nested neomake#utils#hook must not be nested (directly)):
     au User Event3 call s:nested_hook_cb(3)
   augroup END
   call neomake#utils#hook('Event1', {'context': 1})
-  AssertNeomakeMessage "Calling User autocmd Event1 with context: {'context': 1}.", 2
+  AssertNeomakeMessage "Calling User autocmd Event1 with context: {'context': 1}.", 3
   AssertNeomakeMessage 'Queuing action handle_hook for Timer, BufEnter, WinEnter, InsertLeave, CursorHold, CursorHoldI.', 3
   doautocmd InsertLeave
-  AssertNeomakeMessage "Calling User autocmd Event2 with context: {'context': 2}.", 2
+  AssertNeomakeMessage "Calling User autocmd Event2 with context: {'context': 2}.", 3
   AssertNeomakeMessage 'Queuing action handle_hook for Timer, BufEnter, WinEnter, InsertLeave, CursorHold, CursorHoldI.', 3
   doautocmd InsertLeave
-  AssertNeomakeMessage "Calling User autocmd Event3 with context: {'context': 3}.", 2
+  AssertNeomakeMessage "Calling User autocmd Event3 with context: {'context': 3}.", 3
 
 Execute (neomake#utils#hook: reports exception):
   augroup neomake_tests
     au User Event1 throw 'Exception'
   augroup END
   call neomake#utils#hook('Event1', {'context': 1})
-  AssertNeomakeMessage "Calling User autocmd Event1 with context: {'context': 1}.", 2
+  AssertNeomakeMessage "Calling User autocmd Event1 with context: {'context': 1}.", 3
   AssertNeomakeMessage 'Error during User autocmd for Event1: Exception.', 0
   Assert !exists('g:neomake_hook_context'), 'g:neomake_hook_context was cleared'
 
@@ -144,11 +144,11 @@ Execute (Does not nest hooks / User autocommands):
 
     doautocmd WinEnter
     AssertNeomakeMessage 'action queue: calling handle_hook.'
-    AssertNeomakeMessage '\VCalling User autocmd NeomakeCountsChanged with context: ', 2
+    AssertNeomakeMessage '\VCalling User autocmd NeomakeCountsChanged with context: ', 3
     AssertNeomakeMessage 'action queue: calling CleanJobinfo.', 3
     AssertNeomakeMessage 'Cleaning jobinfo.', 3
-    AssertNeomakeMessage '\VCalling User autocmd NeomakeJobFinished with context: ', 2
-    AssertNeomakeMessage '\VCalling User autocmd NeomakeFinished with context: ', 2
+    AssertNeomakeMessage '\VCalling User autocmd NeomakeJobFinished with context: ', 3
+    AssertNeomakeMessage '\VCalling User autocmd NeomakeFinished with context: ', 3
     AssertNeomakeMessage 'Cleaning make info.'
     bwipe
   endif

--- a/tests/hooks.vader
+++ b/tests/hooks.vader
@@ -12,7 +12,7 @@ Execute (Hook execution gets logged):
   let make_id = neomake#GetStatus().last_make_id
   NeomakeTestsWaitForFinishedJobs
 
-  AssertNeomakeMessage '\mCalling User autocmd NeomakeFinished with context: {''options'': ', 2
+  AssertNeomakeMessage '\mCalling User autocmd NeomakeFinished with context: {''options'': ', 3
   AssertEqual map(copy(g:neomake_test_finished), 'sort(keys(v:val))'), [
   \ ['finished_jobs', 'make_id', 'make_info', 'options']]
 

--- a/tests/processing.vader
+++ b/tests/processing.vader
@@ -699,7 +699,7 @@ Execute (get_list_entries: delayed for location list (but in current context)):
   3wincmd w
   AssertNeomakeMessage 'action queue: processing for WinEnter (2 items).', 3, {'winnr': 3}
   AssertNeomakeMessage 'Cleaning jobinfo.'
-  AssertNeomakeMessage '\VCalling User autocmd NeomakeJobFinished with context:', 2
+  AssertNeomakeMessage '\VCalling User autocmd NeomakeJobFinished with context:', 3
 
   AssertEqual winnr(), 2
   AssertEqual map(getloclist(3), '[v:val.bufnr, v:val.text, v:val.type]'), [

--- a/tests/processing.vader
+++ b/tests/processing.vader
@@ -378,7 +378,7 @@ Execute (Sleep in postprocess gets handled correctly):
     AssertNeomakeMessage 'Processing 1 lines of output.', 3, jobinfo
     if !has('nvim-0.2.0')
       AssertNeomakeMessage 'exit (delayed): unnamed_maker: 0.', 3, jobinfo
-      AssertNeomakeMessage '\VCalling User autocmd NeomakeCountsChanged with context:', 2
+      AssertNeomakeMessage '\VCalling User autocmd NeomakeCountsChanged with context:', 3
     endif
 
     if has('nvim-0.4.0')
@@ -392,11 +392,11 @@ Execute (Sleep in postprocess gets handled correctly):
       let expected_final_countchanges = 3
       AssertNeomakeMessage "output on stdout: ['out-22', ''].", 3, jobinfo
       AssertNeomakeMessage 'Processing 1 lines of output.', 3, jobinfo
-      AssertNeomakeMessage '\VCalling User autocmd NeomakeCountsChanged with context:', 2
+      AssertNeomakeMessage '\VCalling User autocmd NeomakeCountsChanged with context:', 3
 
       AssertNeomakeMessage "output on stdout: ['out-333', ''].", 3, jobinfo
       AssertNeomakeMessage 'Processing 1 lines of output.', 3, jobinfo
-      AssertNeomakeMessage '\VCalling User autocmd NeomakeCountsChanged with context:', 2
+      AssertNeomakeMessage '\VCalling User autocmd NeomakeCountsChanged with context:', 3
     endif
 
     if !has('nvim-0.2.0')


### PR DESCRIPTION
This makes `:verbose Neomake …` more useful (in case you have hooks
defined - those are not useful to see there then).