### PR TITLE
Add clj-kondo support

### DIFF
--- a/autoload/neomake/makers/ft/clojure.vim
+++ b/autoload/neomake/makers/ft/clojure.vim
@@ -1,0 +1,23 @@
+" vim: ts=4 sw=4 et
+
+function! neomake#makers#ft#clojure#EnabledMakers() abort
+    return ['clj_kondo']
+endfunction
+
+function! neomake#makers#ft#clojure#clj_kondo() abort
+    let maker = {
+        \ 'exe': 'clj-kondo',
+        \ 'args': ['--lint'],
+        \ 'errorformat':
+            \ '%f:%l:%c: Parse %t%*[^:]: %m,'.
+            \ '%f:%l:%c: %t%*[^:]: %m,'.
+            \ '%-Glinting took %.%#'
+        \ }
+
+    function! maker.supports_stdin(_jobinfo) abort
+        let self.args = ['--filename', '%'] + self.args
+        return 1
+    endfunction
+
+    return maker
+endfunction

--- a/tests/ft_clojure.vader
+++ b/tests/ft_clojure.vader
@@ -1,0 +1,29 @@
+Include: include/setup.vader
+
+Execute (clojure: clj_kondo: errorformat):
+  let maker = NeomakeTestsGetMakerWithOutput(neomake#makers#ft#clojure#clj_kondo(), [
+  \ 'file1.clj:2:1: error: unresolved symbol unknown',
+  \ 'linting took 12ms, errors: 1, warnings: 0',
+  \ ])
+  let maker.name = 'clojure'
+  new
+  file file1.clj
+  CallNeomake 1, [maker]
+  AssertEqualQf getloclist(0), [
+  \ {'lnum': 2, 'bufnr': bufnr('%'), 'col': 1, 'valid': 1, 'vcol': 0,
+  \  'nr': -1, 'type': 'e', 'pattern': '',
+  \  'text': 'unresolved symbol unknown'}]
+  bwipe
+
+Execute (clojure: clj_kondo: supports_stdin):
+  new
+  noautocmd setfiletype clojure
+
+  let b:neomake = {'clj_kondo': {'exe': 'echo', 'errorformat': '%m'}}
+  CallNeomake 1, ['clj_kondo']
+  AssertNeomakeMessage '\vStarting .{-}: echo --filename '''' --lint -.', 2
+
+  file file1.clj
+  CallNeomake 1, ['clj_kondo']
+  AssertNeomakeMessage '\vStarting .{-}: echo --filename file1.clj --lint -.', 2
+  bwipe

--- a/tests/main.vader
+++ b/tests/main.vader
@@ -51,6 +51,7 @@ Include (Vim/Neovim behavior): vim_and_neovim_behavior.vader
 
 ~ Filetype specific
 Include (Asciidoc): ft_asciidoc.vader
+Include (Clojure): ft_clojure.vader
 Include (Cs): ft_cs.vader
 Include (Css): ft_css.vader
 Include (Elixir): ft_elixir.vader


### PR DESCRIPTION
I've gotten most of the way there, but I'm having some issues with stdin
support.  It seems that %t is  not being replaced with `-`, but instead
it is the full path to the file.

I had considered just doing

```vim
self.args = ['--filename', '%'] + self.args
```

But that's not done by any other maker, so I thought I should check
first.

Is there a way to do use these two features together that I've missed?