### PR TITLE
Updated readme preamble with the drop in replacement command for :make.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Neomake is a plugin for [Vim]/[Neovim] to asynchronously run programs.
 
-You can use it instead of the built-in `:make` command (since it can pick
+You can use `:Neomake!` instead of the built-in `:make` command (since it can pick
 up your `'makeprg'` setting), but its focus is on providing an extra layer
 of makers based on the current file (type) or project.
 Its origin is a proof-of-concept for [Syntastic] to be asynchronous.


### PR DESCRIPTION
It was not obvious to me that `:Neomake!` (and not `:Neomake`) was the actual replacement command for `:make`. This is a small addition to make it perfectly clear to any one who installs this to be a replacement to avoid unnecessary friction.