### PR TITLE
add `revive` as a go maker (fix #2429)

### DIFF
--- a/autoload/neomake/makers/ft/go.vim
+++ b/autoload/neomake/makers/ft/go.vim
@@ -2,7 +2,9 @@
 
 function! neomake#makers#ft#go#EnabledMakers() abort
     let makers = ['go']
-    if executable('golangci-lint')
+    if executable('revive')
+        call add(makers, 'revive')
+    elseif executable('golangci-lint')
         call add(makers, 'golangci_lint')
     elseif executable('gometalinter')
         call add(makers, 'gometalinter')
@@ -77,6 +79,16 @@ function! neomake#makers#ft#go#golangci_lint() abort
         \ 'args': ['run', '--out-format=line-number', '--print-issued-lines=false'],
         \ 'output_stream': 'stdout',
         \ 'append_file': 0,
+        \ 'cwd': '%:h',
+        \ 'errorformat':
+            \ '%f:%l:%c: %m,' .
+            \ '%f:%l: %m'
+        \ }
+endfunction
+
+function! neomake#makers#ft#go#revive() abort
+    return {
+        \ 'exe': 'revive',
         \ 'cwd': '%:h',
         \ 'errorformat':
             \ '%f:%l:%c: %m,' .

--- a/tests/ft_go.vader
+++ b/tests/ft_go.vader
@@ -55,3 +55,14 @@ Execute (go: golangci_lint):
   \ {'lnum': 288, 'bufnr': bufnr('%'), 'col': 7, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'no new variables on left side of := (typecheck)'},
   \ ]
   bwipe
+
+Execute (go: revive):
+  new
+  file main.go
+
+  let &efm = neomake#makers#ft#go#revive().errorformat
+  lgetexpr 'main.go:288:2: do not use ALL_CAPS in Go names; use CamelCase'
+  AssertEqualQf getloclist(0), [
+  \ {'lnum': 288, 'bufnr': bufnr('%'), 'col': 2, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'do not use ALL_CAPS in Go names; use CamelCase'},
+  \ ]
+  bwipe

--- a/tests/ft_go.vader
+++ b/tests/ft_go.vader
@@ -57,11 +57,13 @@ Execute (go: golangci_lint):
   bwipe
 
 Execute (go: detects revive as linter):
+  let original_path = $PATH
   call g:NeomakeTestsCreateExe('revive', [])
   runtime autoload/neomake/makers/ft/go.vim
   " NOTE: just detecting revive is enough, if you know a simple way to do «'revive' in some_list»
   " then go ahead
   AssertEqual ['go', 'revive'], neomake#makers#ft#go#EnabledMakers()
+  call g:NeomakeTestsSetPATH(original_path)
 
 Execute (go: revive):
   new

--- a/tests/ft_go.vader
+++ b/tests/ft_go.vader
@@ -59,7 +59,7 @@ Execute (go: golangci_lint):
 Execute (go: detects revive as linter):
   call g:NeomakeTestsCreateExe('revive', [])
   runtime autoload/neomake/makers/ft/go.vim
-  AssertEqual ['revive'], neomake#makers#ft#help#EnabledMakers()
+  AssertEqual ['revive'], neomake#makers#ft#go#EnabledMakers()
 
 Execute (go: revive):
   new

--- a/tests/ft_go.vader
+++ b/tests/ft_go.vader
@@ -56,6 +56,11 @@ Execute (go: golangci_lint):
   \ ]
   bwipe
 
+Execute (go: detects revive as linter):
+  call g:NeomakeTestsCreateExe('revive', [])
+  runtime autoload/neomake/makers/ft/go.vim
+  AssertEqual ['revive'], neomake#makers#ft#help#EnabledMakers()
+
 Execute (go: revive):
   new
   file main.go

--- a/tests/ft_go.vader
+++ b/tests/ft_go.vader
@@ -59,7 +59,9 @@ Execute (go: golangci_lint):
 Execute (go: detects revive as linter):
   call g:NeomakeTestsCreateExe('revive', [])
   runtime autoload/neomake/makers/ft/go.vim
-  AssertEqual ['revive'], neomake#makers#ft#go#EnabledMakers()
+  " NOTE: just detecting revive is enough, if you know a simple way to do «'revive' in some_list»
+  " then go ahead
+  AssertEqual ['go', 'revive'], neomake#makers#ft#go#EnabledMakers()
 
 Execute (go: revive):
   new


### PR DESCRIPTION
fixes https://github.com/neomake/neomake/issues/2429

picked up from
https://github.com/neomake/neomake/commit/baa32269d1873f7beea4b3592717f7a624a557c4