### PR TITLE
tests: fix "python: errorformat" for py38+

### DIFF
--- a/tests/fixtures/errors.py
+++ b/tests/fixtures/errors.py
@@ -1,2 +1,1 @@
-if not this or foo bar:
-    meh
+invalid_syntax(

--- a/tests/fixtures/errors.py
+++ b/tests/fixtures/errors.py
@@ -1,1 +1,1 @@
-invalid_syntax(
+invalid_syntax(  # noqa

--- a/tests/fixtures/errors.py
+++ b/tests/fixtures/errors.py
@@ -1,1 +1,1 @@
-invalid_syntax(  # noqa
+invalid_syntax(

--- a/tests/ft_python.vader
+++ b/tests/ft_python.vader
@@ -10,13 +10,13 @@ Execute (python: errorformat):
   AssertEqualQf getloclist(0), [{
   \ 'lnum': 1,
   \ 'bufnr': bufnr('%'),
-  \ 'col': 22,
+  \ 'col': 16,
   \ 'valid': 1,
   \ 'vcol': 0,
   \ 'nr': -1,
   \ 'type': 'E',
   \ 'pattern': '',
-  \ 'text': 'invalid syntax'}]
+  \ 'text': 'unexpected EOF while parsing'}]
   bwipe
 
 Execute (python: pylama: errorformat):


### PR DESCRIPTION
The location there changed.  This updates the test to use python2 for
now.