### PR TITLE
Added MIX_ENV to avoid compilation in dev environment

### DIFF
--- a/autoload/neomake/makers/ft/elixir.vim
+++ b/autoload/neomake/makers/ft/elixir.vim
@@ -54,7 +54,7 @@ endfunction
 
 function! neomake#makers#ft#elixir#mix() abort
     return {
-      \ 'exe' : 'mix',
+      \ 'exe' : 'MIX_ENV=test mix',
       \ 'args': ['compile', '--warnings-as-errors'],
       \ 'postprocess': function('neomake#makers#ft#elixir#PostprocessEnforceMaxBufferLine'),
       \ 'errorformat':


### PR DESCRIPTION
Using the default env `dev` when calling `mix compile`, prevents phoenix live reload to detect changes and recompile code on the fly.

The same happen if you change code while running `iex -S mix`, if you try to do `recompile` in iex shell the output is alwasy `:noop`

This is resolved in `elixir_ls` by using `test` as `MIX_ENV`.