### PR TITLE
Fix errorformat for markdownlint-cli 0.19.0 or newer

### DIFF
--- a/autoload/neomake/makers/ft/markdown.vim
+++ b/autoload/neomake/makers/ft/markdown.vim
@@ -27,8 +27,15 @@ function! neomake#makers#ft#markdown#mdl() abort
 endfunction
 
 function! neomake#makers#ft#markdown#markdownlint() abort
+    let ver = neomake#compat#systemlist(['markdownlint', '--version'])
+    let ver_split = split(ver[0], '\.')
+    if len(ver_split) >= 2 && ver_split[0] == 0 && ver_split[1] <= 18
+        let errorformat = '%f: %l: %m' "old format
+    else
+        let errorformat = '%f:%l %m'
+    endif
     return {
-                \ 'errorformat': '%f: %l: %m'
+                \ 'errorformat': errorformat
                 \ }
 endfunction
 

--- a/autoload/neomake/makers/ft/markdown.vim
+++ b/autoload/neomake/makers/ft/markdown.vim
@@ -27,15 +27,8 @@ function! neomake#makers#ft#markdown#mdl() abort
 endfunction
 
 function! neomake#makers#ft#markdown#markdownlint() abort
-    let ver = neomake#compat#systemlist(['markdownlint', '--version'])
-    let ver_split = split(ver[0], '\.')
-    if len(ver_split) >= 2 && ver_split[0] == 0 && ver_split[1] <= 18
-        let errorformat = '%f: %l: %m' "old format
-    else
-        let errorformat = '%f:%l %m'
-    endif
     return {
-                \ 'errorformat': errorformat
+                \ 'errorformat': '%f:%l %m,%f: %l: %m'
                 \ }
 endfunction
 


### PR DESCRIPTION
The format of markdownlint-cli seems to have changed at 0.19.0.

```sh
$  echo 'test line' > 0.md
$ npm -g markdownlint-cli@0.18.0
$  markdownlint 0.md
0.md: 1: MD041/first-line-heading/first-line-h1 First line in file should be a top level heading [Context: "test line"]
$ npm -g markdownlint-cli@0.19.0
$ markdownlint 0.md
0.md:1 MD041/first-line-heading/first-line-h1 First line in file should be a top level heading [Context: "test line"]
```