### PR TITLE
fix: Define highlights as defaults to avoid overriding user config

### DIFF
--- a/autoload/neomake/statusline.vim
+++ b/autoload/neomake/statusline.vim
@@ -411,14 +411,14 @@ function! neomake#statusline#DefineHighlights() abort
     endfor
 
     " Default highlight for type counts.
-    exe 'hi NeomakeStatColorDefault cterm=NONE ctermfg=white ctermbg=blue'
+    exe 'hi default NeomakeStatColorDefault cterm=NONE ctermfg=white ctermbg=blue'
     hi link NeomakeStatColorQuickfixDefault NeomakeStatColorDefault
 
     " Specific highlights for types.  Only used if defined.
-    exe 'hi NeomakeStatColorTypeE cterm=NONE ctermfg=white ctermbg=red'
+    exe 'hi default NeomakeStatColorTypeE cterm=NONE ctermfg=white ctermbg=red'
     hi link NeomakeStatColorQuickfixTypeE NeomakeStatColorTypeE
 
-    exe 'hi NeomakeStatColorTypeW cterm=NONE ctermfg=white ctermbg=yellow'
+    exe 'hi default NeomakeStatColorTypeW cterm=NONE ctermfg=white ctermbg=yellow'
     hi link NeomakeStatColorQuickfixTypeW NeomakeStatColorTypeW
 endfunction
 

--- a/tests/statusline.vader
+++ b/tests/statusline.vader
@@ -223,7 +223,6 @@ Execute (neomake#statusline#get: use_highlights_with_defaults):
 Execute (statusline: uses user-configured highlights):
   new
   let bufnr = bufnr('%')
-  Assert !hlexists('NeomakeStatColorTypeW')
   hi NeomakeStatColorTypeW ctermfg=Black ctermbg=Black cterm=none
   let orig = neomake#utils#redir('hi NeomakeStatColorTypeW')
   CallNeomake 1, [g:success_entry_maker]

--- a/tests/statusline.vader
+++ b/tests/statusline.vader
@@ -220,7 +220,7 @@ Execute (neomake#statusline#get: use_highlights_with_defaults):
   \ '%#NeomakeStatusGood#✓%#NeomakeStatReset#'
   bwipe
 
-Execute (statusline: uses user-configured highlights)):
+Execute (statusline: uses user-configured highlights):
   new
   let bufnr = bufnr('%')
   Assert !hlexists('NeomakeStatColorTypeW')

--- a/tests/statusline.vader
+++ b/tests/statusline.vader
@@ -219,3 +219,13 @@ Execute (neomake#statusline#get: use_highlights_with_defaults):
   AssertEqual neomake#statusline#get(bufnr, {'use_highlights_with_defaults': 1}),
   \ '%#NeomakeStatusGood#✓%#NeomakeStatReset#'
   bwipe
+
+Execute (statusline: uses user-configured highlights)):
+  new
+  let bufnr = bufnr('%')
+  Assert !hlexists('NeomakeStatColorTypeW')
+  hi NeomakeStatColorTypeW ctermfg=Black ctermbg=Black cterm=none
+  let orig = neomake#utils#redir('hi NeomakeStatColorTypeW')
+  CallNeomake 1, [g:success_entry_maker]
+  AssertEqual neomake#utils#redir('hi NeomakeStatColorTypeW'), orig
+  bwipe


### PR DESCRIPTION
Neomake currently overrides any user provided `NeomakeStatColorType*` highlight configuration. 

This PR should fix that.

### Bug repro

1. Add the following to .vimrc that already has neomake configured:
   ```vim
   hi NeomakeStatColorTypeW  ctermfg=White  ctermbg=Blue  cterm=none
   
   function! MyStatusLine()
     let bufnr = winbufnr(g:statusline_winid)
     let st = ""
     let st .= "%< %-f  " " File path (truncated if necessary)
     let st .= "%m%r%w %="
     let st .= " %=" " Separation point
     let st = neomake#statusline#get(bufnr, {
       \ 'format_running': '({{running_job_names}}) ',
       \ 'format_loclist_unknown': '',
       \ 'format_loclist_ok': '✓',
       \ 'format_quickfix_ok': '',
       \ 'format_quickfix_issues': '%s',
       \ })
     return st
   endfunction
 
   set statusline=%!MyStatusLine()

   ```
2. Open a file with which neomake has a maker for, that contains a warning
3. Trigger the neomake maker

**Expected outcome:** `W:1` is displayed white on blue in the statusline (per .vimrc)
**Actual outcome:** `W:1` is displayed white on yellow in the statusline (per statusline.vim)
