### PR TITLE
Add basic support for glslc

### DIFF
--- a/autoload/neomake/makers/ft/glsl.vim
+++ b/autoload/neomake/makers/ft/glsl.vim
@@ -1,0 +1,15 @@
+" vim: ts=4 sw=4 et
+
+function! neomake#makers#ft#glsl#EnabledMakers() abort
+    return executable('glslc') ? ['glslc'] : []
+endfunction
+
+function! neomake#makers#ft#glsl#glslc() abort
+    return {
+        \ 'args': ['-c', '-o', g:neomake#compat#dev_null],
+        \ 'errorformat':
+            \ '%f:%l: %trror: %m,' .
+            \ '%f:%l: %tarning: %m,' .
+            \ '%-G%s',
+        \ }
+endfunction

--- a/autoload/neomake/makers/ft/glsl.vim
+++ b/autoload/neomake/makers/ft/glsl.vim
@@ -9,7 +9,9 @@ function! neomake#makers#ft#glsl#glslc() abort
         \ 'args': ['-c', '-o', g:neomake#compat#dev_null],
         \ 'errorformat':
             \ '%f:%l: %trror: %m,' .
+            \ '%f: %trror: %m,' .
             \ '%f:%l: %tarning: %m,' .
+            \ '%f: %tarning: %m,' .
             \ '%-G%s',
         \ }
 endfunction


### PR DESCRIPTION
Hello. I've been recently learning Vulkan and I added basic support for ft/glsl using glslc. I'm not sure about portability (using /dev/null because glslc doesn't have a syntax check only -flag), but the maker seems to run ok on my machine. I also considered using glslangValidator instead but couldn't get any errorformat working for it.