### PR TITLE
Updates golangci_lint error formats for lll

### DIFF
--- a/autoload/neomake/makers/ft/go.vim
+++ b/autoload/neomake/makers/ft/go.vim
@@ -79,6 +79,7 @@ function! neomake#makers#ft#go#golangci_lint() abort
         \ 'append_file': 0,
         \ 'cwd': '%:h',
         \ 'errorformat':
-            \ '%f:%l:%c: %m'
+            \ '%f:%l:%c: %m,' .
+            \ '%f:%l: %m'
         \ }
 endfunction


### PR DESCRIPTION
The long line linter doesn't include a column in the error output:

```
$ golangci-lint run --disable-all --enable=lll --out-format=line-number --print-issued-lines=false main.go
main.go:216: line is 124 characters (lll)
main.go:217: line is 124 characters (lll)
main.go:220: line is 124 characters (lll)
main.go:235: line is 122 characters (lll)
main.go:237: line is 134 characters (lll)
main.go:238: line is 128 characters (lll)
main.go:269: line is 122 characters (lll)
main.go:420: line is 148 characters (lll)
```
This commit adds an errorformat that matches lint output missing column information.