### PR TITLE
python: mypy: append `--follow-imports=silent`

### DIFF
--- a/autoload/neomake/makers/ft/python.vim
+++ b/autoload/neomake/makers/ft/python.vim
@@ -430,7 +430,7 @@ function! neomake#makers#ft#python#mypy() abort
             " Follow imports, but do not emit errors/issues for it, which
             " would result in errors for other buffers etc.
             " XXX: dmypy requires "skip" or "error"
-            call insert(maker.args, '--follow-imports=silent')
+            call add(maker.args, '--follow-imports=silent')
         else
             let project_root = neomake#utils#get_project_root(a:jobinfo.bufnr)
             if empty(project_root)

--- a/tests/ft_python.vader
+++ b/tests/ft_python.vader
@@ -448,7 +448,7 @@ Execute (python: mypy):
 
   let options = {'file_mode': 1}
   let bound_maker = neomake#core#instantiate_maker(maker, options, 0)
-  AssertEqual bound_maker.args, ['--follow-imports=silent'] + base_args
+  AssertEqual bound_maker.args, base_args + ['--follow-imports=silent']
 
   new
   let b:neomake = {'project_root': 'fake_project_root'}


### PR DESCRIPTION
Fixes usage with custom `exe` / `args`.
Ref: https://github.com/neomake/neomake/issues/2107#issuecomment-658018872.