### PR TITLE
makers/nix: adapt error format to nix >= 2.4

### DIFF
--- a/autoload/neomake/makers/ft/nix.vim
+++ b/autoload/neomake/makers/ft/nix.vim
@@ -4,11 +4,13 @@ function! neomake#makers#ft#nix#EnabledMakers() abort
     return ['nix_instantiate']
 endfunction
 
+" there is a single %C last in errorformat because nix >= 2.4 emits multiline
+" error messages with empty lines in the middle.
 function! neomake#makers#ft#nix#nix_instantiate() abort
     return {
         \ 'exe': 'nix-instantiate',
         \ 'args': ['--parse-only'],
-        \ 'errorformat': 'error: %m at %f:%l:%c'
+        \ 'errorformat': 'error: %m at %f:%l:%c,%Eerror: %m,%Z       at %f:%l:%c:,%C'
         \ }
 endfunction
 


### PR DESCRIPTION
Example error message
error: undefined variable 'bar'

       at /tmp/foo.nix:2:1:

            1| { foo }:
            2| bar
             | ^
            3|