### PR TITLE
Only compare maker name when canceling already running jobs

### DIFF
--- a/autoload/neomake.vim
+++ b/autoload/neomake.vim
@@ -1262,17 +1262,18 @@ function! s:Make(options) abort
         " @vimlint(EVL102, 1, l:job)
         for job in jobs
             let running_already = values(filter(copy(s:jobs),
-                        \ '(v:val.maker == job.maker'
+                        \ '(v:val.maker.name == job.maker.name'
                         \ .'   || (!is_automake && get(v:val, "automake", 0)))'
                         \ .' && v:val.bufnr == job.bufnr'
                         \ .' && v:val.file_mode == job.file_mode'
                         \ ." && !get(v:val, 'canceled')"))
             if !empty(running_already)
-                let jobinfo = running_already[0]
-                call neomake#log#info(printf(
-                            \ 'Canceling already running job (%d.%d) for the same maker.',
-                            \ jobinfo.make_id, jobinfo.id), {'make_id': make_id})
-                call neomake#CancelJob(jobinfo.id, 1)
+                for running_job in running_already
+                    call neomake#log#info(printf(
+                                \ 'Canceling already running job (%d.%d) for the same maker.',
+                                \ running_job.make_id, running_job.id), {'make_id': make_id})
+                    call neomake#CancelJob(running_job.id, 1)
+                endfor
             endif
         endfor
     endif

--- a/tests/include/init.vim
+++ b/tests/include/init.vim
@@ -395,7 +395,7 @@ function! s:IncMakerInitForJobs(_jobinfo) dict
     let cmd .= 'echo b'.g:neomake_test_inc_maker_counter.' '.g:neomake_test_inc_maker_counter.':'.i.': buf: '.shellescape(bufname('%')).'; '
   endfor
   let self.args = s:shell_argv[1:] + [cmd]
-  let self.name = 'incmaker_' .. g:neomake_test_inc_maker_counter
+  let self.name = 'incmaker_' . g:neomake_test_inc_maker_counter
 endfunction
 let g:neomake_test_inc_maker = {
       \ 'name': 'incmaker',

--- a/tests/include/init.vim
+++ b/tests/include/init.vim
@@ -395,6 +395,7 @@ function! s:IncMakerInitForJobs(_jobinfo) dict
     let cmd .= 'echo b'.g:neomake_test_inc_maker_counter.' '.g:neomake_test_inc_maker_counter.':'.i.': buf: '.shellescape(bufname('%')).'; '
   endfor
   let self.args = s:shell_argv[1:] + [cmd]
+  let self.name = 'incmaker_' .. g:neomake_test_inc_maker_counter
 endfunction
 let g:neomake_test_inc_maker = {
       \ 'name': 'incmaker',

--- a/tests/processing.vader
+++ b/tests/processing.vader
@@ -425,7 +425,7 @@ Execute (Pending output with restarted job when not in normal/insert mode (locli
     exe "norm! \<Esc>"
     call neomake#Make(1, [g:neomake_test_inc_maker])
 
-    " Maker is different because of args.
+    " Maker is different because of name.
     AssertNeomakeMessageAbsent 'Canceling already running job ('
       \ .make_id.'.'.jobinfo1.id.') for the same maker.', 2, {'make_id': make_id+1}
     AssertNeomakeMessageAbsent 'Removing already finished job', 3, jobinfo1
@@ -460,7 +460,7 @@ Execute (Pending output with restarted job when not in normal/insert mode (quick
     exe "norm! \<Esc>"
     call neomake#Make(0, [g:neomake_test_inc_maker])
 
-    " Maker is different because of args.
+    " Maker is different because of name.
     AssertNeomakeMessageAbsent 'Canceling already running job ('
       \ .make_id.'.'.jobinfo1.id.') for the same maker.', 2, {'make_id': make_id+1}
     AssertNeomakeMessageAbsent 'Removing already finished job', 3, jobinfo1
@@ -621,6 +621,8 @@ Execute (Already running job gets restarted in case of exception):
     AssertEqual len(neomake#GetJobs()), 1, 'The job has not been cleaned because of the exception.'
 
     " Restart, which should work directly.
+    let maker.some_new_key = 1
+    Assert values(neomake#_get_s().jobs)[0].maker != maker
     call neomake#Make(1, [maker])
 
     AssertNeomakeMessage printf('Canceling already running job (%d.%d) for the same maker.',


### PR DESCRIPTION
Instantiated makers might be different from the new/uninstantiated ones,
e.g. with regard to args or `tempfile_name` etc.