### PR TITLE
dockerfile: hadolint: use `--no-color`

### DIFF
--- a/autoload/neomake/makers/ft/dockerfile.vim
+++ b/autoload/neomake/makers/ft/dockerfile.vim
@@ -6,7 +6,7 @@ function! neomake#makers#ft#dockerfile#hadolint() abort
     return {
           \ 'output_stream': 'stdout',
           \ 'uses_stdin': 1,
-          \ 'args': ['--format', 'tty'],
+          \ 'args': ['--format', 'tty', '--no-color'],
           \ 'errorformat': '%f:%l %m',
           \ }
 endfunction


### PR DESCRIPTION
Apparently added in https://github.com/hadolint/hadolint/commit/2006e27b2882f929428a7f7f57fc98b100fb0185 (v1.23.0), although probably only later enabled by default.