### PR TITLE
Gradle kotlin dsl support

### DIFF
--- a/autoload/neomake/makers/ft/java.vim
+++ b/autoload/neomake/makers/ft/java.vim
@@ -321,7 +321,7 @@ endfunction " }}}2
 function! s:GradleOutputDirectory() abort
     let gradle_build_file_name = 'build.gradle'
     let gradle_build = s:findFileInParent(gradle_build_file_name, expand('%:p:h', 1))
-    if !filereadable(gradle)
+    if !filereadable(gradle_build)
         let gradle_build_file_name = 'build.gradle.kts'
         let gradle_build = s:findFileInParent(gradle_build_file_name, expand('%:p:h', 1))
     endif

--- a/autoload/neomake/makers/ft/java.vim
+++ b/autoload/neomake/makers/ft/java.vim
@@ -345,6 +345,7 @@ function! s:GetGradleClasspath() abort
     if !filereadable(gradle)
         let gradle_build_file_name = 'build.gradle.kts'
         let gradle = s:findFileInParent(gradle_build_file_name, expand('%:p:h', 1))
+    endif
     if s:has_gradle && filereadable(gradle)
         if !has_key(g:neomake_java_javac_gradle_ftime, gradle) || g:neomake_java_javac_gradle_ftime[gradle] != getftime(gradle)
             try

--- a/autoload/neomake/makers/ft/java.vim
+++ b/autoload/neomake/makers/ft/java.vim
@@ -319,20 +319,19 @@ function! s:MavenOutputDirectory() abort " {{{2
 endfunction " }}}2
 
 function! s:GradleOutputDirectory() abort
-    let gradle_build = s:findFileInParent('build.gradle', expand('%:p:h', 1))
-    let items = split(gradle_build, s:psep)
-    let outputdir = join(['build', 'intermediates', 'classes', 'debug'], s:psep)
-    if len(items)==1
-        return outputdir
+    let gradle_build_file_name = 'build.gradle'
+    let gradle_build = s:findFileInParent(gradle_build_file_name, expand('%:p:h', 1))
+    if !filereadable(gradle)
+        let gradle_build_file_name = 'build.gradle.kts'
+        let gradle_build = s:findFileInParent(gradle_build_file_name, expand('%:p:h', 1))
     endif
-    let gradle_build = s:findFileInParent('build.gradle.kts', expand('%:p:h', 1))
     let items = split(gradle_build, s:psep)
     if len(items)==1
-        return outputdir
+        return join(['build', 'intermediates', 'classes', 'debug'], s:psep)
     endif
     let outputdir = ''
     for i in items
-        if i !=# 'build.gradle' && i !=# 'build.gradle.kts'
+        if i !=# gradle_build_file_name
             let outputdir .= i . s:psep
         endif
     endfor

--- a/autoload/neomake/makers/ft/java.vim
+++ b/autoload/neomake/makers/ft/java.vim
@@ -325,12 +325,12 @@ function! s:GradleOutputDirectory() abort
     if len(items)==1
         return outputdir
     endif
-    gradle_build = s:findFileInParent('build.gradle.kts', expand('%:p:h', 1))
-    items = split(gradle_build, s:psep)
+    let gradle_build = s:findFileInParent('build.gradle.kts', expand('%:p:h', 1))
+    let items = split(gradle_build, s:psep)
     if len(items)==1
         return outputdir
     endif
-    outputdir = ''
+    let outputdir = ''
     for i in items
         if i !=# 'build.gradle' && i !=# 'build.gradle.kts'
             let outputdir .= i . s:psep
@@ -343,8 +343,8 @@ function! s:GetGradleClasspath() abort
     let gradle_build_file_name = 'build.gradle'
     let gradle = s:findFileInParent(gradle_build_file_name, expand('%:p:h', 1))
     if !filereadable(gradle)
-        gradle_build_file_name = 'build.gradle.kts'
-        gradle = s:findFileInParent(gradle_build_file_name, expand('%:p:h', 1))
+        let gradle_build_file_name = 'build.gradle.kts'
+        let gradle = s:findFileInParent(gradle_build_file_name, expand('%:p:h', 1))
     if s:has_gradle && filereadable(gradle)
         if !has_key(g:neomake_java_javac_gradle_ftime, gradle) || g:neomake_java_javac_gradle_ftime[gradle] != getftime(gradle)
             try

--- a/autoload/neomake/makers/ft/java/classpath.gradle
+++ b/autoload/neomake/makers/ft/java/classpath.gradle
@@ -1,46 +1,53 @@
-task classpath << {
+task classpath {
+  doLast {
+    String finalFileContents = ""
+      HashSet<String> classpathFiles = new HashSet<String>()
+      for (proj in allprojects) {
 
-  String finalFileContents = ""
-  HashSet<String> classpathFiles = new HashSet<String>()
-  for (proj in allprojects) {
-
-    def exploded = proj.getBuildDir().absolutePath + File.separator + "intermediates" + File.separator + "exploded-aar"
-    def listFiles = new File(exploded)
-    if (listFiles.exists()) {
-      listFiles.eachFileRecurse(){ file ->
-        if (file.name.endsWith(".jar")){
-          classpathFiles += file
-        }
-      }
-    }
-
-    def rjava = proj.getBuildDir().absolutePath + File.separator + "intermediates" + File.separator + "classes" + File.separator + "debug"
-    def rFiles = new File(rjava)
-    if (rFiles.exists()) {
-      classpathFiles += rFiles
-    }
-
-    for (conf in proj.configurations) {
-        for (dependency in conf) {
-            if (dependency.name.endsWith("aar")){
-            } else {
-              classpathFiles += dependency
+        def exploded = proj.getBuildDir().absolutePath + File.separator + "intermediates" + File.separator + "exploded-aar"
+          def listFiles = new File(exploded)
+          if (listFiles.exists()) {
+            listFiles.eachFileRecurse(){ file ->
+              if (file.name.endsWith(".jar")){
+                classpathFiles += file
+              }
             }
-        }
-    }
-    if (proj.hasProperty("android")){
-      classpathFiles += proj.android.bootClasspath
-    }
-
-    if (proj.hasProperty("sourceSets")) {
-
-      for (srcSet in proj.sourceSets) {
-          for (dir in srcSet.java.srcDirs) {
-              classpathFiles += dir.absolutePath
           }
+
+        def rjava = proj.getBuildDir().absolutePath + File.separator + "intermediates" + File.separator + "classes" + File.separator + "debug"
+          def rFiles = new File(rjava)
+          if (rFiles.exists()) {
+            classpathFiles += rFiles
+          }
+
+        proj.sourceSets.main.compileClasspath.each {
+          def dependency = it.absolutePath
+          if (dependency.endsWith("aar")){
+          } else {
+            classpathFiles += dependency
+          }
+        }
+        proj.sourceSets.test.compileClasspath.each {
+          def dependency = it.absolutePath
+          if (dependency.endsWith("aar")){
+          } else {
+            classpathFiles += dependency
+          }
+        }
+        if (proj.hasProperty("android")){
+          classpathFiles += proj.android.bootClasspath
+        }
+
+        if (proj.hasProperty("sourceSets")) {
+
+          for (srcSet in proj.sourceSets) {
+            for (dir in srcSet.java.srcDirs) {
+              classpathFiles += dir.absolutePath
+            }
+          }
+        }
       }
-    }
+    def paths = classpathFiles.join(File.pathSeparator)
+      println "CLASSPATH:" + paths
   }
-  def paths = classpathFiles.join(File.pathSeparator)
-  println "CLASSPATH:" + paths
 }


### PR DESCRIPTION
This should add Kotlin DSL support for Gradle (by searching for `build.gradle.kts` files if `build.gradle` files are not found.

Before merging, please note that I have not been able to get Gradle autodetection working yet (neither on your `master` branch, nor on my `gradle-kotlin-dsl-support` branch), for projects using the Groovy DSL and the Kotlin DSL, respectively. This may be a bug, or I am missing something in the configuration of the plugin.