### PR TITLE
Add new filetype makers for javascriptreact and typescriptreact

### DIFF
--- a/autoload/neomake/makers/ft/javascriptreact.vim
+++ b/autoload/neomake/makers/ft/javascriptreact.vim
@@ -1,0 +1,18 @@
+function! neomake#makers#ft#javascriptreact#SupersetOf() abort
+    return 'javascript'
+endfunction
+
+function! neomake#makers#ft#javascriptreact#EnabledMakers() abort
+    return ['jshint', executable('eslint_d') ? 'eslint_d' : 'eslint']
+endfunction
+
+function! neomake#makers#ft#javascriptreact#javascriptreacthint() abort
+    return neomake#makers#ft#javascript#jshint()
+endfunction
+
+function! neomake#makers#ft#javascriptreact#stylelint() abort
+    return neomake#makers#ft#css#stylelint()
+endfunction
+
+" vim: ts=4 sw=4 et
+

--- a/autoload/neomake/makers/ft/typescriptreact.vim
+++ b/autoload/neomake/makers/ft/typescriptreact.vim
@@ -1,0 +1,15 @@
+function! neomake#makers#ft#typescriptreact#SupersetOf() abort
+    return 'typescript'
+endfunction
+
+function! neomake#makers#ft#typescriptreact#EnabledMakers() abort
+    return ['tsc', 'tslint']
+endfunction
+
+function! neomake#makers#ft#typescriptreact#tsc() abort
+    let config = neomake#makers#ft#typescript#tsc()
+    let config.args = config.args + ['--jsx', 'preserve']
+    return config
+endfunction
+
+" vim: ts=4 sw=4 et


### PR DESCRIPTION
Vim has recently added the filetypes javascriptreact and typescriptreact for .jsx and .tsx files respectively. This will add makers for those filetypes and they are simply copies of the jsx and tsx filetype makers.

Another way to do this will be to make them SupersetOf their jsx and tsx filetypes. But not sure of how the SupersetOf() function works since those filetypes are themselves super sets of another type.

https://github.com/vim/vim/issues/4830
https://github.com/vim/vim/commit/92852cee3fcff1dc6ce12387b234634e73267b22