### PR TITLE
Add SwiftLint and Swift Maker

### DIFF
--- a/autoload/neomake/makers/ft/swift.vim
+++ b/autoload/neomake/makers/ft/swift.vim
@@ -1,14 +1,22 @@
 " vim: ts=4 sw=4 et
 
 function! neomake#makers#ft#swift#EnabledMakers() abort
+    let l:list = ['swiftc']
     if !empty(s:get_swiftpm_config())
-        return ['swiftpm']
+        let l:list = ['swiftpm']
     endif
-    return ['swiftc']
+    if s:get_swiftlint_config()
+        let l:list = add(l:list, 'swiftlint')
+    endif
+    return l:list
 endfunction
 
 function! s:get_swiftpm_config() abort
     return neomake#utils#FindGlobFile('Package.swift')
+endfunction
+
+function! s:get_swiftlint_config() abort
+    return executable('swiftlint') && !empty(neomake#utils#FindGlobFile('.swiftlint.yml'))
 endfunction
 
 function! s:get_swiftpm_base_maker() abort
@@ -39,6 +47,20 @@ function! neomake#makers#ft#swift#swiftpmtest() abort
     let maker = s:get_swiftpm_base_maker()
     let maker.args = ['test']
     return maker
+endfunction
+
+function! neomake#makers#ft#swift#swiftlint() abort
+    return {
+        \ 'args': ['lint'],
+        \ 'append_file': 1,
+        \ 'errorformat':
+            \ '%E%f:%l:%c: error: %m,' .
+            \ '%W%f:%l:%c: warning: %m,' .
+            \ '%E%f:%l: error: %m,' .
+            \ '%W%f:%l: warning: %m,' .
+            \ '%Z%\s%#^~%#,' .
+            \ '%-G%.%#',
+        \ }
 endfunction
 
 function! neomake#makers#ft#swift#swiftc() abort

--- a/autoload/neomake/makers/ft/swift.vim
+++ b/autoload/neomake/makers/ft/swift.vim
@@ -49,6 +49,12 @@ function! neomake#makers#ft#swift#swiftpmtest() abort
     return maker
 endfunction
 
+function! neomake#makers#ft#swift#swiftfile() abort
+    let maker = s:get_swiftpm_base_maker()
+    let maker.append_file = 1
+    return maker
+endfunction
+
 function! neomake#makers#ft#swift#swiftlint() abort
     return {
         \ 'args': ['lint'],


### PR DESCRIPTION
This Pull Request adds a new Maker for [SwiftLint](https://github.com/realm/SwiftLint).
It also adds a Maker for compiling a swift script with swift (instead of swiftc).

SwiftLint will automatically be enabled when a `.swiftlint.yml` is found.

`swiftfile` won't be enabled per default. In my own vimrc I'll replace `swiftc` with it though.

Rationale:
Having a `~/.swiftlint.yml` will enable SwiftLint but won't use this configuration but the default instead.
As this is also true for the existing `swiftpm`, I did ignore it.

Possible solutions:
- Replace/restrict `FindGlobFile` with a function which only searches up until the project root.
- Use the found `.swiftlint.yml`*

* This would result in having support for global a SwiftLint config. But as SwiftLint can merge multiple configurations this feature would be lost.