### PR TITLE
c/cpp: cppcheck: do not use "--force"

### DIFF
--- a/autoload/neomake/makers/ft/c.vim
+++ b/autoload/neomake/makers/ft/c.vim
@@ -92,12 +92,10 @@ function! neomake#makers#ft#c#checkpatch() abort
 endfunction
 
 function! neomake#makers#ft#c#cppcheck() abort
-    " Uses --force to avoid:
-    " nofile:0:0:information:Too many #ifdef configurations - cppcheck only checks 12 configurations.
     " NOTE: '--language=c' should be the first args, it gets replaced in
     "       neomake#makers#ft#cpp#cppcheck.
     return {
-        \ 'args': ['--language=c', '--quiet', '--enable=warning', '--force',
+        \ 'args': ['--language=c', '--quiet', '--enable=warning',
         \          '--template={file}:{line}:{column}:{severity}:{message}'],
         \ 'errorformat':
             \ 'nofile:0:0:%trror:%m,' .


### PR DESCRIPTION
This might result in a lot of runs with e.g. Vim's source.

It is better to limit this to the default then (12), displaying an
information then.  User's should configure it then to their liking
instead (using custom args).