### PR TITLE
Replace " with vimscript '' to avoid escape issues

### DIFF
--- a/autoload/neomake/compat.vim
+++ b/autoload/neomake/compat.vim
@@ -203,7 +203,7 @@ if neomake#utils#IsRunningWindows()
                 return argv
             endif
         endif
-        if &shell == 'powershell'
+        if &shell ==? 'powershell'
             return prefix.'{'.argv.'}'
         endif
         return prefix.argv

--- a/autoload/neomake/compat.vim
+++ b/autoload/neomake/compat.vim
@@ -203,6 +203,9 @@ if neomake#utils#IsRunningWindows()
                 return argv
             endif
         endif
+        if &shell == 'powershell'
+            return prefix.'{'.argv.'}'
+        endif
         return prefix.argv
     endfunction
 elseif has('nvim')

--- a/autoload/neomake/makers/ft/python.vim
+++ b/autoload/neomake/makers/ft/python.vim
@@ -67,7 +67,7 @@ function! neomake#makers#ft#python#pylint() abort
     let maker = {
         \ 'args': [
             \ '--output-format=text',
-            \ '--msg-template="{path}:{line}:{column}:{C}: [{symbol}] {msg} [{msg_id}]"',
+            \ '--msg-template=''{path}:{line}:{column}:{C}: [{symbol}] {msg} [{msg_id}]''',
             \ '--reports=no'
         \ ],
         \ 'errorformat':

--- a/autoload/neomake/makers/ft/r.vim
+++ b/autoload/neomake/makers/ft/r.vim
@@ -7,7 +7,7 @@ endfunction
 function! neomake#makers#ft#r#lintr() abort
     return {
         \ 'exe': 'R',
-        \ 'args': ['--slave', '--no-restore', '--no-save', '-e lintr::lint("%t")'],
+        \ 'args': ['--slave', '--no-restore', '--no-save', '-e lintr::lint(''%t'')'],
         \ 'append_file': 0,
         \ 'errorformat':
         \   '%W%f:%l:%c: style: %m,' .

--- a/autoload/neomake/makers/ft/r.vim
+++ b/autoload/neomake/makers/ft/r.vim
@@ -7,7 +7,7 @@ endfunction
 function! neomake#makers#ft#r#lintr() abort
     return {
         \ 'exe': 'R',
-        \ 'args': ['--slave', '--no-restore', '--no-save', '-e lintr::lint(''%t'')'],
+        \ 'args': ['--slave', '--no-restore', '--no-save', '-e', 'lintr::lint(''%t'')'],
         \ 'append_file': 0,
         \ 'errorformat':
         \   '%W%f:%l:%c: style: %m,' .

--- a/autoload/neomake/utils.vim
+++ b/autoload/neomake/utils.vim
@@ -416,7 +416,8 @@ function! neomake#utils#ExpandArgs(args, jobinfo) abort
             let fname = fnamemodify(fname, ':p')
         endif
     endif
-    let ret = map(copy(a:args), "substitute(v:val, '%t', fname, 'g')")
+    let fname = escape(fname, '\\')
+    let ret = map(copy(a:args), "substitute(v:val, '%t', escape(fname, '\\'), 'g')")
 
     " Expand % in args similar to when using :!
     " \% is ignored


### PR DESCRIPTION
Stumbled upon a weird issue with double quotes being ignored thanks to my stupid PowerShell environment at work.

I knew vimscript uses `"` for comments but apparently this has odd effects when used in a string as reported here:
https://stackoverflow.com/questions/24164365/vimscript-quotes-in-strings-when-used-as-expressions

Because the pylint maker uses a message template that contains characters that will be misinterpreted by PowerShell if not escaped correctly, when you change vim's default shell to PowerShell you can see that the `"`'s from
https://github.com/neomake/neomake/blob/053d6bd3605a64f05de11a179cbab423fe759ebe/autoload/neomake/makers/ft/python.vim#L70
are actually ignored and not passed through to the command:
```powershell
Neomake: pylint: unexpected output on stderr: pylint.exe : The command parameter was already specified.
At line:1 char:1
+ pylint --output-format=text --msg-template={path}:{line}:{column}:{C} ...
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidArgument: (:) [], ParameterBindingException
    + FullyQualifiedErrorId : ParameterSpecifiedAlready
```

It seems that changing all instances of `"` in command strings to `''` is more reliable than escaping with `\"`

---

The direction of this PR changed from a one off bug to an analysis of arg escape methods. This new mechanism should work for all OSs with the caveat that all arg strings that have `%f` substitutions will be wrapped in double quotes and all backslashes in the file path will be escaped.