### PR TITLE
sql: add maker for sqlfluff

### DIFF
--- a/autoload/neomake/makers/ft/sql.vim
+++ b/autoload/neomake/makers/ft/sql.vim
@@ -1,5 +1,14 @@
 function! neomake#makers#ft#sql#EnabledMakers() abort
-    return ['sqlint']
+    return ['sqlint', 'sqlfluff']
+endfunction
+
+function! neomake#makers#ft#sql#sqlfluff() abort
+    return {
+        \ 'errorformat':
+            \ '==\ [%f] FAIL,' .
+            \ '%EL:\ %#%l\ |\ P:\ %#%c\ |\ %t%n\ |\ %m,' .
+            \ '%C\ %#|\ %m'
+        \ }
 endfunction
 
 function! neomake#makers#ft#sql#sqlint() abort

--- a/tests/ft_sql.vader
+++ b/tests/ft_sql.vader
@@ -20,3 +20,21 @@ Execute (sqlint):
   AssertEqual loclist[1].text, 'syntax warning at or near alterUser'
   AssertEqual loclist[1].type, 'W'
   bwipe sql/V1__BaseSchema.sql
+
+Execute (sqlfluff):
+  let sqlfluff_output =
+  "== [models/base/deduped_applications_a.sql] FAIL\n
+  \L:   6 | P: 101 | L016 | Line is too long.
+  \L:  10 | P:   3 | L003 | Indentation not hanging or a multiple of 4 spaces
+  \L:  19 | P:  45 |  PRS | Found unparsable section: '\n-- asdf foob 1234567 jkll;
+  \                     | can be multi...'"
+
+  Save &errorformat
+  let &errorformat = neomake#makers#ft#sql#sqlfluff().errorformat
+  lgetexpr sqlfluff_output
+
+  let loclist = getloclist(0)
+  AssertEqual len(loclist), 3
+
+
+


### PR DESCRIPTION
I'm hoping to add a maker for an alternate sql linter named [sqlfluff](https://docs.sqlfluff.com/en/latest/).

I'm new to vim's `errorformat` and got a partially working `&efm` for sqlfluff's default output format.

@blueyed seems really responsive and helpful in PRs, so I am hoping to get some feedback and get this PR working and tested!

Questions:

1. sqlfluff takes a `--dialect` argument.  Is there an example maker I could reference for providing a config option for this?
2. sqlfluff has three output format options: human, json, & yaml,  my `&efm` is attempting to match the human output format as I wanted to avoid multi-line errorformats, and json doesn't have line breaks.  But after getting message-continuations working, I suspect yaml would be easier than the human format.  Suggestions?  I can provide example output.
3. sqlfluff has error codes of `PRS` and `L003`  the efm of `%t%n` breaks when the error code is `PRS`. How should I handle this case?

Here is an example snippet of the human format output:
```
== [models/redacted/foobie_bletch.sql] FAIL
L:   6 | P: 101 | L016 | Line is too long.
L:   8 | P: 112 | L016 | Line is too long.
L:  10 | P:   3 | L003 | Indentation not hanging or a multiple of 4 spaces
L:  11 | P:   3 | L003 | Indentation not hanging or a multiple of 4 spaces
L:  12 | P:   3 | L003 | Indentation not hanging or a multiple of 4 spaces
L:  13 | P:   3 | L003 | Indentation not hanging or a multiple of 4 spaces
L:  14 | P:   3 | L003 | Indentation not hanging or a multiple of 4 spaces
L:  15 | P:   3 | L003 | Indentation not hanging or a multiple of 4 spaces
L:  16 | P:   3 | L003 | Indentation not hanging or a multiple of 4 spaces
L:  17 | P:  47 | L011 | Implicit aliasing of table not allowed. Use explicit
                       | `AS` clause.
L:  18 | P:  63 | L011 | Implicit aliasing of table not allowed. Use explicit
                       | `AS` clause.
L:  19 | P:   3 | L003 | Indentation not hanging or a multiple of 4 spaces
L:  19 | P:  45 |  PRS | Found unparsable section: '\n-- need this because there
                       | can be multi...'

```