### PR TITLE
python: handle SyntaxWarnings

### DIFF
--- a/autoload/neomake/makers/ft/python.vim
+++ b/autoload/neomake/makers/ft/python.vim
@@ -363,7 +363,7 @@ endfunction
 function! neomake#makers#ft#python#python() abort
     return {
         \ 'args': [s:compile_script],
-        \ 'errorformat': '%E%f:%l:%c: %m',
+        \ 'errorformat': '%E%f:%l:%c: E: %m,%W%f:%l: W: %m',
         \ 'serialize': 1,
         \ 'serialize_abort_on_error': 1,
         \ 'output_stream': 'stdout',

--- a/autoload/neomake/makers/ft/python/compile.py
+++ b/autoload/neomake/makers/ft/python/compile.py
@@ -1,14 +1,49 @@
 #!/usr/bin/env python
 
 from __future__ import print_function
-from sys import argv, exit
+
+import warnings
+import sys
 
 
-if len(argv) != 2:
-    exit(64)
+def main(argv):
+    if len(argv) != 2:
+        exit(64)
 
-try:
-    compile(open(argv[1]).read(), argv[1], 'exec', 0, 1)
-except SyntaxError as err:
-    print('%s:%s:%s: %s' % (err.filename, err.lineno, err.offset, err.msg))
-    exit(1)
+    with open(argv[1]) as fp:
+        contents = fp.read()
+
+    exitcode = 0
+    syntax_err = None
+    with warnings.catch_warnings(record=True) as wc:
+        try:
+            compile(contents, argv[1], "exec", 0, 1)
+        except SyntaxError as exc:
+            syntax_err = exc
+
+    # Output any warnings (caught during `compile`).
+    # This could/should maybe only handle SyntaxWarnings?
+    for wm in wc:
+        print(
+            "%s:%s: W: %s (%s)"
+            % (wm.filename, wm.lineno, wm.message, wm.category.__name__)
+        )
+        exitcode |= 2
+
+    # Output any SyntaxError.
+    if syntax_err:
+        print(
+            "%s:%s:%s: E: %s"
+            % (
+                syntax_err.filename,
+                syntax_err.lineno,
+                syntax_err.offset,
+                syntax_err.msg,
+            )
+        )
+        exitcode |= 1
+    return exitcode
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
E.g. '"is" with a literal. Did you mean "=="?"' with `assert 1 is 2`.