### PR TITLE
Use default line & column when is not present on eslint maker

### DIFF
--- a/autoload/neomake/makers/ft/javascript.vim
+++ b/autoload/neomake/makers/ft/javascript.vim
@@ -45,8 +45,8 @@ function! neomake#makers#ft#javascript#ProcessEslint(context) abort
                         \ 'maker_name': 'eslint',
                         \ 'filename': file_data.filePath,
                         \ 'text': err.message,
-                        \ 'lnum': err.line,
-                        \ 'col': err.column,
+                        \ 'lnum': has_key(err, 'line') ? err.line : 0,
+                        \ 'col': has_key(err, 'column') ? err.column : 0,
                         \ 'type': type,
                         \ }
 


### PR DESCRIPTION
Hello!

Sometimes, the _eslint_ maker does not report the line or the column correctly. An example of this is this message when it is misconfigured:

```json
{
  "ruleId": null,
  "fatal": true,
  "severity": 2,
  "message": "Parsing error: ESLint was configured to run on `<tsconfigRootDir>/foo.ts` using `parserOptions.project`: <tsconfigRootDir>/tsconfig.json\nHowever, that TSConfig does not include this file. Either:\n- Change ESLint's list of included files to not include this file\n- Change that TSConfig to include this file\n- Create a new TSConfig that includes this file and include it in your parserOptions.project\nSee the typescript-eslint docs for more info: https://typescript-eslint.io/linting/troubleshooting#i-get-errors-telling-me-eslint-was-configured-to-run--however-that-tsconfig-does-not--none-of-those-tsconfigs-include-this-file"
}
```

The standard formatter assumes that it implies a line and a column of zero value:

```text
/run.ts
  0:0  error  Parsing error: ESLint was configured to run on `<tsconfigRootDir>/foo.ts` using `parserOptions.project`: <tsconfigRootDir>/tsconfig.json
However, that TSConfig does not include this file. Either:
- Change ESLint's list of included files to not include this file
- Change that TSConfig to include this file
- Create a new TSConfig that includes this file and include it in your parserOptions.project
See the typescript-eslint docs for more info: https://typescript-eslint.io/linting/troubleshooting#i-get-errors-telling-me-eslint-was-configured-to-run--however-that-tsconfig-does-not--none-of-those-tsconfigs-include-this-file
```

An easy fix would be doing the same assumption in the parser.

Regards,