### PR TITLE
Adds support for vlang - v and vvet

### DIFF
--- a/autoload/neomake/makers/ft/vlang.vim
+++ b/autoload/neomake/makers/ft/vlang.vim
@@ -7,6 +7,7 @@ endfunction
 function! neomake#makers#ft#vlang#v() abort
     return {
         \ 'exe': 'v',
+        \ 'args': ['-check'],
         \ 'errorformat': '%f:%l:%c: %trror: %m.',
         \ }
 endfunction

--- a/autoload/neomake/makers/ft/vlang.vim
+++ b/autoload/neomake/makers/ft/vlang.vim
@@ -1,0 +1,20 @@
+" vim: ts=4 sw=4 et
+
+function! neomake#makers#ft#vlang#EnabledMakers() abort
+    return ['v', 'vvet']
+endfunction
+
+function! neomake#makers#ft#vlang#v() abort
+    return {
+        \ 'exe': 'v',
+        \ 'errorformat': '%f:%l:%c: %trror: %m.',
+        \ }
+endfunction
+
+function! neomake#makers#ft#vlang#vvet() abort
+    return {
+        \ 'exe': 'v',
+        \ 'args': ['vet'],
+        \ 'errorformat': '%f:%l: %trror: %m.',
+        \ }
+endfunction


### PR DESCRIPTION
This PR adds simple initial support for `vlang` - some optimization can be made around the multi-line errors with its recommendations.

```vlang
common.v:11:8: error: unknown type `i34`.
Did you mean `App`?
    9 | mut:
   10 |     gg    &gg.Context
   11 |     value i34
      |           ~~~
   12 |     timer &time.StopWatch
   13 | }
```