### PR TITLE
python: pyflakes/flake8: errorformat: remove '%-Z%p^'

### DIFF
--- a/autoload/neomake/makers/ft/python.vim
+++ b/autoload/neomake/makers/ft/python.vim
@@ -115,7 +115,6 @@ function! neomake#makers#ft#python#flake8() abort
     let maker = {
         \ 'args': ['--format=default'],
         \ 'errorformat':
-            \ '%E%f:%l: could not compile,%-Z%p^,' .
             \ '%A%f:%l:%c: %t%n %m,' .
             \ '%A%f:%l: %t%n %m,' .
             \ '%-G%.%#',
@@ -271,8 +270,6 @@ function! neomake#makers#ft#python#pyflakes() abort
     "       except for SyntaxErrors.
     return {
         \ 'errorformat':
-            \ '%E%f:%l: could not compile,' .
-            \ '%-Z%p^,'.
             \ '%E%f:%l:%c: %m,' .
             \ '%E%f:%l:%c %m,' .
             \ '%E%f:%l: %m,' .


### PR DESCRIPTION
This was meant to parse the column out of `\s+\^` with compilation
errors from pyflakes, but is not used since pyflakes 0.7.3 anymore [1].

It would trigger different test outcome with Vim patch 8.0.0026 [2].

1: https://github.com/PyCQA/pyflakes/commit/5946f55
2: https://github.com/vim/vim/commit/9b4579481