### PR TITLE
tests: source plugin later in init.vim

### DIFF
--- a/tests/include/init.vim
+++ b/tests/include/init.vim
@@ -1,5 +1,12 @@
 " Sourced by ./setup.vader.
 " Keeping this in a separate file is better for performance.
+"
+let s:slash = has('win32') ? '\' : '/'
+
+let s:plugin_dir = expand('<sfile>:p:h:h:h')
+let &runtimepath .= ','.s:plugin_dir
+
+exe 'source' join([s:plugin_dir, 'plugin', 'neomake.vim'], s:slash)
 
 function! s:wait_for_jobs(filter)
   let max = 45

--- a/tests/vim/vimrc
+++ b/tests/vim/vimrc
@@ -59,11 +59,6 @@ function! s:load_plugin_on_demand(name) abort
 endfunction
 command! -nargs=1 NeomakeTestsLoadPlugin call s:load_plugin_on_demand(<args>)
 
-let s:plugin_dir = expand('<sfile>:p:h:h:h')
-let &runtimepath .= ','.s:plugin_dir
-
-exe 'source' join([s:plugin_dir, 'plugin', 'neomake.vim'], s:slash)
-
 filetype plugin indent on
 
 augroup ssshhhhhh


### PR DESCRIPTION
This allows for having `Log` etc during initialization already
(triggered via `ColorScheme`).