### PR TITLE
Fix errorformat of markdownlint

### DIFF
--- a/autoload/neomake/makers/ft/markdown.vim
+++ b/autoload/neomake/makers/ft/markdown.vim
@@ -29,8 +29,10 @@ endfunction
 function! neomake#makers#ft#markdown#markdownlint() abort
     return {
                 \ 'errorformat':
-                \ '%f:%l:%c %m,%f: %l: %m,' .
-                \ '%f:%l %m,%f: %l: %m'
+                \ '%f:%l:%c %m,' .
+                \ '%f: %l: %c: %m,' .
+                \ '%f:%l %m,' .
+                \ '%f: %l: %m'
                 \ }
 endfunction
 

--- a/autoload/neomake/makers/ft/markdown.vim
+++ b/autoload/neomake/makers/ft/markdown.vim
@@ -28,7 +28,9 @@ endfunction
 
 function! neomake#makers#ft#markdown#markdownlint() abort
     return {
-                \ 'errorformat': '%f:%l %m,%f: %l: %m'
+                \ 'errorformat':
+                \ '%f:%l:%c %m,%f: %l: %m,' .
+                \ '%f:%l %m,%f: %l: %m'
                 \ }
 endfunction
 

--- a/tests/ft_markdown.vader
+++ b/tests/ft_markdown.vader
@@ -64,3 +64,35 @@ Execute (markdown: mdl):
     \ 'text': 'Inline HTML (MD033)',
     \ }]
   bwipe
+
+Execute (markdown: markdownlint):
+  let maker = NeomakeTestsGetMakerWithOutput(neomake#makers#ft#markdown#markdownlint(), [
+    \ 'README.md:66:81 MD013/line-length Line length [Expected: 80; Actual: 83]',
+    \ 'README.md:122 MD025/single-title/single-h1 Multiple top level headings in the same document [Context: "# Contributing"]',
+    \ ])
+
+  new
+  noautocmd file README.md
+  CallNeomake 1, [maker]
+  AssertEqualQf getloclist(0), [{
+    \ 'lnum': 66,
+    \ 'bufnr': bufnr('%'),
+    \ 'col': 81,
+    \ 'valid': 1,
+    \ 'vcol': 0,
+    \ 'nr': -1,
+    \ 'type': 'W',
+    \ 'pattern': '',
+    \ 'text': 'MD013/line-length Line length [Expected: 80; Actual: 83]',
+    \ },{
+    \ 'lnum': 122,
+    \ 'bufnr': bufnr('%'),
+    \ 'col': 0,
+    \ 'valid': 1,
+    \ 'vcol': 0,
+    \ 'nr': -1,
+    \ 'type': 'W',
+    \ 'pattern': '',
+    \ 'text': 'MD025/single-title/single-h1 Multiple top level headings in the same document [Context: "# Contributing"]',
+    \ }]
+  bwipe


### PR DESCRIPTION
Some error messages of markdownlint contain also a character. This
caused the character to be interpreted as line and the line to be part
of the filename.

Example:
```
README.md:1:81 MD013/line-length Line length [Expected: 80; Actual: 129]
```

Closes #2480