### PR TITLE
python: flake8: parse type/code out of msg

### DIFF
--- a/autoload/neomake/makers/ft/python.vim
+++ b/autoload/neomake/makers/ft/python.vim
@@ -115,8 +115,8 @@ function! neomake#makers#ft#python#flake8() abort
     let maker = {
         \ 'args': ['--format=default'],
         \ 'errorformat':
-            \ '%A%f:%l:%c: %t%n %m,' .
-            \ '%A%f:%l: %t%n %m,' .
+            \ '%A%f:%l:%c: %m,' .
+            \ '%A%f:%l: %m,' .
             \ '%-G%.%#',
         \ 'postprocess': function('neomake#makers#ft#python#Flake8EntryProcess'),
         \ 'short_name': 'fl8',
@@ -147,6 +147,13 @@ function! neomake#makers#ft#python#flake8() abort
 endfunction
 
 function! neomake#makers#ft#python#Flake8EntryProcess(entry) abort
+    let m = matchlist(a:entry.text, '\v^(\D+)(\d+) (.*)$')
+    if len(m) > 1
+        let type = m[1]
+        let a:entry.type = type[0]
+        let nr = m[2]
+        let a:entry.nr = nr
+    endif
     if a:entry.type ==# 'F'  " pyflakes
         " Ref: http://flake8.pycqa.org/en/latest/user/error-codes.html
         if a:entry.nr > 400 && a:entry.nr < 500
@@ -257,7 +264,6 @@ function! neomake#makers#ft#python#Flake8EntryProcess(entry) abort
         endif
     endif
 
-    let a:entry.text = a:entry.type . a:entry.nr . ' ' . a:entry.text
     let a:entry.type = type
     " Reset "nr" to Avoid redundancy with neomake#GetCurrentErrorMsg.
     " TODO: This is rather bad, since "nr" itself can be useful.

--- a/tests/ft_python.vader
+++ b/tests/ft_python.vader
@@ -76,8 +76,8 @@ Execute (python: flake8: errorformat/postprocess: F811):
 
   AssertEqualQf getloclist(0), [
   \ {'lnum': 2, 'bufnr': bufnr('%'), 'col': 1, 'valid': 1, 'vcol': 0,
-  \  'nr': 811, 'type': 'F', 'pattern': '',
-  \  'text': "redefinition of unused 'os' from line 1"}]
+  \  'nr': -1, 'type': '', 'pattern': '',
+  \  'text': "F811 redefinition of unused 'os' from line 1"}]
 
   let e = getloclist(0)[0]
   call neomake#makers#ft#python#Flake8EntryProcess(e)
@@ -97,8 +97,8 @@ Execute (python: flake8: errorformat/postprocess: F811):
 
   AssertEqualQf getloclist(0), [
   \ {'lnum': 3, 'bufnr': bufnr('%'), 'col': 1, 'valid': 1, 'vcol': 0,
-  \  'nr': 811, 'type': 'F', 'pattern': '',
-  \  'text': "redefinition of unused 'os' from line 2"}]
+  \  'nr': -1, 'type': '', 'pattern': '',
+  \  'text': "F811 redefinition of unused 'os' from line 2"}]
 
   let e = getloclist(0)[0]
   call neomake#makers#ft#python#Flake8EntryProcess(e)
@@ -185,19 +185,19 @@ Execute (flake8: postprocess for F821 in continuous f-strings):
 
 Execute (python: flake8: neomake#makers#ft#python#Flake8EntryProcess):
   let bufnr = bufnr('%')
-  let entry = {'type': 'F', 'nr': 841, 'text': "local variable 'foo' is assigned to but never used", 'lnum': 1, 'col': 1, 'bufnr': bufnr}
+  let entry = {'text': "F841 local variable 'foo' is assigned to but never used", 'lnum': 1, 'col': 1, 'bufnr': bufnr}
   call neomake#makers#ft#python#Flake8EntryProcess(entry)
   AssertEqual entry.type, 'W'
 
-  let entry = {'type': 'F', 'nr': 999, 'text': "something", 'lnum': 1, 'col': 1, 'bufnr': bufnr}
+  let entry = {'text': "F999 something", 'lnum': 1, 'col': 1, 'bufnr': bufnr}
   call neomake#makers#ft#python#Flake8EntryProcess(entry)
   AssertEqual entry.type, 'E'
 
-  let entry = {'type': 'F', 'nr': 404, 'text': "not found", 'lnum': 1, 'col': 1, 'bufnr': bufnr}
+  let entry = {'text': "F404 not found", 'lnum': 1, 'col': 1, 'bufnr': bufnr}
   call neomake#makers#ft#python#Flake8EntryProcess(entry)
   AssertEqual entry.type, 'W'
 
-  let entry = {'type': 'F', 'nr': 407, 'text': "no future", 'lnum': 1, 'col': 1, 'bufnr': bufnr}
+  let entry = {'text': "F407 no future", 'lnum': 1, 'col': 1, 'bufnr': bufnr}
   call neomake#makers#ft#python#Flake8EntryProcess(entry)
   AssertEqual entry.type, 'E'
 
@@ -212,13 +212,13 @@ Execute (python: flake8):
   let bufnr = bufnr('%')
   AssertEqualQf llist, [
   \ {'lnum': 90, 'bufnr': bufnr, 'col': 1, 'valid': 1, 'vcol': 0,
-  \  'nr': 1, 'type': 'I', 'pattern': '',
-  \  'text': 'isort found an import in the wrong position'}]
+  \  'nr': -1, 'type': '', 'pattern': '',
+  \  'text': 'I001 isort found an import in the wrong position'}]
   let entry = llist[0]
   call neomake#makers#ft#python#Flake8EntryProcess(entry)
   AssertEqualQf [entry], [{'lnum': 90, 'bufnr': bufnr, 'col': 1, 'valid': 1,
   \ 'vcol': 0, 'nr': -1, 'type': 'I', 'pattern': '',
-  \ 'text': 'I1 isort found an import in the wrong position'}]
+  \ 'text': 'I001 isort found an import in the wrong position'}]
   bwipe
 
 Execute (python: flake8: supports_stdin):
@@ -229,7 +229,7 @@ Execute (python: flake8: supports_stdin):
   CallNeomake 1, ['flake8']
   AssertNeomakeMessage '\vStarting .{-}: echo --format\=default --stdin-display-name '''' -.', 2
   AssertEqual getloclist(0)[0].text,
-  \ '-1 --format=default --stdin-display-name  -'
+  \ '--format=default --stdin-display-name  -'
   bwipe
 
 Execute (python: flake8: supports_stdin: changes cwd (non-existing)):
@@ -246,7 +246,7 @@ Execute (python: flake8: supports_stdin: changes cwd (non-existing)):
   AssertNeomakeMessage printf('\vStarting .{-}: echo --format\=default --stdin-display-name %s -.', fname), 2
   AssertNeomakeMessage printf('cwd: %s.', getcwd())
   AssertEqual getloclist(0)[0].text,
-  \ printf('-1 --format=default --stdin-display-name %s -', fname)
+  \ printf('--format=default --stdin-display-name %s -', fname)
   bwipe
 
 Execute (python: flake8: supports_stdin: changes cwd (existing)):
@@ -261,7 +261,7 @@ Execute (python: flake8: supports_stdin: changes cwd (existing)):
   AssertNeomakeMessage printf('\vStarting .{-}: echo --format\=default --stdin-display-name %s -.', fname), 2
   AssertNeomakeMessage printf('cwd: %s (changed).', tempdir)
   AssertEqual getloclist(0)[0].text,
-  \ printf('-1 --format=default --stdin-display-name %s -', fname)
+  \ printf('--format=default --stdin-display-name %s -', fname)
   bwipe
 
 Execute (python: flake8: supports_stdin: changes cwd also with buffer in subdir):
@@ -281,7 +281,7 @@ Execute (python: flake8: supports_stdin: changes cwd also with buffer in subdir)
   \ fname), 2
   AssertNeomakeMessage printf('cwd: %s (changed).', fdir)
   AssertEqual getloclist(0)[0].text,
-  \ printf('-1 --format=default --stdin-display-name %s -', fname)
+  \ printf('--format=default --stdin-display-name %s -', fname)
   bwipe
 
 Execute (python: pyflakes: SyntaxError):


### PR DESCRIPTION
This is required to handle multi-char code prefixes, e.g. "WPS".

Fixes https://github.com/neomake/neomake/issues/2444