### PR TITLE
neomake#utils#WideMessage: use v:echospace

### DIFF
--- a/autoload/neomake/utils.vim
+++ b/autoload/neomake/utils.vim
@@ -58,9 +58,6 @@ endfunction
 " This comes straight out of syntastic.
 "print as much of a:msg as possible without "Press Enter" prompt appearing
 function! neomake#utils#WideMessage(msg) abort " {{{2
-    let old_ruler = &ruler
-    let old_showcmd = &showcmd
-
     " Replace newlines (typically in the msg) with a single space.  This
     " might happen with writegood.
     let msg = substitute(a:msg, '\r\?\n', ' ', 'g')
@@ -69,14 +66,21 @@ function! neomake#utils#WideMessage(msg) abort " {{{2
     "width as the proper amount of characters
     let chunks = split(msg, "\t", 1)
     let msg = join(map(chunks[:-2], "v:val . repeat(' ', &tabstop - strwidth(v:val) % &tabstop)"), '') . chunks[-1]
+
+    if exists('v:echospace')
+        let msg = neomake#utils#truncate_width(msg, v:echospace)
+        call neomake#log#debug('WideMessage: echo '.msg.'.')
+        echo msg
+        return
+    endif
+
     let msg = neomake#utils#truncate_width(msg, &columns-1)
 
+    let old_ruler = &ruler
+    let old_showcmd = &showcmd
     set noruler noshowcmd
     redraw
-
-    call neomake#log#debug('WideMessage: echo '.msg.'.')
     echo msg
-
     let &ruler = old_ruler
     let &showcmd = old_showcmd
 endfunction " }}}2


### PR DESCRIPTION
Added in Vim patch 8.1.1913.