### PR TITLE
Makers: Add support for modern LaTeX engines.

### DIFF
--- a/autoload/neomake/makers/ft/tex.vim
+++ b/autoload/neomake/makers/ft/tex.vim
@@ -64,6 +64,30 @@ function! neomake#makers#ft#tex#pdflatex() abort
                 \ }
 endfunction
 
+function! neomake#makers#ft#tex#lualatex() abort
+    return {
+               \ 'exe': 'lualatex',
+               \ 'args': ['-shell-escape', '-file-line-error', '-interaction', 'nonstopmode'],
+               \ 'errorformat': '%E%f:%l: %m'
+               \ }
+endfunction
+
+function! neomake#makers#ft#tex#xelatex() abort
+    return {
+               \ 'exe': 'xelatex',
+               \ 'args': ['-shell-escape', 'file-line-error', '-interaction', 'nonstopmode'],
+               \ 'errorformat': '%E%f:%l: %m'
+               \ }
+endfunction
+
+function! neomake#makers#ft#tex#uplatex() abort
+    return {
+               \ 'exe': 'uplatex',
+               \ 'args': ['-shell-escape', 'file-line-error', '-interaction', 'nonstopmode'],
+               \ 'errorformat': '%E%f:%l: %m'
+               \ }
+endfunction
+
 function! neomake#makers#ft#tex#proselint() abort
     return neomake#makers#ft#text#proselint()
 endfunction


### PR DESCRIPTION
While `pdflatex` has difficulty using OTF fonts, it’s not convenient anymore, especially with non-English documents. That’s why I think we need some more modern TeX engines available as makers, namely XeLaTeX, LuaLaTeX, and upLaTeX.

![E854542A-E8EB-4C96-911D-1CE0A9B1D9A9](https://github.com/neomake/neomake/assets/86350742/d38cf271-5bd5-4563-bde3-17047b133b29)
(Fig.1, `pdflatex` fails when handling CJK documents.)

Need to add the following into `makers.md` to update the wiki:
```
- [lualatex](https://www.tug.org/mailman/listinfo/luatex) (not enabled by default)
- [xelatex](https://www.tug.org/xetex/) (not enabled by default)
- [uplatex](https://www.ctan.org/pkg/uptex) (not enabled by default)
```

I was just wondering if we need to add support to plain-TeX for those TeXackers :)
——(That’s not difficult and I would be happy to do that)