### PR TITLE
ruby: remove `-T1` with ruby maker for ruby3

### DIFF
--- a/autoload/neomake/makers/ft/ruby.vim
+++ b/autoload/neomake/makers/ft/ruby.vim
@@ -57,7 +57,7 @@ function! neomake#makers#ft#ruby#mri() abort
 
     return {
         \ 'exe': 'ruby',
-        \ 'args': ['-c', '-T1', '-w'],
+        \ 'args': ['-c', '-w'],
         \ 'errorformat': errorformat,
         \ 'output_stream': 'both',
         \ }


### PR DESCRIPTION
Fixes https://github.com/neomake/neomake/issues/2548.